### PR TITLE
Add 3D Pipes PolyCSS adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ pnpm prepare:super-mario-64 -- --rom .local/baserom.us.z64
 
 Nintendo game data is not included.
 
+## Adapters
+
+### 3D Pipes
+
+[`src/adapters/3dpipes`](src/adapters/3dpipes) is an original generative
+PolyCSS scene inspired by XScreenSaver `pipes.c` and Windows 3D Pipes. It uses
+prepared connected tube meshes, lighting, and playback with stable retained
+DOM.
+
+```sh
+pnpm install
+pnpm build:3dpipes:full
+pnpm dev:3dpipes
+```
+
 ## License
 
 cssGraphics source code is [MIT licensed](LICENSE). Third-party models retain

--- a/package.json
+++ b/package.json
@@ -34,12 +34,16 @@
   },
   "scripts": {
     "dev": "vite --host 127.0.0.1",
+    "dev:3dpipes": "vite --config src/adapters/3dpipes/vite.config.mjs --host 127.0.0.1",
     "build": "pnpm build:site && pnpm build:lib",
     "build:site": "vite build",
     "build:lib": "vite build --mode library && node scripts/build-cli.mjs",
+    "build:3dpipes": "vite build --config src/adapters/3dpipes/vite.config.mjs",
+    "build:3dpipes:full": "pnpm prepare:3dpipes && pnpm build:3dpipes",
     "prepack": "pnpm build:lib",
     "preview": "vite preview --host 127.0.0.1",
     "prepare:super-mario-64": "pnpm build:lib && node scripts/prepare/super-mario-64.mjs",
+    "prepare:3dpipes": "node src/adapters/3dpipes/tools/prepare-csspipes.mjs",
     "prepare:catalog": "pnpm build:lib && node scripts/prepare/catalog.mjs",
     "prepare:site-models": "node scripts/prepare/site-models.mjs",
     "prepare:site-previews": "pnpm prepare:site-models && node scripts/prepare/site-previews.mjs",
@@ -47,8 +51,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@layoutit/polycss": "0.2.10",
-    "@layoutit/polycss-morph": "0.2.10",
+    "@layoutit/polycss": "0.2.11",
+    "@layoutit/polycss-morph": "0.2.11",
     "prismjs": "1.30.0"
   },
   "devDependencies": {
@@ -56,6 +60,7 @@
     "@types/node": "^24.10.0",
     "@types/prismjs": "1.26.5",
     "playwright": "1.60.0",
+    "pngjs": "7.0.0",
     "sharp": "0.35.3",
     "typescript": "5.9.3",
     "vite": "7.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@layoutit/polycss':
-        specifier: 0.2.10
-        version: 0.2.10
+        specifier: 0.2.11
+        version: 0.2.11
       '@layoutit/polycss-morph':
-        specifier: 0.2.10
-        version: 0.2.10
+        specifier: 0.2.11
+        version: 0.2.11
       prismjs:
         specifier: 1.30.0
         version: 1.30.0
@@ -30,6 +30,9 @@ importers:
       playwright:
         specifier: 1.60.0
         version: 1.60.0
+      pngjs:
+        specifier: 7.0.0
+        version: 7.0.0
       sharp:
         specifier: 0.35.3
         version: 0.35.3(@types/node@24.13.3)
@@ -366,14 +369,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@layoutit/polycss-core@0.2.10':
-    resolution: {integrity: sha512-17ClTkF13jRtG/4tyx+6BcmcH8pscuZUSUz7k60dyo56DXi8e/Km3ZFZ7s9vXXE1XQYfGCQSc5xZ069UXn3wCQ==}
+  '@layoutit/polycss-core@0.2.11':
+    resolution: {integrity: sha512-JC2amXB5k1xooOBZevkKq6KW4SZwJa7wkzH1onarFsppzE1hxPhXmRLE+AoC2AfnOfBdt6Uz2d9Vdr38J4ITnA==}
 
-  '@layoutit/polycss-morph@0.2.10':
-    resolution: {integrity: sha512-mdnvrFyl+kIc2JZR9erpAvBoZEDqbQb7+WUo6jK1pya4vNLusfgA+fM1G0dSYkBOP8nn0+WNd6vnQHTn2qpy/g==}
+  '@layoutit/polycss-morph@0.2.11':
+    resolution: {integrity: sha512-V9BOU5C+daIPD+AlarieqIkNWXboPRgiqMqmQG/PA0p+ZKV1jKX0edfvVnvj8pTztXZX3aQ7T9CnvAvlVj98Pw==}
 
-  '@layoutit/polycss@0.2.10':
-    resolution: {integrity: sha512-kEyrBY0iRb0dpukmy2FL3cFfs6ZlNbJ2L0JN8UlL3rCgvPZU+TgC2UrtyVcDY8zcnwPrL0a2W0ouQyqRc4YFQg==}
+  '@layoutit/polycss@0.2.11':
+    resolution: {integrity: sha512-5SBf8yY8TVcyKdwXvzVhJEWezd35QYme3eeIO6I6kvRZyAFLCRa2xL6oMfAjx8Pj87XXGSnph2h5YTfjp9P8YA==}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
@@ -571,6 +574,10 @@ packages:
     resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss@8.5.20:
     resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
@@ -851,15 +858,15 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
-  '@layoutit/polycss-core@0.2.10': {}
+  '@layoutit/polycss-core@0.2.11': {}
 
-  '@layoutit/polycss-morph@0.2.10':
+  '@layoutit/polycss-morph@0.2.11':
     dependencies:
-      '@layoutit/polycss': 0.2.10
+      '@layoutit/polycss': 0.2.11
 
-  '@layoutit/polycss@0.2.10':
+  '@layoutit/polycss@0.2.11':
     dependencies:
-      '@layoutit/polycss-core': 0.2.10
+      '@layoutit/polycss-core': 0.2.11
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
@@ -998,6 +1005,8 @@ snapshots:
       playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   postcss@8.5.20:
     dependencies:

--- a/site/public/catalog.json
+++ b/site/public/catalog.json
@@ -2,7 +2,7 @@
   "schema": "cssgraphics.distribution@1",
   "runtime": {
     "package": "@layoutit/polycss-morph",
-    "version": "0.2.10",
+    "version": "0.2.11",
     "license": "MIT"
   },
   "assets": [

--- a/src/adapters/3dpipes/README.md
+++ b/src/adapters/3dpipes/README.md
@@ -1,0 +1,30 @@
+# 3D Pipes
+
+An original generative PolyCSS scene inspired by XScreenSaver `pipes.c` and
+Windows 3D Pipes. Connected tubes are retained HTML/CSS geometry rendered by
+[PolyCSS](https://github.com/LayoutitStudio/polycss), without Canvas, WebGL, or
+WebGPU. This is not a behavioral or visual port of either work.
+
+From the repository root:
+
+```sh
+pnpm install
+pnpm build:3dpipes:full
+pnpm dev:3dpipes
+```
+
+Open <http://127.0.0.1:5173/>.
+
+Preparation authors 64 deterministic desktop and mobile clips. The browser
+mounts two fixed seven-root banks and replays prepared transforms, visibility,
+materials, and lighting through stable DOM. It does not generate paths,
+geometry, lighting, or DOM at runtime.
+
+Generated clips are content-addressed and loaded through a four-clip horizon.
+They remain under ignored `build/generated/`; `pnpm prepare:3dpipes`
+regenerates and verifies them.
+
+Material provenance and redistribution boundaries are recorded in
+[`notes/provenance-bible.md`](notes/provenance-bible.md). The adapter is covered
+by the repository's [MIT license](../../../LICENSE); Microsoft and XScreenSaver
+source, executables, and assets are not included.

--- a/src/adapters/3dpipes/index.html
+++ b/src/adapters/3dpipes/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta
+      name="description"
+      content="Generative 3D pipes rendered entirely with HTML and CSS."
+    >
+    <meta name="theme-color" content="#0b1119">
+    <link rel="icon" href="data:,">
+    <title>css.graphics/pipes</title>
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="site-wordmark" href="https://css.graphics/" aria-label="css.graphics home">
+        <svg class="site-wordmark-svg" viewBox="0 0 190 30" aria-hidden="true" focusable="false">
+          <text x="0" y="23"><tspan class="site-wordmark-css">css.</tspan><tspan class="site-wordmark-graphics">graphics</tspan><tspan class="site-wordmark-path">/pipes</tspan></text>
+        </svg>
+      </a>
+      <nav class="site-actions" aria-label="Scene actions">
+        <a
+          class="site-action-icon-only"
+          href="https://github.com/layoutit/cssGraphics"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="View cssGraphics on GitHub"
+          title="View cssGraphics on GitHub"
+        >
+          <svg class="site-action-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3.3-.4 6.8-1.6 6.8-7A5.5 5.5 0 0 0 19.3 3.7 5.1 5.1 0 0 0 19.1 0S17.9-.4 15 1.5a13.4 13.4 0 0 0-6 0C6.1-.4 4.9 0 4.9 0a5.1 5.1 0 0 0-.2 3.7 5.5 5.5 0 0 0-1.5 3.8c0 5.4 3.5 6.6 6.8 7A4.8 4.8 0 0 0 9 18v4"></path>
+            <path d="M9 19c-3 .9-3-1.5-4.2-2"></path>
+          </svg>
+        </a>
+      </nav>
+    </header>
+    <main id="csspipes-root" aria-label="cssPipes PolyCSS scene"></main>
+    <script type="module" src="/src/main.mjs"></script>
+  </body>
+</html>

--- a/src/adapters/3dpipes/notes/provenance-bible.md
+++ b/src/adapters/3dpipes/notes/provenance-bible.md
@@ -1,0 +1,117 @@
+# 3D Pipes provenance bible
+
+Status: original generative PolyCSS artwork
+Last verified: 2026-08-06
+
+## Classification
+
+3D Pipes is an authored browser artwork inspired by XScreenSaver `pipes.c` and
+the visual memory of Windows 3D Pipes. It is not an exact source port, native
+reconstruction, or parity project. The product authority is this repository's
+deterministic preparation pipeline and prepared clip library.
+
+No XScreenSaver or Microsoft source, assets, or binaries are bundled. The MIT
+license in this repository covers the authored implementation only.
+
+## Historical sources
+
+- XScreenSaver `hacks/glx/pipes.c`, release 6.15, is the named procedural and
+  visual inspiration. Its exact identity is recorded in
+  `xscreensaver-pipes-source-lock.json`.
+- The Microsoft Win95 SDK OpenGL 3D Pipes sample `material.c` is direct
+  authority only for its sixteen `goodMaterials` tuples and their ordering.
+  Its exact identity and values are recorded in
+  `windows-pipes-material-source-lock.json`.
+- The product uses four colors derived from that historical bank and three
+  authored colors. It does not reproduce either source renderer.
+
+Safe public description: "An original generative PolyCSS artwork inspired by
+XScreenSaver Pipes and the classic Windows 3D Pipes screensaver."
+
+## PolyCSS architecture
+
+The implementation uses established cssGraphics techniques:
+
+- one prepared PolyCSS retained-DOM snapshot;
+- fixed-tick prepared transform playback through PolyCSS Morph;
+- a prepared space-texel lighting atlas with diffuse and specular response;
+- the public PolyCSS cylinder and projective-quad preparation paths;
+- `<b>` solid quads for four-sided caps and `<i>` solid polygons for caps with
+  five through seven sides;
+- `seamBleed: 0` and an explicit zero projective guard for every wall face;
+- one retained camera wrapper and no Canvas, SVG scene renderer, WebGL, or
+  runtime DOM growth.
+
+## Prepared scene contract
+
+- 64 deterministic clips: 32 desktop and 32 mobile.
+- Seven pipes per clip with fixed facet families `[4, 4, 5, 5, 6, 6, 7]`.
+- Fixed palette: emerald `#4ece4e`, ruby `#ce3939`, cyan `#00bdbd`, amber
+  `#dca400`, cool slate `#59636c`, pearl `#ffebeb`, and purple `#b14ece`.
+- 60 logical path steps per pipe and 420 per clip.
+- Every pipe is compiled as one connected ordered ring strip. Turns are not
+  separate elbows: adjacent bands share the same ring vertices.
+- Every complete final pipe is prepared first, recorded while retracting, and
+  replayed in reverse so it appears to grow.
+- Timing is derived from cumulative centerline distance, including turn arcs,
+  so straight and curved portions move at one authored speed.
+- Route candidates are accepted only after prepared camera-fit, screen
+  occupancy, weld, recording, and continuity checks.
+- The bounded-snake timeline prepares simultaneous head growth and tail crop.
+  Neighboring clips share their prepared handoff rings; playback does not stop
+  or construct a new tube at the seam.
+
+## Retained output
+
+The snapshot contains two fixed playback banks:
+
+- 14 pipe roots total;
+- 3,290 retained surface leaves total;
+- 28 cap leaves total;
+- seven roots visible for the active clip;
+- a four-clip prepared loading horizon;
+- no section, run, elbow, turn, or per-frame roots.
+
+Preparation packs the seven fixed facet families by worst required band count.
+The retained root capacities are 47, 45, 47, 41, 45, 35, and 49 bands. Four-
+sided caps are single quad leaves; higher-sided caps are single polygon leaves.
+
+## Lighting and materials
+
+Preparation emits one 8-by-8 RGBA space-texel field per product material and
+facet orientation. The atlas preserves the authored circular diffuse falloff
+and adds a prepared Blinn-Phong-style specular lobe derived from the selected
+historical material tuple. Static CSS binds each clip and source-pipe identity
+to its prepared wall fields and matching cap color.
+
+The browser performs no lighting calculation, material choice, random color
+selection, or per-leaf color writes.
+
+## Prepare/runtime boundary
+
+Preparation owns seeded route generation, self-avoidance, viewport profiles,
+screen occupancy, camera fitting, connected meshes, facet assignment, packing,
+all wall and cap matrices, lighting texels, material bindings, head/tail crop
+rows, clip chaining, playlists, stable ids, scene JSON, snapshot, and manifest.
+
+Runtime owns only manifest/snapshot loading, desktop-or-mobile profile choice,
+an already-prepared random playlist start, four-clip lookahead loading, fixed-
+rate publication of prepared transforms and visibility, bank swapping, pause,
+resume, and clean restart after the prepared playlist is exhausted.
+
+Runtime geometry, route generation, turn detection, camera fitting, matrix
+derivation, lighting, topology changes, CSS interpolation, and DOM growth are
+forbidden.
+
+## Release evidence
+
+Release verification is intentionally narrow:
+
+1. regenerate the prepared assets;
+2. require the canonical scene, snapshot, and atlas hashes to remain unchanged
+   for a code-only cleanup;
+3. build the production adapter;
+4. run repository type and source-only checks.
+
+Visual acceptance belongs to the prepared scene itself. Historical native
+screenshots may explain inspiration but are not parity evidence.

--- a/src/adapters/3dpipes/notes/windows-pipes-material-source-lock.json
+++ b/src/adapters/3dpipes/notes/windows-pipes-material-source-lock.json
@@ -1,0 +1,54 @@
+{
+  "schema": "csspipes-windows-3d-pipes-material-source-lock@1",
+  "target": {
+    "title": "Microsoft Win95 SDK OpenGL 3D Pipes screen-saver sample",
+    "module": "material.c",
+    "scope": "goodMaterials selection bank and its OpenGL material tuples"
+  },
+  "upstream": {
+    "repositoryUrl": "https://github.com/joncampbell123/windows_sdk_collection",
+    "repositoryRole": "historical mirror of the publicly distributed July 1995 Win32 SDK sample tree",
+    "commit": "e707dd87e84171c8e061c7ed6268eb3edaf85b49",
+    "tree": "b358359c185b9ebca3cb9e06b025c90cd75c03c4",
+    "commitDate": "2026-07-13T06:59:17Z"
+  },
+  "file": {
+    "path": "win/win95/sdk-1995-07-win32/win32sdk/mstools/samples/opengl/pipes/material.c",
+    "bytes": 5113,
+    "gitBlob": "d9992adedafa93fd9a88e9b3abb65ba945f4d0d4",
+    "sha256": "e8b7559efd580cdf166ef2482877bd98dbd5bbdf808ee0a9fa45e5b92048148c",
+    "copyrightNotice": "Copyright (c) 1994-1995 Microsoft Corporation"
+  },
+  "authority": {
+    "goodMaterialsLines": "31-34",
+    "materialTableLines": "45-94",
+    "selectionLines": "135-144",
+    "goodMaterialSourceIndices": [0, 1, 3, 4, 5, 6, 7, 9, 10, 11, 13, 16, 17, 19, 20, 22],
+    "goodMaterialSymbols": [
+      "EMERALD",
+      "JADE",
+      "PEARL",
+      "RUBY",
+      "TURQUOISE",
+      "BRASS",
+      "BRONZE",
+      "COPPER",
+      "GOLD",
+      "SILVER",
+      "CYAN_PLASTIC",
+      "WHITE_PLASTIC",
+      "YELLOW_PLASTIC",
+      "CYAN_RUBBER",
+      "GREEN_RUBBER",
+      "WHITE_RUBBER"
+    ],
+    "selectionExpression": "teaMaterial[goodMaterials[mfRand(16)]]",
+    "selectionWithReplacement": true
+  },
+  "boundary": {
+    "transcribedData": "the sixteen selected ambient, diffuse, specular, and shininess tuples",
+    "bundledUpstreamSource": false,
+    "bundledMicrosoftBinaryOrAsset": false,
+    "runtimeSourceDependency": false
+  }
+}

--- a/src/adapters/3dpipes/notes/xscreensaver-pipes-source-lock.json
+++ b/src/adapters/3dpipes/notes/xscreensaver-pipes-source-lock.json
@@ -1,0 +1,26 @@
+{
+  "schema": "csspipes-xscreensaver-source-lock@1",
+  "classification": "named visual and procedural inspiration only",
+  "target": {
+    "title": "XScreenSaver Pipes",
+    "sourcePath": "hacks/glx/pipes.c",
+    "sourceSha256": "b1a2c82eae0257cd8a73596a51c9bcd7e034b56b3d54ccf35bc064684c4fc084",
+    "suppliedFileSha256": "b1a2c82eae0257cd8a73596a51c9bcd7e034b56b3d54ccf35bc064684c4fc084"
+  },
+  "upstream": {
+    "officialProjectUrl": "https://www.jwz.org/xscreensaver/",
+    "githubMirrorUrl": "https://github.com/Zygo/xscreensaver.git",
+    "githubMirrorRole": "read-only mirror of the official non-GitHub upstream",
+    "release": "XScreenSaver 6.15",
+    "commit": "906693799e4fb7581436590cf84ecb2d3c9186ba",
+    "commitDate": "2026-03-30T22:29:40-04:00",
+    "commitSubject": "From https://www.jwz.org/xscreensaver/xscreensaver-6.15.tar.gz"
+  },
+  "boundary": {
+    "bundledUpstreamSource": false,
+    "bundledUpstreamAssets": false,
+    "bundledUpstreamBinaries": false,
+    "geometryAuthority": "authored 3D Pipes preparation pipeline",
+    "parityClaim": false
+  }
+}

--- a/src/adapters/3dpipes/src/csspipes/client.mjs
+++ b/src/adapters/3dpipes/src/csspipes/client.mjs
@@ -1,0 +1,65 @@
+import {
+  loadCssPipesManifest,
+  loadCssPipesScene,
+  selectDefaultScene,
+} from "./manifestClient.mjs";
+import { createCssPipesPrebakedPlayer } from "./prebakedPlayback.mjs";
+import { mountPreparedPolyCssSnapshot } from "./polycssScene.mjs";
+import { mountCssPipesPresentation } from "./presentation.mjs";
+
+const PREPARE_FAILURE = "cssPipes prepared clip scene unavailable. Run pnpm prepare:3dpipes.";
+export async function startCssPipesClient(host, route) {
+  let presentation = null;
+  let player = null;
+  let unsubscribePresentation = null;
+  try {
+    const manifest = await loadCssPipesManifest(route.manifestUrl);
+    const descriptor = selectDefaultScene(manifest);
+    const scene = await loadCssPipesScene(descriptor);
+    const snapshot = await mountPreparedPolyCssSnapshot(host, scene);
+    presentation = mountCssPipesPresentation({
+      host,
+      viewport: snapshot.viewport,
+      camera: snapshot.camera,
+      sourceViewport: scene.camera.sourceViewport,
+      responsivePresentation: scene.camera.responsivePresentation,
+    });
+    const playbackRoot = host.querySelector("[data-csspipes-playback-root]");
+    const shapeRoots = host.querySelectorAll("[data-csspipes-shape-index]");
+    const leafRoots = host.querySelectorAll("[data-csspipes-leaf-index]");
+    if (!(playbackRoot instanceof HTMLElement) || shapeRoots.length === 0 || leafRoots.length === 0) {
+      throw new Error("Prepared cssPipes playback targets are missing");
+    }
+    player = await createCssPipesPrebakedPlayer({
+      playback: scene.playback,
+      sceneRoot: snapshot.scene,
+      playbackRoot,
+      shapeRoots,
+      leafRoots,
+      initialViewportProfile: presentation.viewportProfile,
+    });
+    unsubscribePresentation = presentation.subscribe((layout) => {
+      void player.setViewportProfile(layout.viewportProfile);
+    });
+    const mounted = Object.freeze({
+      ...snapshot,
+      presentation,
+      player,
+      destroy() {
+        unsubscribePresentation();
+        presentation.destroy();
+        player.destroy();
+      },
+    });
+    host.dataset.csspipesReady = "true";
+    globalThis.requestAnimationFrame(() => player.resume());
+    return mounted;
+  } catch (error) {
+    unsubscribePresentation?.();
+    player?.destroy();
+    presentation?.destroy();
+    host.dataset.csspipesReady = "error";
+    host.textContent = `${PREPARE_FAILURE} ${error instanceof Error ? error.message : String(error)}`;
+    return null;
+  }
+}

--- a/src/adapters/3dpipes/src/csspipes/devtoolsAttrs.mjs
+++ b/src/adapters/3dpipes/src/csspipes/devtoolsAttrs.mjs
@@ -1,0 +1,9 @@
+export function applyCssPipesAttributes(element, values) {
+  if (!(element instanceof HTMLElement)) throw new TypeError("cssPipes attribute target must be an element");
+  for (const [key, value] of Object.entries(values)) {
+    if (!/^[a-z][a-z0-9]*$/i.test(key)) throw new TypeError(`Invalid cssPipes data key ${key}`);
+    if (!["string", "number", "boolean"].includes(typeof value)) continue;
+    element.dataset[`csspipes${key[0].toUpperCase()}${key.slice(1)}`] = String(value);
+  }
+  return element;
+}

--- a/src/adapters/3dpipes/src/csspipes/manifestClient.mjs
+++ b/src/adapters/3dpipes/src/csspipes/manifestClient.mjs
@@ -1,0 +1,60 @@
+import { CssPipesContractError, nonEmptyString, object, safeGeneratedUrl } from "./types.mjs";
+import { readPreparedJson } from "./preparedResponse.mjs";
+
+export function validateCssPipesManifest(input) {
+  const manifest = object(input, "cssPipes manifest");
+  if (manifest.schema !== "csspipes-manifest@1" || manifest.status !== "ready") {
+    throw new CssPipesContractError("cssPipes manifest is not a ready v1 manifest");
+  }
+  const defaultScene = nonEmptyString(manifest.defaultScene, "manifest.defaultScene");
+  if (!Array.isArray(manifest.scenes) || manifest.scenes.length === 0) {
+    throw new CssPipesContractError("cssPipes manifest has no prepared scenes");
+  }
+  const ids = new Set();
+  const scenes = manifest.scenes.map((entry, index) => {
+    const scene = object(entry, `manifest.scenes[${index}]`);
+    const id = nonEmptyString(scene.id, `manifest.scenes[${index}].id`);
+    if (ids.has(id)) throw new CssPipesContractError(`Duplicate manifest scene ${id}`);
+    ids.add(id);
+    return Object.freeze({
+      ...scene,
+      id,
+      sceneUrl: safeGeneratedUrl(scene.sceneUrl, `manifest.scenes[${index}].sceneUrl`),
+      snapshotUrl: safeGeneratedUrl(scene.snapshotUrl, `manifest.scenes[${index}].snapshotUrl`),
+    });
+  });
+  if (!ids.has(defaultScene)) {
+    throw new CssPipesContractError("manifest.defaultScene does not name a prepared scene");
+  }
+  return Object.freeze({ ...manifest, defaultScene, scenes: Object.freeze(scenes) });
+}
+
+export async function loadCssPipesManifest(url, fetchImpl = globalThis.fetch) {
+  const response = await fetchImpl(url, { cache: "no-store" });
+  if (!response?.ok) throw new CssPipesContractError(`Manifest request failed (${response?.status ?? "network"})`);
+  return validateCssPipesManifest(await response.json());
+}
+
+export function selectDefaultScene(manifest) {
+  const scene = manifest.scenes.find((candidate) => candidate.id === manifest.defaultScene);
+  if (!scene) throw new CssPipesContractError("Prepared default scene is missing");
+  return scene;
+}
+
+export async function loadCssPipesScene(descriptor, fetchImpl = globalThis.fetch) {
+  const response = await fetchImpl(descriptor.sceneUrl, { cache: "no-store" });
+  if (!response?.ok) {
+    throw new CssPipesContractError(`Prepared scene request failed (${response?.status ?? "network"})`);
+  }
+  const scene = descriptor.sceneUrl.endsWith(".gz")
+    ? await readPreparedJson(response)
+    : await response.json();
+  if (scene.schema !== "csspipes-prebaked-scene@12" || scene.id !== descriptor.id) {
+    throw new CssPipesContractError("Prepared cssPipes scene does not match its manifest descriptor");
+  }
+  return Object.freeze({
+    ...scene,
+    snapshotUrl: descriptor.snapshotUrl,
+    manifestMetrics: descriptor.metrics,
+  });
+}

--- a/src/adapters/3dpipes/src/csspipes/polycssScene.mjs
+++ b/src/adapters/3dpipes/src/csspipes/polycssScene.mjs
@@ -1,0 +1,73 @@
+import { applyCssPipesAttributes } from "./devtoolsAttrs.mjs";
+import { CssPipesContractError } from "./types.mjs";
+import { readPreparedText } from "./preparedResponse.mjs";
+
+const ALLOWED_SNAPSHOT_TAGS = new Set([
+  "html", "head", "meta", "title", "style", "body", "div", "b", "i",
+]);
+const FORBIDDEN_SNAPSHOT_ATTRIBUTES = new Set([
+  "action", "formaction", "href", "src", "srcdoc",
+]);
+
+function assertSafePreparedCss(css) {
+  if (/@import\b/i.test(css)) {
+    throw new CssPipesContractError("Prepared snapshot CSS contains an external import");
+  }
+  for (const match of css.matchAll(/url\(\s*([^)]+?)\s*\)/giu)) {
+    const value = match[1].replace(/^["']|["']$/gu, "");
+    if (!value.startsWith("data:image/png;base64,")) {
+      throw new CssPipesContractError("Prepared snapshot CSS contains an external URL");
+    }
+  }
+}
+
+function importedSnapshot(documentNode) {
+  for (const element of documentNode.querySelectorAll("*")) {
+    if (!ALLOWED_SNAPSHOT_TAGS.has(element.localName)) {
+      throw new CssPipesContractError(`Prepared snapshot contains forbidden <${element.localName}>`);
+    }
+    for (const attribute of element.attributes) {
+      const name = attribute.name.toLowerCase();
+      if (name.startsWith("on") || FORBIDDEN_SNAPSHOT_ATTRIBUTES.has(name)) {
+        throw new CssPipesContractError(`Prepared snapshot contains forbidden ${name} attribute`);
+      }
+      if (name === "style") assertSafePreparedCss(attribute.value);
+    }
+  }
+  const cameras = documentNode.querySelectorAll(".polycss-camera");
+  const scenes = documentNode.querySelectorAll(".polycss-scene");
+  const camera = cameras[0];
+  const scene = scenes[0];
+  if (cameras.length !== 1 || scenes.length !== 1 || !camera.contains(scene)) {
+    throw new CssPipesContractError("Prepared snapshot is missing one PolyCSS camera/scene");
+  }
+  const styles = [...documentNode.querySelectorAll("style")];
+  if (styles.length === 0) throw new CssPipesContractError("Prepared snapshot has no retained PolyCSS styles");
+  for (const style of styles) assertSafePreparedCss(style.textContent ?? "");
+  return { camera, styles };
+}
+
+export async function mountPreparedPolyCssSnapshot(host, sceneContract, fetchImpl = globalThis.fetch) {
+  const response = await fetchImpl(sceneContract.snapshotUrl, { cache: "no-store" });
+  if (!response?.ok) throw new CssPipesContractError(`Snapshot request failed (${response?.status ?? "network"})`);
+  const html = await readPreparedText(response);
+  if (/\/(?:Users|home)\//.test(html) || /<script\b/i.test(html)) {
+    throw new CssPipesContractError("Prepared snapshot failed path/script sanitization");
+  }
+  const parsed = new DOMParser().parseFromString(html, "text/html");
+  const snapshot = importedSnapshot(parsed);
+  const fragment = document.createDocumentFragment();
+  for (const style of snapshot.styles) fragment.append(document.importNode(style, true));
+  const viewport = document.createElement("div");
+  viewport.dataset.csspipesViewport = "true";
+  const camera = document.importNode(snapshot.camera, true);
+  viewport.append(camera);
+  fragment.append(viewport);
+  host.replaceChildren(fragment);
+  applyCssPipesAttributes(host, { scene: sceneContract.id, snapshot: "prepared" });
+  return Object.freeze({
+    viewport,
+    camera,
+    scene: camera.querySelector(".polycss-scene"),
+  });
+}

--- a/src/adapters/3dpipes/src/csspipes/prebakedPlayback.mjs
+++ b/src/adapters/3dpipes/src/csspipes/prebakedPlayback.mjs
@@ -1,0 +1,393 @@
+import { createPreparedDomBanks } from "./preparedDomBanks.mjs";
+import { createPreparedClipStore } from "./preparedClipStore.mjs";
+
+function viewportProfile(value) {
+  if (value !== "desktop" && value !== "mobile") {
+    throw new RangeError("cssPipes viewport profile must be desktop or mobile");
+  }
+  return value;
+}
+
+function selectedPlaylistCursor(playback, profile) {
+  const playlist = playback.viewportPlaylists[profile];
+  if (globalThis.crypto?.getRandomValues) {
+    return globalThis.crypto.getRandomValues(new Uint32Array(1))[0] % playlist.length;
+  }
+  return 0;
+}
+
+function horizonClipIndices(playback, playlist, startClipIndex) {
+  const indices = new Set();
+  let current = startClipIndex;
+  while (indices.size < playback.clipChunks.runtimeLookaheadClipCount) {
+    indices.add(current);
+    const track = playback.experiments.zSeedLoop.tracks[current];
+    if (track.recycleClipIndex !== null) indices.add(track.recycleClipIndex);
+    current = track.terminal ? playlist[0] : track.nextClipIndex;
+    indices.add(current);
+  }
+  return [...indices].slice(0, playback.clipChunks.runtimeLookaheadClipCount);
+}
+
+function loadedClip(store, index) {
+  const prepared = store.loaded(index);
+  if (!prepared) throw new Error(`Prepared clip ${index} is not loaded`);
+  return prepared;
+}
+
+function trackShapeTransforms(playback, prepared) {
+  const transforms = prepared.placement.shapeTransforms;
+  if (transforms?.length !== playback.retainedRootCount) {
+    throw new Error(`Prepared clip ${prepared.clipIndex} is missing its roots`);
+  }
+  return transforms;
+}
+
+export async function createCssPipesPrebakedPlayer(options) {
+  const playback = options.playback;
+  const playbackRoot = options.playbackRoot;
+  const sceneRoot = options.sceneRoot;
+  if (!playbackRoot?.style || !sceneRoot?.style) {
+    throw new Error("Prepared cssPipes retained roots are missing");
+  }
+  const dom = createPreparedDomBanks(options);
+  const clipStore = createPreparedClipStore(playback, options.fetchImpl);
+  const requestFrame = globalThis.requestAnimationFrame.bind(globalThis);
+  const cancelFrame = globalThis.cancelAnimationFrame.bind(globalThis);
+  const frameMilliseconds = 1000 / playback.playbackFramesPerSecond;
+  let selectedViewportProfile = viewportProfile(options.initialViewportProfile ?? "desktop");
+  let activePlaylist = playback.viewportPlaylists[selectedViewportProfile];
+  let playlistCursor = selectedPlaylistCursor(playback, selectedViewportProfile);
+  let clipIndex = activePlaylist[playlistCursor];
+  let clipData = null;
+  let frameIndex = -1;
+  let seedLoopStep = 0;
+  let seedLoopPhase = "opening";
+  let headBank = 0;
+  let tailBank = null;
+  let nextHeadBank = 1;
+  let clipCycle = 0;
+  let paused = true;
+  let request = null, nextFrameAt = null;
+  let horizonRequest = 0;
+  let selectionRequest = 0;
+  const {
+    hideAllBanks,
+    hideBank,
+    writeBankMaterial,
+    writeLeaf,
+    writeModelTransform,
+    writePipeMaterial,
+    writePlaybackRoot,
+    writeShape,
+  } = dom;
+
+  async function prepareHorizon(startClipIndex) {
+    const requestId = ++horizonRequest;
+    const indices = horizonClipIndices(playback, activePlaylist, startClipIndex);
+    await clipStore.preload(indices);
+    if (requestId === horizonRequest) clipStore.retain(indices);
+  }
+
+  function seedTrack(currentClipIndex = clipIndex) {
+    return playback.experiments.zSeedLoop.tracks[currentClipIndex];
+  }
+
+  function publishPreparedState(
+    bank,
+    initial,
+    prepared,
+    preparedShapeTransforms = trackShapeTransforms(playback, prepared),
+  ) {
+    const transforms = prepared.transforms;
+    writeModelTransform(transforms, prepared.placement.modelTransform);
+    for (let offset = 0; offset < initial.shapes.length; offset += 3) {
+      const shapeIndex = initial.shapes[offset];
+      writeShape(
+        transforms,
+        bank,
+        shapeIndex,
+        preparedShapeTransforms[shapeIndex],
+        initial.shapes[offset + 2],
+      );
+    }
+    for (let offset = 0; offset < initial.leaves.length; offset += 3) {
+      writeLeaf(
+        transforms,
+        bank,
+        initial.leaves[offset],
+        initial.leaves[offset + 1],
+        initial.leaves[offset + 2],
+      );
+    }
+    writePlaybackRoot(transforms, prepared.placement.seedOriginTransform, initial.rootOpacity);
+  }
+
+  function publishInitial(bank, prepared) {
+    publishPreparedState(bank, prepared.recording.experiment.initial, prepared);
+  }
+
+  function applyPackedLeafRow(bank, transforms, preparedRows, row, side) {
+    const transformColumn = side === "before" ? 1 : 3;
+    const visibilityColumn = side === "before" ? 2 : 4;
+    for (let index = 0; index < row[1]; index += 1) {
+      const offset = (row[0] + index) * 5;
+      writeLeaf(
+        transforms,
+        bank,
+        preparedRows.leafTransitions[offset],
+        preparedRows.leafTransitions[offset + transformColumn],
+        preparedRows.leafTransitions[offset + visibilityColumn],
+      );
+    }
+  }
+
+  function applyReverseSourceRow(bank, prepared, sourceIndex) {
+    const recording = prepared.recording;
+    const row = recording.sourceRows[sourceIndex];
+    if (!row) throw new Error(`Prepared retraction source row ${sourceIndex} is missing`);
+    applyPackedLeafRow(bank, prepared.transforms, recording, row, "before");
+  }
+
+  function applySnakeTailSourceRow(bank, prepared, sourceIndex) {
+    const recording = prepared.recording;
+    const tail = recording.snakeTail;
+    const row = tail.sourceRows[sourceIndex];
+    if (!row) throw new Error(`Prepared Snake tail row ${sourceIndex} is missing`);
+    for (let index = 0; index < row[1]; index += 1) {
+      const offset = (row[0] + index) * 3;
+      writeLeaf(
+        prepared.transforms,
+        bank,
+        tail.leafAssignments[offset],
+        tail.leafAssignments[offset + 1],
+        tail.leafAssignments[offset + 2],
+      );
+    }
+  }
+
+  function prearmPreparedBank(bank, prepared) {
+    writeBankMaterial(bank, prepared.clipIndex);
+    const initial = prepared.recording.experiment.connectedInitial;
+    const shapeTransforms = trackShapeTransforms(playback, prepared);
+    for (let offset = 0; offset < initial.shapes.length; offset += 3) {
+      const shape = initial.shapes[offset];
+      writeShape(prepared.transforms, bank, shape, shapeTransforms[shape], 0);
+    }
+    for (let offset = 0; offset < initial.leaves.length; offset += 3) {
+      writeLeaf(
+        prepared.transforms,
+        bank,
+        initial.leaves[offset],
+        initial.leaves[offset + 1],
+        0,
+      );
+    }
+  }
+
+  function applyPreparedBankRecycle(bank, track, frame) {
+    const row = track.recycleRows[frame];
+    if (!row) return;
+    const recycled = loadedClip(clipStore, track.recycleClipIndex);
+    for (let index = 0; index < row[1]; index += 1) {
+      const offset = (row[0] + index) * 2;
+      const pipe = track.recycleShapeAssignments[offset];
+      writeShape(
+        recycled.transforms,
+        bank,
+        pipe,
+        track.recycleShapeAssignments[offset + 1],
+        1,
+      );
+      writePipeMaterial(bank, pipe, track.recycleClipIndex);
+    }
+    for (let index = 0; index < row[3]; index += 1) {
+      const offset = (row[2] + index) * 3;
+      writeLeaf(
+        recycled.transforms,
+        bank,
+        track.recycleLeafAssignments[offset],
+        track.recycleLeafAssignments[offset + 1],
+        track.recycleLeafAssignments[offset + 2],
+      );
+    }
+  }
+
+  function applyScheduledHeadRows(bank, prepared, scheduleRow) {
+    if (!scheduleRow) throw new Error("Prepared Snake head schedule row is missing");
+    for (let offset = 0; offset < scheduleRow[1]; offset += 1) {
+      applyReverseSourceRow(bank, prepared, scheduleRow[0] - offset);
+    }
+  }
+
+  function applyScheduledTailRows(bank, prepared, scheduleRow) {
+    if (!scheduleRow) throw new Error("Prepared Snake tail schedule row is missing");
+    for (let offset = 0; offset < scheduleRow[1]; offset += 1) {
+      applySnakeTailSourceRow(bank, prepared, scheduleRow[0] + offset);
+    }
+  }
+
+  function beginOpening() {
+    const track = seedTrack();
+    frameIndex = -1;
+    seedLoopStep = 0;
+    seedLoopPhase = "opening";
+    headBank = 0;
+    tailBank = null;
+    nextHeadBank = 1;
+    hideAllBanks();
+    writeBankMaterial(headBank, clipIndex);
+    publishInitial(headBank, clipData);
+    if (!track.terminal) {
+      prearmPreparedBank(nextHeadBank, loadedClip(clipStore, track.nextClipIndex));
+    }
+    dom.assertStableDomIdentity();
+  }
+
+  function restartOpening() {
+    playlistCursor = 0;
+    clipCycle += 1;
+    clipIndex = activePlaylist[playlistCursor];
+    clipData = loadedClip(clipStore, clipIndex);
+    beginOpening();
+  }
+
+  function advanceOpeningFrame(track) {
+    if (seedLoopStep === 0) {
+      const growEntry = clipData.recording.experiment.growEntry;
+      applyPackedLeafRow(headBank, clipData.transforms, growEntry, growEntry.row, "after");
+    }
+    applyScheduledHeadRows(headBank, clipData, track.openingHeadRows[seedLoopStep]);
+    frameIndex = seedLoopStep;
+    seedLoopStep += 1;
+    if (seedLoopStep !== track.openingFrameCount) return;
+    seedLoopStep = 0;
+    seedLoopPhase = track.terminal ? "restart" : "transition";
+  }
+
+  function beginTransitionFrame(track, nextPrepared) {
+    tailBank = headBank;
+    nextHeadBank = headBank === 0 ? 1 : 0;
+    publishPreparedState(
+      nextHeadBank,
+      nextPrepared.recording.experiment.connectedInitial,
+      nextPrepared,
+    );
+    applySnakeTailSourceRow(tailBank, clipData, 0);
+  }
+
+  function finishTransition(track, nextPrepared, nextTrack) {
+    if (track.recycleClipIndex === null) hideBank(tailBank);
+    playlistCursor = nextTrack.chainIndex;
+    clipCycle += 1;
+    clipIndex = track.nextClipIndex;
+    clipData = nextPrepared;
+    headBank = nextHeadBank;
+    tailBank = null;
+    seedLoopStep = 0;
+    seedLoopPhase = nextTrack.terminal ? "restart" : "transition";
+    void prepareHorizon(clipIndex);
+  }
+
+  function advanceTransitionFrame(track) {
+    const nextPrepared = loadedClip(clipStore, track.nextClipIndex);
+    const nextTrack = seedTrack(track.nextClipIndex);
+    if (seedLoopStep === 0) beginTransitionFrame(track, nextPrepared);
+    applyScheduledTailRows(tailBank, clipData, track.tailSourceRows[seedLoopStep]);
+    applyPreparedBankRecycle(tailBank, track, seedLoopStep);
+    applyScheduledHeadRows(
+      nextHeadBank,
+      nextPrepared,
+      track.headSourceRows[seedLoopStep],
+    );
+    frameIndex = seedLoopStep;
+    seedLoopStep += 1;
+    if (seedLoopStep === track.transitionFrameCount) {
+      finishTransition(track, nextPrepared, nextTrack);
+    }
+  }
+
+  function advanceFrame() {
+    const track = seedTrack();
+    if (seedLoopPhase === "opening") advanceOpeningFrame(track);
+    else if (seedLoopPhase === "transition") advanceTransitionFrame(track);
+    else if (seedLoopPhase === "restart") {
+      restartOpening();
+      return frameIndex;
+    } else throw new Error(`Prepared seed-loop phase ${seedLoopPhase} cannot advance`);
+    return frameIndex;
+  }
+
+  function stopPlaybackLoop() {
+    const wasPaused = paused;
+    paused = true;
+    nextFrameAt = null;
+    if (request !== null) cancelFrame(request);
+    request = null;
+    return wasPaused;
+  }
+
+  function restorePlaybackLoop(wasPaused) {
+    if (wasPaused) return;
+    paused = false;
+    request = requestFrame(loop);
+  }
+
+  function loop(timestamp) {
+    request = null;
+    if (paused) return;
+    if (nextFrameAt === null) {
+      nextFrameAt = timestamp + frameMilliseconds;
+    } else if (timestamp >= nextFrameAt - 0.5) {
+      advanceFrame();
+      nextFrameAt += frameMilliseconds;
+      if (nextFrameAt <= timestamp) nextFrameAt = timestamp + frameMilliseconds;
+    }
+    request = requestFrame(loop);
+  }
+
+  function pause() {
+    paused = true;
+    nextFrameAt = null;
+    if (request !== null) cancelFrame(request);
+    request = null;
+    return frameIndex;
+  }
+
+  function resume() {
+    if (!paused) return frameIndex;
+    paused = false;
+    nextFrameAt = null;
+    request = requestFrame(loop);
+    return frameIndex;
+  }
+
+  async function setViewportProfile(value) {
+    const nextProfile = viewportProfile(value);
+    if (nextProfile === selectedViewportProfile) return selectedViewportProfile;
+    const requestId = ++selectionRequest;
+    const wasPaused = stopPlaybackLoop();
+    selectedViewportProfile = nextProfile;
+    activePlaylist = playback.viewportPlaylists[selectedViewportProfile];
+    playlistCursor = clipCycle % activePlaylist.length;
+    clipIndex = activePlaylist[playlistCursor];
+    await prepareHorizon(clipIndex);
+    if (requestId !== selectionRequest) return selectedViewportProfile;
+    clipData = loadedClip(clipStore, clipIndex);
+    beginOpening();
+    restorePlaybackLoop(wasPaused);
+    return selectedViewportProfile;
+  }
+
+  await prepareHorizon(clipIndex);
+  clipData = loadedClip(clipStore, clipIndex);
+  beginOpening();
+  return Object.freeze({
+    resume,
+    setViewportProfile,
+    destroy() {
+      pause();
+      dom.destroy();
+    },
+  });
+}

--- a/src/adapters/3dpipes/src/csspipes/preparedClipStore.mjs
+++ b/src/adapters/3dpipes/src/csspipes/preparedClipStore.mjs
@@ -1,0 +1,82 @@
+import { CssPipesContractError, object, safeGeneratedUrl } from "./types.mjs";
+import { readPreparedJson } from "./preparedResponse.mjs";
+
+function validateDescriptor(value, index) {
+  const descriptor = object(value, `playback.clipChunks.descriptors[${index}]`);
+  if (descriptor.clipIndex !== index || !Number.isInteger(descriptor.bytes) ||
+      descriptor.bytes <= 0 || !Number.isInteger(descriptor.transformCount) ||
+      descriptor.transformCount <= 0 || descriptor.encoding !== "gzip" ||
+      !Number.isInteger(descriptor.storedBytes) || descriptor.storedBytes <= 0) {
+    throw new CssPipesContractError(`Prepared clip descriptor ${index} is invalid`);
+  }
+  return Object.freeze({
+    ...descriptor,
+    url: safeGeneratedUrl(descriptor.url, `playback clip ${index} URL`),
+  });
+}
+
+function validateChunk(input, descriptor) {
+  const chunk = object(input, `prepared clip ${descriptor.clipIndex}`);
+  if (chunk.schema !== "csspipes-prepared-clip-chunk@1" ||
+      chunk.clipIndex !== descriptor.clipIndex ||
+      !Array.isArray(chunk.transforms) ||
+      chunk.transforms.length !== descriptor.transformCount ||
+      !chunk.transforms.every((transform) => typeof transform === "string") ||
+      !chunk.placement || !chunk.recording) {
+    throw new CssPipesContractError(
+      `Prepared clip ${descriptor.clipIndex} does not match its descriptor`,
+    );
+  }
+  return Object.freeze(chunk);
+}
+
+export function createPreparedClipStore(playback, fetchImpl = globalThis.fetch) {
+  const contract = object(playback.clipChunks, "playback.clipChunks");
+  if (contract.schema !== "csspipes-prepared-clip-chunks@1" ||
+      !Array.isArray(contract.descriptors) ||
+      contract.count !== playback.clipCount ||
+      contract.descriptors.length !== contract.count) {
+    throw new CssPipesContractError("Prepared clip storage contract is invalid");
+  }
+  const descriptors = Object.freeze(contract.descriptors.map(validateDescriptor));
+  const cache = new Map();
+  const values = new Map();
+
+  function load(index) {
+    const descriptor = descriptors[index];
+    if (!descriptor) throw new RangeError(`Prepared clip ${index} is out of range`);
+    let request = cache.get(index);
+    if (!request) {
+      request = fetchImpl(descriptor.url, { cache: "force-cache" }).then(async (response) => {
+        if (!response?.ok) {
+          throw new CssPipesContractError(
+            `Prepared clip ${index} request failed (${response?.status ?? "network"})`,
+          );
+        }
+        const chunk = validateChunk(await readPreparedJson(response), descriptor);
+        if (cache.get(index) === request) values.set(index, chunk);
+        return chunk;
+      });
+      cache.set(index, request);
+    }
+    return request;
+  }
+
+  return Object.freeze({
+    load,
+    preload(indices) {
+      return Promise.all([...new Set(indices)].map(load));
+    },
+    loaded(index) {
+      return values.get(index) ?? null;
+    },
+    retain(indices) {
+      const retained = new Set(indices);
+      for (const index of cache.keys()) {
+        if (retained.has(index)) continue;
+        cache.delete(index);
+        values.delete(index);
+      }
+    },
+  });
+}

--- a/src/adapters/3dpipes/src/csspipes/preparedDomBanks.mjs
+++ b/src/adapters/3dpipes/src/csspipes/preparedDomBanks.mjs
@@ -1,0 +1,167 @@
+import { createPolyMorphPreparedDomTarget } from "@layoutit/polycss-morph";
+
+function integerAttribute(node, name, label) {
+  const value = Number(node.getAttribute(name));
+  if (!Number.isInteger(value)) throw new Error(`${label} must be an integer`);
+  return value;
+}
+
+function sortedTargets(nodes, attribute, label) {
+  return [...nodes].sort((left, right) =>
+    integerAttribute(left, attribute, label) - integerAttribute(right, attribute, label));
+}
+
+function bankedTargets(nodes, attribute, label, bankCount, targetCount) {
+  const banks = Array.from({ length: bankCount }, () => []);
+  for (const node of nodes) {
+    const bank = integerAttribute(node, "data-csspipes-bank-index", "Prepared bank index");
+    if (bank < 0 || bank >= bankCount) {
+      throw new Error(`Prepared ${label} bank ${bank} is out of range`);
+    }
+    banks[bank].push(node);
+  }
+  for (let bank = 0; bank < bankCount; bank += 1) {
+    banks[bank] = sortedTargets(banks[bank], attribute, label);
+    if (banks[bank].length !== targetCount || !banks[bank].every((node, index) =>
+      integerAttribute(node, attribute, label) === index)) {
+      throw new Error(`Prepared ${label} bank ${bank} is incomplete`);
+    }
+  }
+  return Object.freeze(banks.map((bank) => Object.freeze(bank)));
+}
+
+export function createPreparedDomBanks(options) {
+  const { playback, playbackRoot, sceneRoot } = options;
+  const shapeRootsByBank = bankedTargets(
+    options.shapeRoots,
+    "data-csspipes-shape-index",
+    "Prepared shape index",
+    playback.retainedBankCount,
+    playback.retainedRootCount,
+  );
+  const leafRootsByBank = bankedTargets(
+    options.leafRoots,
+    "data-csspipes-leaf-index",
+    "Prepared leaf index",
+    playback.retainedBankCount,
+    playback.leafTargetCount,
+  );
+  const shapeRoots = shapeRootsByBank.flat();
+  const leafRoots = leafRootsByBank.flat();
+  const shapeVisibility = new Uint8Array(playback.totalRetainedRootCount);
+  const leafVisibility = new Uint8Array(playback.totalLeafTargetCount);
+  const morphTarget = createPolyMorphPreparedDomTarget({
+    model: {
+      element: sceneRoot,
+      writeTransform(transform) {
+        if (sceneRoot.style.transform === transform) return false;
+        sceneRoot.style.transform = transform;
+        return true;
+      },
+    },
+    shapes: shapeRoots.map((element) => ({ element })),
+    leaves: leafRoots.map((element) => ({ element })),
+  });
+
+  function preparedTransform(transforms, index) {
+    const transform = transforms[index];
+    if (typeof transform !== "string") {
+      throw new Error(`Prepared transform ${index} is missing`);
+    }
+    return transform;
+  }
+
+  function writeShape(transforms, bank, index, transformIndex, visible) {
+    const targetIndex = bank * playback.retainedRootCount + index;
+    const target = morphTarget.shapes[targetIndex];
+    const root = shapeRoots[targetIndex];
+    const valid = [
+      target,
+      root,
+      Number.isInteger(transformIndex),
+      visible === 0 || visible === 1,
+    ].every(Boolean);
+    if (!valid) throw new Error(`Prepared shape assignment ${index} is invalid`);
+    target.writeTransform(preparedTransform(transforms, transformIndex));
+    const nextVisible = visible === 1;
+    target.writeVisibility(nextVisible);
+    target.writeOpacity(nextVisible ? 1 : 0);
+    shapeVisibility[targetIndex] = visible;
+  }
+
+  function writeLeaf(transforms, bank, index, transformIndex, visible) {
+    const targetIndex = bank * playback.leafTargetCount + index;
+    const target = morphTarget.leaves[targetIndex];
+    const root = leafRoots[targetIndex];
+    if (!target || !root || (visible !== 0 && visible !== 1)) {
+      throw new Error(`Prepared leaf assignment ${index} is invalid`);
+    }
+    target.writeTransform(preparedTransform(transforms, transformIndex));
+    const nextVisible = visible === 1;
+    target.writeVisibility(nextVisible);
+    leafVisibility[targetIndex] = visible;
+  }
+
+  function hideBank(bank) {
+    for (let index = 0; index < playback.retainedRootCount; index += 1) {
+      const targetIndex = bank * playback.retainedRootCount + index;
+      if (shapeVisibility[targetIndex] === 0) continue;
+      const target = morphTarget.shapes[targetIndex];
+      target.writeVisibility(false);
+      target.writeOpacity(0);
+      shapeVisibility[targetIndex] = 0;
+    }
+    for (let index = 0; index < playback.leafTargetCount; index += 1) {
+      const targetIndex = bank * playback.leafTargetCount + index;
+      if (leafVisibility[targetIndex] === 0) continue;
+      const target = morphTarget.leaves[targetIndex];
+      target.writeVisibility(false);
+      leafVisibility[targetIndex] = 0;
+    }
+  }
+
+  function writePlaybackRoot(transforms, transformIndex, opacity) {
+    if (transformIndex >= 0) {
+      const transform = preparedTransform(transforms, transformIndex);
+      if (playbackRoot.style.transform !== transform) {
+        playbackRoot.style.transform = transform;
+      }
+    }
+    if (opacity >= 0 && playbackRoot.style.opacity !== String(opacity)) {
+      playbackRoot.style.opacity = String(opacity);
+    }
+  }
+
+  function writePipeMaterial(bank, pipe, clipIndex) {
+    const root = shapeRootsByBank[bank][pipe];
+    const value = String(clipIndex);
+    if (root.getAttribute("data-csspipes-material-clip") === value) return;
+    root.setAttribute("data-csspipes-material-clip", value);
+  }
+
+  return Object.freeze({
+    preparedTransform,
+    writeModelTransform(transforms, transformIndex) {
+      morphTarget.model.writeTransform(preparedTransform(transforms, transformIndex));
+    },
+    writeShape,
+    writeLeaf,
+    hideBank,
+    hideAllBanks() {
+      for (let bank = 0; bank < playback.retainedBankCount; bank += 1) hideBank(bank);
+    },
+    writePlaybackRoot,
+    writePipeMaterial,
+    writeBankMaterial(bank, clipIndex) {
+      for (let pipe = 0; pipe < playback.pipeCount; pipe += 1) {
+        writePipeMaterial(bank, pipe, clipIndex);
+      }
+    },
+    assertStableDomIdentity() {
+      morphTarget.assertStableDomIdentity();
+    },
+    destroy() {
+      morphTarget.destroy();
+    },
+  });
+}

--- a/src/adapters/3dpipes/src/csspipes/preparedResponse.mjs
+++ b/src/adapters/3dpipes/src/csspipes/preparedResponse.mjs
@@ -1,0 +1,19 @@
+import { CssPipesContractError } from "./types.mjs";
+
+function preparedResponse(response, encoding) {
+  if (response.headers?.get("content-encoding")?.includes(encoding)) return response;
+  if (typeof globalThis.DecompressionStream !== "function") {
+    throw new CssPipesContractError(`This browser cannot read prepared ${encoding} assets`);
+  }
+  const stream = response.body?.pipeThrough(new DecompressionStream(encoding));
+  if (!stream) throw new CssPipesContractError(`Prepared ${encoding} body is missing`);
+  return new Response(stream);
+}
+
+export function readPreparedJson(response, encoding = "gzip") {
+  return preparedResponse(response, encoding).json();
+}
+
+export function readPreparedText(response, encoding = "gzip") {
+  return preparedResponse(response, encoding).text();
+}

--- a/src/adapters/3dpipes/src/csspipes/presentation.mjs
+++ b/src/adapters/3dpipes/src/csspipes/presentation.mjs
@@ -1,0 +1,169 @@
+import { CssPipesContractError } from "./types.mjs";
+
+const CSSPIPES_TOP_GAP = 0;
+const CSSPIPES_VERTICAL_BIAS_RATIO = -0.06;
+
+const dimension = (value, label) => {
+  if (!(value > 0) || !Number.isFinite(value)) {
+    throw new CssPipesContractError(`${label} must be a positive finite number`);
+  }
+  return value;
+};
+
+function profiles(width, height, contract) {
+  return contract?.profiles ?? {
+    desktop: {
+      id: "desktop",
+      quarterTurns: 0,
+      rotationDegrees: 0,
+      projectedViewport: { width, height },
+    },
+    mobile: {
+      id: "mobile",
+      quarterTurns: 1,
+      rotationDegrees: 90,
+      projectedViewport: { width: height, height: width },
+    },
+  };
+}
+
+function chooseProfile(width, height, sourceWidth, sourceHeight, contract) {
+  const id = Math.max(width / sourceHeight, height / sourceWidth) <
+    Math.max(width / sourceWidth, height / sourceHeight) ? "mobile" : "desktop";
+  const profile = profiles(sourceWidth, sourceHeight, contract)[id];
+  const quarterTurns = profile.quarterTurns;
+  const bounds = [
+    [0, 0],
+    [-sourceHeight, 0],
+    [-sourceWidth, -sourceHeight],
+    [0, -sourceWidth],
+  ][quarterTurns];
+  return {
+    id,
+    quarterTurns,
+    rotationDegrees: profile.rotationDegrees,
+    projectedWidth: profile.projectedViewport.width,
+    projectedHeight: profile.projectedViewport.height,
+    rotatedLeft: bounds[0],
+    rotatedTop: bounds[1],
+  };
+}
+
+function calculateCssPipesPresentation(
+  hostWidth,
+  hostHeight,
+  sourceViewport,
+  topGap = CSSPIPES_TOP_GAP,
+  responsivePresentation,
+) {
+  const width = dimension(hostWidth, "presentation host width");
+  const height = dimension(hostHeight, "presentation host height");
+  const sourceWidth = dimension(sourceViewport?.width, "presentation source width");
+  const sourceHeight = dimension(sourceViewport?.height, "presentation source height");
+  if (topGap < 0 || topGap >= height) {
+    throw new CssPipesContractError("presentation top gap must leave a positive scene viewport");
+  }
+  const viewportHeight = height - topGap;
+  const verticalOffset = viewportHeight * CSSPIPES_VERTICAL_BIAS_RATIO;
+  const profile = chooseProfile(
+    width,
+    viewportHeight + 2 * Math.abs(verticalOffset),
+    sourceWidth,
+    sourceHeight,
+    responsivePresentation,
+  );
+  const scale = Math.max(
+    width / profile.projectedWidth,
+    (viewportHeight + 2 * Math.abs(verticalOffset)) / profile.projectedHeight,
+  );
+  const visualLeft = (width - profile.projectedWidth * scale) / 2;
+  const visualTop = (viewportHeight - profile.projectedHeight * scale) / 2 + verticalOffset;
+  return {
+    sourceWidth,
+    sourceHeight,
+    hostWidth: width,
+    hostHeight: height,
+    viewportWidth: width,
+    viewportHeight,
+    topGap,
+    verticalOffset,
+    viewportProfile: profile.id,
+    quarterTurns: profile.quarterTurns,
+    rotationDegrees: profile.rotationDegrees,
+    projectedSourceWidth: profile.projectedWidth,
+    projectedSourceHeight: profile.projectedHeight,
+    scale,
+    left: visualLeft - profile.rotatedLeft * scale,
+    top: visualTop - profile.rotatedTop * scale,
+  };
+}
+
+export function mountCssPipesPresentation({
+  host,
+  viewport,
+  camera,
+  sourceViewport,
+  responsivePresentation,
+  topGap = CSSPIPES_TOP_GAP,
+  ResizeObserverImpl = globalThis.ResizeObserver,
+  windowImpl = host?.ownerDocument?.defaultView ?? globalThis.window,
+}) {
+  Object.assign(viewport.style, {
+    position: "absolute",
+    left: "0",
+    right: "0",
+    top: `${topGap}px`,
+    bottom: "0",
+    overflow: "hidden",
+  });
+  viewport.dataset.csspipesTopGap = String(topGap);
+  let current;
+  const listeners = new Set();
+  const refresh = () => {
+    current = calculateCssPipesPresentation(
+      host.clientWidth,
+      host.clientHeight,
+      sourceViewport,
+      topGap,
+      responsivePresentation,
+    );
+    Object.assign(camera.style, {
+      width: `${current.sourceWidth}px`,
+      height: `${current.sourceHeight}px`,
+      left: `${current.left}px`,
+      top: `${current.top}px`,
+      transformOrigin: "0 0",
+      transform: [
+        current.rotationDegrees && `rotate(${current.rotationDegrees}deg)`,
+        current.scale !== 1 && `scale(${current.scale})`,
+      ].filter(Boolean).join(" "),
+    });
+    camera.dataset.csspipesPresentation = "responsive-cover-full-viewport";
+    camera.dataset.csspipesViewportProfile = current.viewportProfile;
+    camera.dataset.csspipesPresentationRotation = String(current.rotationDegrees);
+    camera.dataset.csspipesPresentationScale = String(current.scale);
+    camera.dataset.csspipesPresentationVerticalOffset = String(current.verticalOffset);
+    for (const listener of listeners) listener(current);
+    return current;
+  };
+  refresh();
+  const observer = typeof ResizeObserverImpl === "function"
+    ? new ResizeObserverImpl(refresh)
+    : null;
+  observer?.observe(host);
+  if (!observer) windowImpl?.addEventListener?.("resize", refresh, { passive: true });
+  return {
+    refresh,
+    get viewportProfile() { return current.viewportProfile; },
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(current);
+      return () => listeners.delete(listener);
+    },
+    destroy() {
+      observer?.disconnect();
+      if (!observer) windowImpl?.removeEventListener?.("resize", refresh);
+      listeners.clear();
+    },
+  };
+}

--- a/src/adapters/3dpipes/src/csspipes/routeState.mjs
+++ b/src/adapters/3dpipes/src/csspipes/routeState.mjs
@@ -1,0 +1,16 @@
+import { CssPipesContractError } from "./types.mjs";
+
+export function resolveCssPipesRoute(input) {
+  const url = input instanceof URL ? input : new URL(String(input), "http://127.0.0.1");
+  if (url.pathname !== "/" && url.pathname !== "/index.html") {
+    throw new CssPipesContractError(`Unsupported cssPipes route ${url.pathname}`);
+  }
+  if (url.search || url.hash) {
+    throw new CssPipesContractError("cssPipes does not accept ad hoc scene selectors");
+  }
+  return Object.freeze({
+    pathname: "/",
+    manifestUrl: "/csspipes/manifest.json",
+    selection: "manifest-default",
+  });
+}

--- a/src/adapters/3dpipes/src/csspipes/styles.css
+++ b/src/adapters/3dpipes/src/csspipes/styles.css
@@ -1,0 +1,169 @@
+:root {
+  color-scheme: dark;
+  background: linear-gradient(180deg, #0b1119 0%, #000 100%);
+  color: #dfe9f3;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+#csspipes-root {
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  position: relative;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(180deg, #0b1119 0%, #000 100%);
+}
+
+.site-header {
+  position: fixed;
+  inset: 0 0 auto;
+  z-index: 21;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 50px;
+  padding: 0 12px 0 16px;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+}
+
+.site-wordmark {
+  display: inline-flex;
+  align-items: center;
+  color: #f0f0f0;
+  opacity: 0.72;
+  text-decoration: none;
+}
+
+.site-wordmark-svg {
+  display: block;
+  width: 190px;
+  height: 30px;
+  overflow: visible;
+}
+
+.site-wordmark-svg text {
+  fill: currentColor;
+  font-family: inherit;
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: 0.1px;
+}
+
+.site-wordmark-css {
+  font-weight: 500;
+}
+
+.site-wordmark-graphics {
+  font-weight: 200;
+}
+
+.site-wordmark-path {
+  font-weight: 100;
+}
+
+.site-wordmark:hover,
+.site-wordmark:focus-visible {
+  opacity: 1;
+}
+
+.site-wordmark:focus-visible {
+  outline: 1px solid currentColor;
+  outline-offset: 4px;
+}
+
+.site-actions {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  height: 100%;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+}
+
+.site-actions a {
+  display: inline-flex;
+  min-width: 72px;
+  height: 50px;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 4px;
+  margin: 0;
+  color: #f0f0f0;
+  background: transparent;
+  border: 0;
+  font: 400 13px/1 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  opacity: 0.72;
+}
+
+.site-actions .site-action-icon-only {
+  width: 36px;
+  min-width: 36px;
+  padding: 0;
+}
+
+.site-action-icon {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.site-actions a:hover,
+.site-actions a:focus-visible {
+  opacity: 1;
+}
+
+.site-actions a:focus-visible {
+  outline: 1px solid currentColor;
+  outline-offset: -5px;
+}
+
+#csspipes-root[data-csspipes-ready="error"] {
+  padding: 2rem;
+  white-space: pre-wrap;
+  color: #ffb5a7;
+}
+
+[data-csspipes-viewport] > .polycss-camera {
+  position: absolute;
+}
+
+[data-csspipes-pipe-root],
+[data-csspipes-face],
+[data-csspipes-playback-root] {
+  pointer-events: none;
+  transform-style: preserve-3d;
+  transition: none;
+}
+
+.polycss-scene [data-csspipes-face] {
+  backface-visibility: visible;
+}
+
+@media (max-width: 360px) {
+  .site-header {
+    padding-inline: 12px;
+  }
+
+}

--- a/src/adapters/3dpipes/src/csspipes/types.mjs
+++ b/src/adapters/3dpipes/src/csspipes/types.mjs
@@ -1,0 +1,36 @@
+export class CssPipesContractError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CssPipesContractError";
+  }
+}
+
+export function object(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new CssPipesContractError(`${label} must be an object`);
+  }
+  return value;
+}
+
+export function nonEmptyString(value, label) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new CssPipesContractError(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+export function safeGeneratedUrl(value, label) {
+  const url = nonEmptyString(value, label);
+  let normalized;
+  try {
+    normalized = new URL(url, "https://csspipes.invalid/");
+  } catch {
+    throw new CssPipesContractError(`${label} is not a valid URL`);
+  }
+  if (normalized.origin !== "https://csspipes.invalid" ||
+      !normalized.pathname.startsWith("/csspipes/") ||
+      normalized.search || normalized.hash) {
+    throw new CssPipesContractError(`${label} is outside the generated cssPipes root`);
+  }
+  return normalized.pathname;
+}

--- a/src/adapters/3dpipes/src/main.mjs
+++ b/src/adapters/3dpipes/src/main.mjs
@@ -1,0 +1,7 @@
+import "./csspipes/styles.css";
+import { startCssPipesClient } from "./csspipes/client.mjs";
+import { resolveCssPipesRoute } from "./csspipes/routeState.mjs";
+
+const host = document.querySelector("#csspipes-root");
+if (!(host instanceof HTMLElement)) throw new Error("Missing #csspipes-root host");
+await startCssPipesClient(host, resolveCssPipesRoute(globalThis.location.href));

--- a/src/adapters/3dpipes/src/prepare/csspipes/endlessTubes.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/endlessTubes.mjs
@@ -1,0 +1,380 @@
+import { createPolyCylinder } from "@layoutit/polycss";
+import { sourceMaterialColor } from "./formatAdapters.mjs";
+
+function windowsMaterial(sourceIndex, symbol, ambient, diffuse, specular, shininess) {
+  return Object.freeze({
+    sourceIndex,
+    symbol,
+    ambient: Object.freeze([...ambient, 1]),
+    diffuse: Object.freeze([...diffuse, 1]),
+    specular: Object.freeze([...specular, 1]),
+    shininess,
+    cssSrgb: sourceMaterialColor([...diffuse, 1]),
+  });
+}
+
+// Exact source order from the Microsoft Win95 SDK sample's goodMaterials[].
+const WINDOWS_GOOD_MATERIALS = Object.freeze([
+  windowsMaterial(0, "EMERALD",
+    [0.0215, 0.1745, 0.0215], [0.07568, 0.61424, 0.07568],
+    [0.633, 0.727811, 0.633], 0.6),
+  windowsMaterial(1, "JADE",
+    [0.135, 0.2225, 0.1575], [0.54, 0.89, 0.63],
+    [0.316228, 0.316228, 0.316228], 0.1),
+  windowsMaterial(3, "PEARL",
+    [0.25, 0.20725, 0.20725], [1, 0.829, 0.829],
+    [0.296648, 0.296648, 0.296648], 0.088),
+  windowsMaterial(4, "RUBY",
+    [0.1745, 0.01175, 0.01175], [0.61424, 0.04136, 0.04136],
+    [0.727811, 0.626959, 0.626959], 0.6),
+  windowsMaterial(5, "TURQUOISE",
+    [0.1, 0.18725, 0.1745], [0.396, 0.74151, 0.69102],
+    [0.297254, 0.30829, 0.306678], 0.1),
+  windowsMaterial(6, "BRASS",
+    [0.329412, 0.223529, 0.027451], [0.780392, 0.568627, 0.113725],
+    [0.992157, 0.941176, 0.807843], 0.21794872),
+  windowsMaterial(7, "BRONZE",
+    [0.2125, 0.1275, 0.054], [0.714, 0.4284, 0.18144],
+    [0.393548, 0.271906, 0.166721], 0.2),
+  windowsMaterial(9, "COPPER",
+    [0.19125, 0.0735, 0.0225], [0.7038, 0.27048, 0.0828],
+    [0.256777, 0.137622, 0.086014], 0.1),
+  windowsMaterial(10, "GOLD",
+    [0.24725, 0.1995, 0.0745], [0.75164, 0.60648, 0.22648],
+    [0.628281, 0.555802, 0.366065], 0.4),
+  windowsMaterial(11, "SILVER",
+    [0.19225, 0.19225, 0.19225], [0.50754, 0.50754, 0.50754],
+    [0.508273, 0.508273, 0.508273], 0.4),
+  windowsMaterial(13, "CYAN_PLASTIC",
+    [0, 0.1, 0.06], [0, 0.50980392, 0.50980392],
+    [0.50196078, 0.50196078, 0.50196078], 0.25),
+  windowsMaterial(16, "WHITE_PLASTIC",
+    [0, 0, 0], [0.55, 0.55, 0.55], [0.7, 0.7, 0.7], 0.25),
+  windowsMaterial(17, "YELLOW_PLASTIC",
+    [0, 0, 0], [0.5, 0.5, 0], [0.6, 0.6, 0.5], 0.25),
+  windowsMaterial(19, "CYAN_RUBBER",
+    [0, 0.05, 0.05], [0.4, 0.5, 0.5], [0.04, 0.7, 0.7], 0.078125),
+  windowsMaterial(20, "GREEN_RUBBER",
+    [0, 0.05, 0], [0.4, 0.5, 0.4], [0.04, 0.7, 0.04], 0.078125),
+  windowsMaterial(22, "WHITE_RUBBER",
+    [0.05, 0.05, 0.05], [0.5, 0.5, 0.5], [0.7, 0.7, 0.7], 0.078125),
+]);
+
+export const CSSPIPES_HISTORICAL_PALETTE = Object.freeze({
+  schema: "csspipes-windows-good-materials@1",
+  source: Object.freeze({
+    title: "Microsoft Win95 SDK OpenGL 3D Pipes screen-saver sample",
+    repository: "joncampbell123/windows_sdk_collection",
+    commit: "e707dd87e84171c8e061c7ed6268eb3edaf85b49",
+    path: "win/win95/sdk-1995-07-win32/win32sdk/mstools/samples/opengl/pipes/material.c",
+    sha256: "e8b7559efd580cdf166ef2482877bd98dbd5bbdf808ee0a9fa45e5b92048148c",
+    selectionLines: "31-34, 135-144",
+    materialLines: "45-94",
+  }),
+  sourceColorSpace: "linear-light OpenGL ambient/diffuse/specular RGBA",
+  outputColorSpace: "CSS sRGB",
+  conversion: "IEC 61966-2-1 linear-to-sRGB transfer function",
+  sourceSelection: Object.freeze({
+    symbol: "goodMaterials",
+    count: 16,
+    expression: "teaMaterial[goodMaterials[mfRand(16)]]",
+    replacement: true,
+  }),
+  materials: WINDOWS_GOOD_MATERIALS,
+});
+
+const historicalMaterial = (symbol) => {
+  const material = WINDOWS_GOOD_MATERIALS.find((entry) => entry.symbol === symbol);
+  if (!material) throw new Error(`Missing historical cssPipes material ${symbol}`);
+  return material;
+};
+
+function authoredMaterial(symbol, ambient, diffuse, specular, shininess, cssSrgb, provenance) {
+  if (sourceMaterialColor([...diffuse, 1]) !== cssSrgb) {
+    throw new Error(`Authored cssPipes material ${symbol} does not match its linear diffuse color`);
+  }
+  return Object.freeze({
+    sourceIndex: null,
+    symbol,
+    ambient: Object.freeze([...ambient, 1]),
+    diffuse: Object.freeze([...diffuse, 1]),
+    specular: Object.freeze([...specular, 1]),
+    shininess,
+    cssSrgb,
+    provenance,
+  });
+}
+
+const CSSPIPES_AMBER = authoredMaterial(
+  "AMBER",
+  [0, 0, 0],
+  [0.715693501, 0.37123768, 0],
+  [0.6, 0.6, 0.5],
+  0.25,
+  "#dca400",
+  "authored-cssPipes-amber-with-yellow-plastic-response",
+);
+
+const CSSPIPES_SLATE = authoredMaterial(
+  "SLATE",
+  [0.03, 0.04, 0.05],
+  [0.099898728, 0.124771818, 0.14995979],
+  [0.50196078, 0.50196078, 0.50196078],
+  0.25,
+  "#59636c",
+  "authored-cssPipes-cool-slate-with-plastic-response",
+);
+
+const CSSPIPES_PURPLE = Object.freeze({
+  sourceIndex: null,
+  symbol: "PURPLE",
+  ambient: Object.freeze([0.1745, 0.0215, 0.1745, 1]),
+  diffuse: Object.freeze([0.439657, 0.076185, 0.617207, 1]),
+  specular: Object.freeze([0.68, 0.68, 0.68, 1]),
+  shininess: 0.6,
+  cssSrgb: "#b14ece",
+  provenance: "authored-cssPipes-vivid-purple",
+});
+
+export const CSSPIPES_PRODUCT_MATERIALS = Object.freeze([
+  historicalMaterial("EMERALD"),
+  historicalMaterial("RUBY"),
+  historicalMaterial("CYAN_PLASTIC"),
+  CSSPIPES_AMBER,
+  CSSPIPES_SLATE,
+  historicalMaterial("PEARL"),
+  CSSPIPES_PURPLE,
+]);
+
+export const CSSPIPES_PRODUCT_PALETTE = Object.freeze({
+  schema: "csspipes-fixed-seven-color-product-palette@1",
+  selection: "fixed-by-source-pipe-identity",
+  historicalPalette: CSSPIPES_HISTORICAL_PALETTE,
+  materials: CSSPIPES_PRODUCT_MATERIALS,
+});
+
+export const CSSPIPES_PALETTE = Object.freeze(
+  CSSPIPES_PRODUCT_MATERIALS.map((material) => material.cssSrgb),
+);
+
+export const CSSPIPES_SOURCE_VIEWPORT = Object.freeze({ width: 1280, height: 720 });
+export const CSSPIPES_VIEWPORT_PROFILES = Object.freeze({
+  desktop: Object.freeze({
+    id: "desktop",
+    seedCount: 32,
+    quarterTurns: 0,
+    rotationDegrees: 0,
+    projectedViewport: CSSPIPES_SOURCE_VIEWPORT,
+  }),
+  mobile: Object.freeze({
+    id: "mobile",
+    seedCount: 32,
+    quarterTurns: 1,
+    rotationDegrees: 90,
+    projectedViewport: Object.freeze({
+      width: CSSPIPES_SOURCE_VIEWPORT.height,
+      height: CSSPIPES_SOURCE_VIEWPORT.width,
+    }),
+  }),
+});
+export const CSSPIPES_CAMERA_CONTRACT = Object.freeze({
+  projection: "perspective",
+  perspective: 1400,
+  rotX: 60,
+  rotY: -38,
+  distance: 0,
+  safeTopGap: 0,
+});
+
+export const CSSPIPES_PREBAKE_CONFIG = Object.freeze({
+  schema: "csspipes-prebake-contract@13",
+  clipCount: 64,
+  viewportSeedCountPerProfile: 32,
+  preparedForwardChainChapterCount: 1,
+  snakeFramesPerSeed: 462,
+  preparedCameraAspectRatioMinimum: 1.1,
+  preparedCameraAspectRatioMaximum: 2.5,
+  preparedCameraOverscanMaximum: 1.8,
+  preparedScreenGridColumns: 4,
+  preparedScreenGridRows: 3,
+  preparedScreenMinimumOccupiedCells: 10,
+  preparedChainEndpointSafeMarginXRatio: 0.12,
+  preparedChainEndpointSafeMarginYRatio: 0.08,
+  preparedChainEndpointReturnSegments: 24,
+  preparedBandSlotsByPipe: Object.freeze([47, 45, 47, 41, 45, 35, 49]),
+  pipeCount: 7,
+  segmentsPerPipe: 60,
+  logicalSegmentCount: 420,
+  stepLength: 1.25,
+  tubeLength: 1,
+  tubeRadius: 0.34,
+  radialSegments: 7,
+  radialSegmentsByPipe: Object.freeze([4, 4, 5, 5, 6, 6, 7]),
+  radialSegmentsBySourcePipe: Object.freeze([6, 5, 6, 4, 4, 5, 7]),
+  turnRadius: 0.46,
+  jointSeamOverlap: 0,
+  tubeEntryProgress: 0.04,
+  growthWorldUnitsPerSecond: 9.375,
+  pipeStaggerFrames: 0,
+  sourceTicksPerSecond: 30,
+  playbackFramesPerSecond: 60,
+  frameMorphDurationMilliseconds: 16.666667,
+  morphEasing: "linear",
+  holdTicks: 30,
+  fadeTicks: 24,
+  straightWeight: 0.8,
+});
+
+if (CSSPIPES_PREBAKE_CONFIG.logicalSegmentCount !==
+    CSSPIPES_PREBAKE_CONFIG.pipeCount * CSSPIPES_PREBAKE_CONFIG.segmentsPerPipe) {
+  throw new Error("cssPipes logical segment count must be pipeCount x segmentsPerPipe");
+}
+if (CSSPIPES_PREBAKE_CONFIG.clipCount !==
+    CSSPIPES_PREBAKE_CONFIG.viewportSeedCountPerProfile *
+      Object.keys(CSSPIPES_VIEWPORT_PROFILES).length) {
+  throw new Error("cssPipes clip count must split evenly across viewport seed profiles");
+}
+
+const CYLINDER_SURFACES = new Map(
+  [...new Set(CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe)].map((radialSegments) => {
+    const polygons = createPolyCylinder({
+      radius: CSSPIPES_PREBAKE_CONFIG.tubeRadius,
+      height: CSSPIPES_PREBAKE_CONFIG.tubeLength,
+      radialSegments,
+    }).polygons;
+    const sides = Object.freeze(
+      polygons.filter((polygon) => polygon.vertices.length === 4),
+    );
+    const caps = polygons.filter((polygon) => polygon.vertices.length === 3);
+    const capPolygons = Object.freeze(["start", "tip"].map((cap) => {
+      const isStart = cap === "start";
+      const triangles = caps.slice(
+        isStart ? 0 : radialSegments,
+        isStart ? radialSegments : radialSegments * 2,
+      );
+      const vertices = triangles.map(
+        (polygon) => polygon.vertices[isStart ? 2 : 1],
+      );
+      if (isStart) vertices.reverse();
+      return Object.freeze({
+        vertices: Object.freeze(vertices.map((vertex) => Object.freeze([...vertex]))),
+        color: "#cccccc",
+      });
+    }));
+    if (sides.length !== radialSegments || caps.length !== radialSegments * 2 ||
+        capPolygons.some((polygon) => polygon.vertices.length !== radialSegments)) {
+      throw new Error(`PolyCSS ${radialSegments}-facet cylinder surface contract drifted`);
+    }
+    return [radialSegments, Object.freeze({ sides, capPolygons })];
+  }),
+);
+
+export const CSSPIPES_END_CAP_VERTICES_PER_END =
+  CSSPIPES_PREBAKE_CONFIG.radialSegments;
+export const CSSPIPES_END_CAP_LEAVES_PER_END = 1;
+export const CSSPIPES_END_CAP_LEAVES_PER_PIPE =
+  CSSPIPES_END_CAP_LEAVES_PER_END * 2;
+export const CSSPIPES_END_CAP_TARGETS_PER_PIPE = 2;
+
+export function preparedPipeLeafCount(
+  bandSlotsPerPipe,
+  radialSegments = CSSPIPES_PREBAKE_CONFIG.radialSegments,
+) {
+  if (!Number.isInteger(bandSlotsPerPipe) || bandSlotsPerPipe < 1) {
+    throw new TypeError("cssPipes bandSlotsPerPipe must be a positive integer");
+  }
+  return bandSlotsPerPipe * radialSegments +
+    CSSPIPES_END_CAP_TARGETS_PER_PIPE;
+}
+
+function canonicalBandFace(pipe, band, side, radialSegments, color, polygon) {
+  const id = `csspipes-pipe-${String(pipe).padStart(2, "0")}-band-${String(band).padStart(3, "0")}-side-${String(side).padStart(2, "0")}`;
+  const zOffset = (band + 0.5) * CSSPIPES_PREBAKE_CONFIG.tubeLength;
+  return Object.freeze({
+    id,
+    polygon: Object.freeze({
+      vertices: Object.freeze(polygon.vertices.map(([x, y, z]) =>
+        Object.freeze([x, y, z + zOffset]))),
+      color,
+      data: Object.freeze({
+        "csspipes-face": id,
+        "csspipes-family": "tube",
+        "csspipes-pipe": pipe,
+        "csspipes-band": band,
+        "csspipes-cylinder-side": side,
+        "csspipes-surface": "wall",
+        "csspipes-leaf-slot": band * radialSegments + side,
+        "csspipes-seam-bleed": 0,
+      }),
+    }),
+  });
+}
+
+function canonicalCapFace(pipe, cap, color, polygon) {
+  const id = `csspipes-pipe-${String(pipe).padStart(2, "0")}-${cap}-cap`;
+  const isStart = cap === "start";
+  const zOffset = isStart ? 0.5 : -0.5;
+  return Object.freeze({
+    id,
+    polygon: Object.freeze({
+      vertices: Object.freeze(polygon.vertices.map(([x, y, z]) =>
+        Object.freeze([x, y, z + zOffset]))),
+      color,
+      data: Object.freeze({
+        "csspipes-face": id,
+        "csspipes-family": "tube",
+        "csspipes-pipe": pipe,
+        "csspipes-cap": cap,
+        "csspipes-cap-polygon": 0,
+        "csspipes-surface": "end-cap",
+        "csspipes-seam-bleed": 0,
+      }),
+    }),
+  });
+}
+
+export function buildPreparedPipeMeshes(bandSlotsByPipe, pipeColors) {
+  if (!Array.isArray(bandSlotsByPipe) ||
+      bandSlotsByPipe.length !== CSSPIPES_PREBAKE_CONFIG.pipeCount ||
+      bandSlotsByPipe.some((count) => !Number.isInteger(count) || count < 1)) {
+    throw new TypeError("cssPipes bandSlotsByPipe must contain one positive integer per pipe");
+  }
+  if (!Array.isArray(pipeColors) ||
+      pipeColors.length !== CSSPIPES_PREBAKE_CONFIG.pipeCount ||
+      pipeColors.some((color) => !/^#[0-9a-f]{6}$/iu.test(color))) {
+    throw new TypeError("cssPipes pipeColors must contain one CSS hex color per pipe");
+  }
+  return Object.freeze(Array.from(
+    { length: CSSPIPES_PREBAKE_CONFIG.pipeCount },
+    (_, pipe) => {
+      const color = pipeColors[pipe];
+      const bandSlotsPerPipe = bandSlotsByPipe[pipe];
+      const radialSegments = CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe[pipe];
+      const cylinder = CYLINDER_SURFACES.get(radialSegments);
+      const polygons = [];
+      for (let band = 0; band < bandSlotsPerPipe; band += 1) {
+        for (let side = 0; side < cylinder.sides.length; side += 1) {
+          polygons.push(canonicalBandFace(
+            pipe,
+            band,
+            side,
+            radialSegments,
+            color,
+            cylinder.sides[side],
+          ));
+        }
+      }
+      polygons.push(canonicalCapFace(pipe, "start", color, cylinder.capPolygons[0]));
+      polygons.push(canonicalCapFace(pipe, "tip", color, cylinder.capPolygons[1]));
+      return Object.freeze({
+        id: `csspipes-pipe-${String(pipe).padStart(2, "0")}`,
+        pipe,
+        color,
+        bandCount: bandSlotsPerPipe,
+        radialSegments,
+        endCapLeafCount: CSSPIPES_END_CAP_LEAVES_PER_PIPE,
+        polygons: Object.freeze(polygons),
+      });
+    },
+  ));
+}

--- a/src/adapters/3dpipes/src/prepare/csspipes/formatAdapters.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/formatAdapters.mjs
@@ -1,0 +1,14 @@
+// OpenGL material constants are linear-light values. CSS hex colors are sRGB,
+// so a direct value * 255 conversion makes the retained scene visibly dark.
+const linearToSrgb = (value) => value <= 0.0031308
+  ? value * 12.92
+  : 1.055 * value ** (1 / 2.4) - 0.055;
+const byte = (value) => Math.max(0, Math.min(255, Math.round(linearToSrgb(value) * 255)));
+const hex = (value) => byte(value).toString(16).padStart(2, "0");
+
+export function sourceMaterialColor(material) {
+  if (!Array.isArray(material) || material.length !== 4 || !material.every(Number.isFinite)) {
+    throw new TypeError("Source material must be a finite RGBA tuple");
+  }
+  return `#${hex(material[0])}${hex(material[1])}${hex(material[2])}`;
+}

--- a/src/adapters/3dpipes/src/prepare/csspipes/paths.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/paths.mjs
@@ -1,0 +1,34 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const CSSPIPES_ADAPTER_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)), "..", "..", "..",
+);
+export const CSSPIPES_REPO_ROOT = resolve(
+  CSSPIPES_ADAPTER_ROOT, "..", "..", "..",
+);
+const CSSPIPES_GENERATED_PUBLIC_DIR = resolve(
+  process.env.CSSPIPES_GENERATED_PUBLIC_DIR ??
+    resolve(CSSPIPES_REPO_ROOT, "build/generated/public"),
+);
+export const CSSPIPES_GENERATED_PUBLIC_ROOT = resolve(
+  CSSPIPES_GENERATED_PUBLIC_DIR, "csspipes",
+);
+export const CSSPIPES_SCENE_PATH = resolve(
+  CSSPIPES_GENERATED_PUBLIC_ROOT, "scenes/pipes-clips.scene.json.gz",
+);
+export const CSSPIPES_PREPARE_SCENE_PATH = resolve(
+  CSSPIPES_GENERATED_PUBLIC_ROOT, "scenes/pipes-clips.scene.prepare.json",
+);
+export const CSSPIPES_CLIPS_ROOT = resolve(
+  CSSPIPES_GENERATED_PUBLIC_ROOT, "clips",
+);
+export const CSSPIPES_SNAPSHOT_PATH = resolve(
+  CSSPIPES_GENERATED_PUBLIC_ROOT, "scenes/pipes-clips.polycss.html.gz",
+);
+export const CSSPIPES_PREPARE_SNAPSHOT_PATH = resolve(
+  CSSPIPES_GENERATED_PUBLIC_ROOT, "scenes/pipes-clips.polycss.prepare.html",
+);
+export const CSSPIPES_MANIFEST_PATH = resolve(
+  CSSPIPES_GENERATED_PUBLIC_ROOT, "manifest.json",
+);

--- a/src/adapters/3dpipes/src/prepare/csspipes/prepare.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/prepare.mjs
@@ -1,0 +1,17 @@
+import { buildCssPipesScene } from "./sceneBuilder.mjs";
+import {
+  buildPipeSpaceTexelLighting,
+  writePipeSpaceTexelLighting,
+} from "./preparedLighting.mjs";
+import { writeCssPipesScene } from "./writeScene.mjs";
+
+export async function prepareCssPipesScene() {
+  const lightingBundle = buildPipeSpaceTexelLighting();
+  const scene = await buildCssPipesScene({ lightingBundle });
+  const lighting = await writePipeSpaceTexelLighting(lightingBundle);
+  if (lighting.contract.assetSha256 !== scene.lighting.assetSha256) {
+    throw new Error("Prepared cssPipes space-texel lighting drifted while writing");
+  }
+  const output = await writeCssPipesScene(scene);
+  return Object.freeze({ scene, output, lighting });
+}

--- a/src/adapters/3dpipes/src/prepare/csspipes/preparedClips.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/preparedClips.mjs
@@ -1,0 +1,2148 @@
+import { createHash } from "node:crypto";
+import {
+  buildPolySceneTransform,
+} from "@layoutit/polycss";
+import {
+  CSSPIPES_CAMERA_CONTRACT,
+  CSSPIPES_END_CAP_LEAVES_PER_PIPE,
+  CSSPIPES_END_CAP_LEAVES_PER_END,
+  CSSPIPES_END_CAP_TARGETS_PER_PIPE,
+  CSSPIPES_END_CAP_VERTICES_PER_END,
+  CSSPIPES_PALETTE,
+  CSSPIPES_PREBAKE_CONFIG,
+  CSSPIPES_PRODUCT_PALETTE,
+  CSSPIPES_SOURCE_VIEWPORT,
+  CSSPIPES_VIEWPORT_PROFILES,
+  preparedPipeLeafCount,
+} from "./endlessTubes.mjs";
+import {
+  buildPreparedBandIntervalLeafTransforms,
+  buildPreparedBandLeafTransforms,
+  buildPreparedStartCapRootTransform,
+  buildPreparedTipCapRootTransform,
+  buildPreparedTransportedFrames,
+  buildWeldedPipeMesh,
+} from "./weldedTubeMesh.mjs";
+
+const DIRECTIONS = Object.freeze([
+  Object.freeze({ delta: Object.freeze([1, 0, 0]) }),
+  Object.freeze({ delta: Object.freeze([-1, 0, 0]) }),
+  Object.freeze({ delta: Object.freeze([0, 1, 0]) }),
+  Object.freeze({ delta: Object.freeze([0, -1, 0]) }),
+  Object.freeze({ delta: Object.freeze([0, 0, 1]) }),
+  Object.freeze({ delta: Object.freeze([0, 0, -1]) }),
+]);
+
+const STARTS = Object.freeze([
+  Object.freeze([-6, -4, -3]),
+  Object.freeze([6, -4, 3]),
+  Object.freeze([-5, 5, 3]),
+  Object.freeze([5, 5, -3]),
+  Object.freeze([0, 0, 0]),
+  Object.freeze([-6, 0, 3]),
+  Object.freeze([6, 0, -3]),
+]);
+
+if (STARTS.length !== CSSPIPES_PREBAKE_CONFIG.pipeCount) {
+  throw new Error("cssPipes prepared start count must match pipeCount");
+}
+
+function xorshift32(seed) {
+  let state = seed >>> 0 || 0x6d2b79f5;
+  return Object.freeze({
+    next() {
+      state ^= state << 13;
+      state ^= state >>> 17;
+      state ^= state << 5;
+      state >>>= 0;
+      return state / 0x1_0000_0000;
+    },
+  });
+}
+
+const cellKey = (cell) => `${cell[0]},${cell[1]},${cell[2]}`;
+const addCell = (cell, delta) => [
+  cell[0] + delta[0], cell[1] + delta[1], cell[2] + delta[2],
+];
+const opposite = (left, right) =>
+  left.delta[0] === -right.delta[0] &&
+  left.delta[1] === -right.delta[1] &&
+  left.delta[2] === -right.delta[2];
+
+function chooseDirection(
+  random,
+  current,
+  cell,
+  occupied,
+  allowedCell = () => true,
+  preferredCellScore = null,
+) {
+  const candidates = DIRECTIONS.filter((direction) => {
+    const next = addCell(cell, direction.delta);
+    return !opposite(direction, current) && allowedCell(next) &&
+      !occupied.has(cellKey(next));
+  });
+  if (candidates.length === 0) return null;
+  if (preferredCellScore) {
+    const scored = candidates.map((direction) => ({
+      direction,
+      score: preferredCellScore(addCell(cell, direction.delta)),
+    }));
+    const minimum = Math.min(...scored.map((entry) => entry.score));
+    const preferred = scored.filter((entry) => entry.score === minimum)
+      .map((entry) => entry.direction);
+    const straight = preferred.find((direction) => direction === current);
+    if (straight && random.next() < CSSPIPES_PREBAKE_CONFIG.straightWeight) {
+      return straight;
+    }
+    return preferred[Math.floor(random.next() * preferred.length)];
+  }
+  const straight = candidates.find((direction) => direction === current);
+  if (straight && random.next() < CSSPIPES_PREBAKE_CONFIG.straightWeight) return straight;
+  const turns = candidates.filter((direction) => direction !== current);
+  const pool = turns.length > 0 ? turns : candidates;
+  return pool[Math.floor(random.next() * pool.length)];
+}
+
+const candidateSeed = (candidate) =>
+  (0x9e3779b9 * (candidate + 1) + 0x43535350) >>> 0;
+
+const MATERIAL_FIXED_INDICES = Object.freeze([0, 1, 2, 3, 4, 5, 6]);
+
+function preparedColorOklab(hex) {
+  const channels = hex.match(/[0-9a-f]{2}/giu).map((value) =>
+    Number.parseInt(value, 16) / 255).map((value) =>
+    value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4);
+  const [red, green, blue] = channels;
+  const long = Math.cbrt(
+    0.4122214708 * red + 0.5363325363 * green + 0.0514459929 * blue,
+  );
+  const medium = Math.cbrt(
+    0.2119034982 * red + 0.6806995451 * green + 0.1073969566 * blue,
+  );
+  const short = Math.cbrt(
+    0.0883024619 * red + 0.2817188376 * green + 0.6299787005 * blue,
+  );
+  return Object.freeze([
+    0.2104542553 * long + 0.793617785 * medium - 0.0040720468 * short,
+    1.9779984951 * long - 2.428592205 * medium + 0.4505937099 * short,
+    0.0259040371 * long + 0.7827717662 * medium - 0.808675766 * short,
+  ]);
+}
+
+const MATERIAL_OKLAB = Object.freeze(CSSPIPES_PALETTE.map(preparedColorOklab));
+
+function materialOklabDistance(left, right) {
+  return Math.hypot(
+    MATERIAL_OKLAB[left][0] - MATERIAL_OKLAB[right][0],
+    MATERIAL_OKLAB[left][1] - MATERIAL_OKLAB[right][1],
+    MATERIAL_OKLAB[left][2] - MATERIAL_OKLAB[right][2],
+  );
+}
+
+function minimumMaterialOklabDistance(indices) {
+  let minimum = Number.POSITIVE_INFINITY;
+  for (let left = 0; left < indices.length; left += 1) {
+    for (let right = left + 1; right < indices.length; right += 1) {
+      minimum = Math.min(minimum, materialOklabDistance(indices[left], indices[right]));
+    }
+  }
+  return minimum;
+}
+
+function buildPreparedMaterialSelection(_seed, sourcePipeBySlot) {
+  if (!Array.isArray(sourcePipeBySlot) ||
+      sourcePipeBySlot.length !== CSSPIPES_PREBAKE_CONFIG.pipeCount ||
+      new Set(sourcePipeBySlot).size !== CSSPIPES_PREBAKE_CONFIG.pipeCount ||
+      !sourcePipeBySlot.every((sourcePipe) => Number.isInteger(sourcePipe) &&
+        sourcePipe >= 0 && sourcePipe < CSSPIPES_PREBAKE_CONFIG.pipeCount)) {
+    throw new Error("cssPipes prepared source-pipe order must be a complete permutation");
+  }
+  const materialIndicesByPipe = Object.freeze(
+    sourcePipeBySlot.map((sourcePipe) => MATERIAL_FIXED_INDICES[sourcePipe]),
+  );
+  return Object.freeze({
+    materialIndicesByPipe,
+    diversity: Object.freeze({
+      schema: "csspipes-prepared-fixed-material-proof@1",
+      fixedSet: true,
+      sourcePipeStable: true,
+      repeatedMaterialCount: materialIndicesByPipe.length -
+        new Set(materialIndicesByPipe).size,
+      minimumOklabDistance: Number(
+        minimumMaterialOklabDistance(materialIndicesByPipe).toFixed(6),
+      ),
+    }),
+  });
+}
+
+function initializeCandidateWalkers({
+  random,
+  occupied,
+  starts,
+  initialDirections,
+  allowedCell,
+  usePreparedStarts,
+}) {
+  return starts.map((start, pipe) => {
+    const preparedStart = usePreparedStarts
+      ? [...start]
+      : start.map((value) => value + Math.floor(random.next() * 5) - 2);
+    if (!allowedCell(preparedStart) || occupied.has(cellKey(preparedStart))) return null;
+    occupied.add(cellKey(preparedStart));
+    return {
+      pipe,
+      startCell: preparedStart,
+      cell: preparedStart,
+      direction: initialDirections?.[pipe] ??
+        DIRECTIONS[Math.floor(random.next() * DIRECTIONS.length)],
+      segments: [],
+    };
+  });
+}
+
+function advanceCandidateWalkers({
+  random,
+  occupied,
+  walkers,
+  endpointTargets,
+  allowedCell,
+  returnToStarts,
+  forceInitialDirections,
+}) {
+  for (let segment = 0; segment < CSSPIPES_PREBAKE_CONFIG.segmentsPerPipe; segment += 1) {
+    for (const walker of walkers) {
+      const endpointTarget = endpointTargets?.[walker.pipe] ??
+        (returnToStarts ? walker.startCell : null);
+      const preferredCellScore = endpointTarget && segment >=
+          CSSPIPES_PREBAKE_CONFIG.segmentsPerPipe -
+            CSSPIPES_PREBAKE_CONFIG.preparedChainEndpointReturnSegments
+        ? (cell) => cell.reduce(
+          (total, value, axis) => total + Math.abs(value - endpointTarget[axis]),
+          0,
+        )
+        : null;
+      const forcedDirection = segment === 0 && forceInitialDirections
+        ? walker.direction
+        : null;
+      const forcedNext = forcedDirection
+        ? addCell(walker.cell, forcedDirection.delta)
+        : null;
+      const direction = forcedDirection && allowedCell(forcedNext) &&
+          !occupied.has(cellKey(forcedNext))
+        ? forcedDirection
+        : forcedDirection
+          ? null
+          : chooseDirection(
+            random,
+            walker.direction,
+            walker.cell,
+            occupied,
+            allowedCell,
+            preferredCellScore,
+          );
+      if (!direction) return false;
+      const next = addCell(walker.cell, direction.delta);
+      walker.segments.push({ start: walker.cell, end: next, direction });
+      walker.cell = next;
+      walker.direction = direction;
+      occupied.add(cellKey(next));
+    }
+  }
+  return true;
+}
+
+function candidateBounds(walkers) {
+  const segments = walkers.flatMap((walker) => walker.segments);
+  const points = segments.flatMap((segment) => [segment.start, segment.end]);
+  const min = [0, 1, 2].map((axis) => Math.min(...points.map((point) => point[axis])));
+  const max = [0, 1, 2].map((axis) => Math.max(...points.map((point) => point[axis])));
+  const span = min.map((value, axis) => max[axis] - value);
+  if (Math.max(...span) > 34 || span[0] < 15 || span[1] < 15 || span[2] < 12) {
+    return null;
+  }
+  const center = [0, 1, 2].map((axis) =>
+    points.reduce((total, point) => total + point[axis], 0) / points.length);
+  return { walkers, points, min, max, span, center };
+}
+
+function generateCandidate(seed, options = {}) {
+  const random = xorshift32(seed);
+  const occupied = new Set(options.blockedCellKeys ?? []);
+  const starts = options.starts ?? STARTS;
+  const initialDirections = options.initialDirections ?? null;
+  const endpointTargets = options.endpointTargets ?? null;
+  const allowedCell = options.allowedCell ?? (() => true);
+  if (starts.length !== CSSPIPES_PREBAKE_CONFIG.pipeCount ||
+      (initialDirections && initialDirections.length !== starts.length)) {
+    throw new Error("Prepared cssPipes chained start state is incomplete");
+  }
+  if (options.starts) {
+    for (const start of starts) occupied.delete(cellKey(start));
+  }
+  const walkers = initializeCandidateWalkers({
+    random,
+    occupied,
+    starts,
+    initialDirections,
+    allowedCell,
+    usePreparedStarts: Boolean(options.starts),
+  });
+  if (walkers.includes(null) || !advanceCandidateWalkers({
+    random,
+    occupied,
+    walkers,
+    endpointTargets,
+    allowedCell,
+    returnToStarts: options.returnToStarts,
+    forceInitialDirections: options.forceInitialDirections,
+  })) return null;
+  if (options.requireFreeContinuation && walkers.some((walker) =>
+    occupied.has(cellKey(addCell(walker.cell, walker.direction.delta))))) {
+    return null;
+  }
+  return candidateBounds(walkers);
+}
+
+function generatedCellKeys(generated) {
+  return new Set(generated.walkers.flatMap((walker) => walker.segments.flatMap(
+    (segment) => [cellKey(segment.start), cellKey(segment.end)],
+  )));
+}
+
+function generatedFromPipeSegments(segmentsByPipe) {
+  if (!Array.isArray(segmentsByPipe) ||
+      segmentsByPipe.length !== CSSPIPES_PREBAKE_CONFIG.pipeCount ||
+      segmentsByPipe.some((segments) => !Array.isArray(segments) || segments.length === 0)) {
+    throw new TypeError("Prepared cssPipes full route requires seven non-empty pipes");
+  }
+  const walkers = segmentsByPipe.map((segments, pipe) => Object.freeze({
+    pipe,
+    startCell: Object.freeze([...segments[0].start]),
+    cell: Object.freeze([...segments.at(-1).end]),
+    direction: segments.at(-1).direction,
+    segments: Object.freeze([...segments]),
+  }));
+  const points = walkers.flatMap((walker) =>
+    walker.segments.flatMap((segment) => [segment.start, segment.end]));
+  const min = [0, 1, 2].map((axis) =>
+    Math.min(...points.map((point) => point[axis])));
+  const max = [0, 1, 2].map((axis) =>
+    Math.max(...points.map((point) => point[axis])));
+  const span = min.map((value, axis) => max[axis] - value);
+  const center = [0, 1, 2].map((axis) =>
+    points.reduce((total, point) => total + point[axis], 0) / points.length);
+  return Object.freeze({
+    walkers: Object.freeze(walkers),
+    points: Object.freeze(points),
+    min: Object.freeze(min),
+    max: Object.freeze(max),
+    span: Object.freeze(span),
+    center: Object.freeze(center),
+  });
+}
+
+function concatenateGeneratedCheckpoints(checkpoints) {
+  if (!Array.isArray(checkpoints) || checkpoints.length === 0) {
+    throw new TypeError("Prepared cssPipes full route requires generation checkpoints");
+  }
+  const segmentsByPipe = Array.from(
+    { length: CSSPIPES_PREBAKE_CONFIG.pipeCount },
+    (_, sourcePipe) => checkpoints.flatMap((checkpoint, checkpointIndex) => {
+      const walker = checkpoint.generated.walkers[sourcePipe];
+      if (checkpointIndex > 0) {
+        const previous = checkpoints[checkpointIndex - 1].generated.walkers[sourcePipe];
+        if (cellKey(previous.cell) !== cellKey(walker.segments[0].start) ||
+            previous.direction !== walker.segments[0].direction) {
+          throw new Error(
+            "Prepared cssPipes full route lost a welded generation checkpoint",
+          );
+        }
+      }
+      return walker.segments;
+    }),
+  );
+  return generatedFromPipeSegments(segmentsByPipe);
+}
+
+function sliceGeneratedRouteBackwards(generated, segmentCount) {
+  const totalSegments = generated.walkers[0].segments.length;
+  if (!Number.isInteger(segmentCount) || segmentCount < 1 ||
+      totalSegments % segmentCount !== 0 ||
+      generated.walkers.some((walker) => walker.segments.length !== totalSegments)) {
+    throw new Error("Prepared cssPipes full route cannot be sliced evenly");
+  }
+  const backwardSlices = [];
+  for (let end = totalSegments; end > 0; end -= segmentCount) {
+    const start = end - segmentCount;
+    backwardSlices.push(Object.freeze({
+      fullSegmentStart: start,
+      generated: generatedFromPipeSegments(generated.walkers.map((walker) =>
+        walker.segments.slice(start, end))),
+    }));
+  }
+  return Object.freeze(backwardSlices.reverse());
+}
+
+function preparedFullRouteHash(generated) {
+  return createHash("sha256").update(JSON.stringify(generated.walkers.map((walker) =>
+    walker.segments.map((segment) => [
+      segment.start,
+      segment.end,
+      segment.direction.delta,
+    ])))).digest("hex");
+}
+
+function compileMaximalRuns(segments) {
+  if (!Array.isArray(segments) || segments.length === 0) return Object.freeze([]);
+  const runs = [];
+  let startSegment = 0;
+  for (let segmentIndex = 1; segmentIndex <= segments.length; segmentIndex += 1) {
+    if (segmentIndex < segments.length &&
+        segments[segmentIndex].direction === segments[startSegment].direction) continue;
+    const runSegments = segments.slice(startSegment, segmentIndex);
+    runs.push({
+      startSegment,
+      endSegment: segmentIndex,
+      segmentCount: segmentIndex - startSegment,
+      direction: runSegments[0].direction,
+      start: runSegments[0].start,
+      end: runSegments.at(-1).end,
+      segments: runSegments,
+    });
+    startSegment = segmentIndex;
+  }
+  return Object.freeze(runs.map((run, runIndex) => Object.freeze({
+    ...run,
+    hasPrevious: runIndex > 0,
+    hasNext: runIndex < runs.length - 1,
+    segments: Object.freeze(run.segments),
+  })));
+}
+
+const radians = (degrees) => degrees * Math.PI / 180;
+
+function rotateZ([x, y, z], degrees) {
+  const angle = radians(degrees);
+  const cosine = Math.cos(angle);
+  const sine = Math.sin(angle);
+  return [cosine * x - sine * y, sine * x + cosine * y, z];
+}
+
+function rotateX([x, y, z], degrees) {
+  const angle = radians(degrees);
+  const cosine = Math.cos(angle);
+  const sine = Math.sin(angle);
+  return [x, cosine * y - sine * z, sine * y + cosine * z];
+}
+
+function projectPreparedPoint(point, target, zoom) {
+  const relative = point.map((value, axis) => value - target[axis]);
+  let css = [relative[1] * 50, relative[0] * 50, relative[2] * 50];
+  css = rotateZ(css, CSSPIPES_CAMERA_CONTRACT.rotY);
+  css = rotateX(css, CSSPIPES_CAMERA_CONTRACT.rotX);
+  css = css.map((value) => value * zoom / 50);
+  const perspectiveScale = CSSPIPES_CAMERA_CONTRACT.perspective /
+    (CSSPIPES_CAMERA_CONTRACT.perspective - css[2]);
+  return [
+    CSSPIPES_SOURCE_VIEWPORT.width / 2 + css[0] * perspectiveScale,
+    CSSPIPES_SOURCE_VIEWPORT.height / 2 + css[1] * perspectiveScale,
+  ];
+}
+
+function projectedBounds(points, target, zoom) {
+  const projected = points.map((point) => projectPreparedPoint(point, target, zoom));
+  const minX = Math.min(...projected.map((point) => point[0]));
+  const maxX = Math.max(...projected.map((point) => point[0]));
+  const minY = Math.min(...projected.map((point) => point[1]));
+  const maxY = Math.max(...projected.map((point) => point[1]));
+  return { minX, maxX, minY, maxY, width: maxX - minX, height: maxY - minY };
+}
+
+function fitCamera(points) {
+  const expanded = points.flatMap((point) => {
+    const radius = CSSPIPES_PREBAKE_CONFIG.tubeRadius * 1.35;
+    return [
+      point,
+      [point[0] + radius, point[1], point[2]],
+      [point[0] - radius, point[1], point[2]],
+      [point[0], point[1] + radius, point[2]],
+      [point[0], point[1] - radius, point[2]],
+      [point[0], point[1], point[2] + radius],
+      [point[0], point[1], point[2] - radius],
+    ];
+  });
+  const target = [0, 0, 0];
+  let zoom = 27;
+  const targetWidth = CSSPIPES_SOURCE_VIEWPORT.width;
+  const targetHeight = CSSPIPES_SOURCE_VIEWPORT.height - CSSPIPES_CAMERA_CONTRACT.safeTopGap;
+  for (let iteration = 0; iteration < 6; iteration += 1) {
+    const bounds = projectedBounds(expanded, target, zoom);
+    zoom *= Math.max(1, targetWidth / bounds.width, targetHeight / bounds.height);
+  }
+  zoom = Math.max(18, Math.min(58, zoom));
+  for (let iteration = 0; iteration < 3; iteration += 1) {
+    const bounds = projectedBounds(expanded, target, zoom);
+    const errorX = (bounds.minX + bounds.maxX) / 2 - CSSPIPES_SOURCE_VIEWPORT.width / 2;
+    const errorY = (bounds.minY + bounds.maxY) / 2 - CSSPIPES_SOURCE_VIEWPORT.height / 2;
+    const xBounds = projectedBounds(expanded, [target[0] + 0.1, target[1], target[2]], zoom);
+    const yBounds = projectedBounds(expanded, [target[0], target[1] + 0.1, target[2]], zoom);
+    const ax = ((xBounds.minX + xBounds.maxX) / 2 - (bounds.minX + bounds.maxX) / 2) / 0.1;
+    const ay = ((xBounds.minY + xBounds.maxY) / 2 - (bounds.minY + bounds.maxY) / 2) / 0.1;
+    const bx = ((yBounds.minX + yBounds.maxX) / 2 - (bounds.minX + bounds.maxX) / 2) / 0.1;
+    const by = ((yBounds.minY + yBounds.maxY) / 2 - (bounds.minY + bounds.maxY) / 2) / 0.1;
+    const determinant = ax * by - ay * bx;
+    if (Math.abs(determinant) < 1e-8) break;
+    target[0] += (-errorX * by + errorY * bx) / determinant;
+    target[1] += (-ax * errorY + ay * errorX) / determinant;
+  }
+  for (let iteration = 0; iteration < 4; iteration += 1) {
+    const bounds = projectedBounds(expanded, target, zoom);
+    const factor = Math.max(1, targetWidth / bounds.width, targetHeight / bounds.height);
+    if (Math.abs(factor - 1) < 0.0001) break;
+    zoom = Math.max(18, Math.min(58, zoom * factor));
+  }
+  const bounds = projectedBounds(expanded, target, zoom);
+  const state = Object.freeze({
+    target: Object.freeze(target.map((value) => Number(value.toFixed(6)))),
+    zoom: Number(zoom.toFixed(6)),
+    rotX: CSSPIPES_CAMERA_CONTRACT.rotX,
+    rotY: CSSPIPES_CAMERA_CONTRACT.rotY,
+    distance: CSSPIPES_CAMERA_CONTRACT.distance,
+  });
+  return Object.freeze({
+    state,
+    transform: buildPolySceneTransform(state),
+    projectedBounds: Object.freeze(Object.fromEntries(
+      Object.entries(bounds).map(([key, value]) => [key, Number(value.toFixed(3))]),
+    )),
+  });
+}
+
+function preparedCameraQualification(camera) {
+  const bounds = camera.projectedBounds;
+  const aspectRatio = bounds.width / bounds.height;
+  const overscanRatio = Math.max(
+    bounds.width / CSSPIPES_SOURCE_VIEWPORT.width,
+    bounds.height / CSSPIPES_SOURCE_VIEWPORT.height,
+  );
+  const qualified = bounds.width >= 1200 && bounds.height >= 620 &&
+    aspectRatio >= CSSPIPES_PREBAKE_CONFIG.preparedCameraAspectRatioMinimum &&
+    aspectRatio <= CSSPIPES_PREBAKE_CONFIG.preparedCameraAspectRatioMaximum &&
+    overscanRatio <= CSSPIPES_PREBAKE_CONFIG.preparedCameraOverscanMaximum;
+  return Object.freeze({
+    qualified,
+    aspectRatio: Number(aspectRatio.toFixed(6)),
+    overscanRatio: Number(overscanRatio.toFixed(6)),
+  });
+}
+
+function preparedScreenOccupancy(points, camera) {
+  const columns = CSSPIPES_PREBAKE_CONFIG.preparedScreenGridColumns;
+  const rows = CSSPIPES_PREBAKE_CONFIG.preparedScreenGridRows;
+  const occupied = new Set();
+  for (const point of points) {
+    const [x, y] = projectPreparedPoint(point, camera.state.target, camera.state.zoom);
+    if (x < 0 || x > CSSPIPES_SOURCE_VIEWPORT.width ||
+        y < 0 || y > CSSPIPES_SOURCE_VIEWPORT.height) continue;
+    const column = Math.min(columns - 1, Math.floor(
+      x / CSSPIPES_SOURCE_VIEWPORT.width * columns,
+    ));
+    const row = Math.min(rows - 1, Math.floor(
+      y / CSSPIPES_SOURCE_VIEWPORT.height * rows,
+    ));
+    occupied.add(row * columns + column);
+  }
+  const occupiedCellCount = occupied.size;
+  const totalCellCount = columns * rows;
+  return Object.freeze({
+    schema: "csspipes-prepared-screen-occupancy@1",
+    columns,
+    rows,
+    occupiedCellCount,
+    totalCellCount,
+    occupiedRatio: Number((occupiedCellCount / totalCellCount).toFixed(6)),
+    qualified: occupiedCellCount >=
+      CSSPIPES_PREBAKE_CONFIG.preparedScreenMinimumOccupiedCells,
+  });
+}
+
+const sameState = (left, right) =>
+  left.rootTransform === right.rootTransform && left.rootOpacity === right.rootOpacity &&
+  JSON.stringify(left.shapeTransforms) === JSON.stringify(right.shapeTransforms) &&
+  JSON.stringify(left.shapeVisibility) === JSON.stringify(right.shapeVisibility) &&
+  JSON.stringify(left.leafTransforms) === JSON.stringify(right.leafTransforms) &&
+  JSON.stringify(left.leafVisibility) === JSON.stringify(right.leafVisibility);
+
+function cloneState(state) {
+  return {
+    rootTransform: state.rootTransform,
+    rootOpacity: state.rootOpacity,
+    shapeTransforms: [...state.shapeTransforms],
+    shapeVisibility: [...state.shapeVisibility],
+    leafTransforms: [...state.leafTransforms],
+    leafVisibility: [...state.leafVisibility],
+  };
+}
+
+function applyRetractionRows(state, rows, leafTransitions, side) {
+  const transformColumn = side === "before" ? 1 : 3;
+  const visibilityColumn = side === "before" ? 2 : 4;
+  for (const row of rows) {
+    for (let index = 0; index < row[1]; index += 1) {
+      const offset = (row[0] + index) * 5;
+      const leaf = leafTransitions[offset];
+      state.leafTransforms[leaf] = leafTransitions[offset + transformColumn];
+      state.leafVisibility[leaf] = leafTransitions[offset + visibilityColumn];
+    }
+  }
+  return state;
+}
+
+function stateDigest(state) {
+  return createHash("sha256").update(JSON.stringify(state)).digest("hex");
+}
+
+const preparedTransformScalar = (value) => Number(value.toFixed(12));
+
+function preparedPipeRing(mesh, cap) {
+  const ring = mesh.caps.find((entry) => entry.cap === cap)?.ring;
+  if (!ring) throw new Error(`Prepared cssPipes ${cap} ring is missing`);
+  return ring;
+}
+
+function preparedPipeCapPoint(entry, sourcePipe, cap) {
+  const slot = entry.sourcePipeBySlot.indexOf(sourcePipe);
+  if (slot < 0) throw new Error(`Prepared cssPipes source pipe ${sourcePipe} is missing`);
+  const mesh = entry.weldedMeshesByPipe[slot];
+  const ring = preparedPipeRing(mesh, cap);
+  return Object.freeze(mesh.rootPosition.map((value, axis) =>
+    preparedTransformScalar(value + ring.center[axis])));
+}
+
+function preparedPipeCapRingPoints(entry, sourcePipe, cap) {
+  const slot = entry.sourcePipeBySlot.indexOf(sourcePipe);
+  if (slot < 0) throw new Error(`Prepared cssPipes source pipe ${sourcePipe} is missing`);
+  const mesh = entry.weldedMeshesByPipe[slot];
+  const ring = preparedPipeRing(mesh, cap);
+  return Object.freeze(ring.vertices.map((vertex) => Object.freeze(
+    vertex.map((value, axis) => preparedTransformScalar(
+      value + mesh.rootPosition[axis],
+    )),
+  )));
+}
+
+function preparedRingSetError(left, right) {
+  return Math.max(...left.map((point) => Math.min(...right.map((candidate) =>
+    Math.hypot(...point.map((value, axis) => value - candidate[axis]))))));
+}
+
+function buildPreparedSourceSchedule(sourceFrameCount, targetFrameCount, direction) {
+  if (!Number.isInteger(sourceFrameCount) || sourceFrameCount < 1 ||
+      !Number.isInteger(targetFrameCount) || targetFrameCount < 1 ||
+      (direction !== "ascending" && direction !== "descending")) {
+    throw new TypeError("Prepared cssPipes snake schedule is incomplete");
+  }
+  const motionFrameCount = sourceFrameCount - 1;
+  if (motionFrameCount < 1 || targetFrameCount > motionFrameCount) {
+    throw new RangeError("Prepared cssPipes snake schedule cannot contain idle frames");
+  }
+  let consumed = 0;
+  const rows = Array.from({ length: targetFrameCount }, (_, frame) => {
+    const start = Math.floor(frame * motionFrameCount / targetFrameCount);
+    const end = Math.floor((frame + 1) * motionFrameCount / targetFrameCount);
+    const count = end - start;
+    consumed += count;
+    return Object.freeze([
+      direction === "ascending" ? start + 1 : sourceFrameCount - start - 2,
+      count,
+    ]);
+  });
+  if (consumed !== motionFrameCount || rows.some((row) => row[1] < 1)) {
+    throw new Error("Prepared cssPipes snake schedule did not consume its source rows");
+  }
+  return Object.freeze(rows);
+}
+
+function buildPreparedBankRecycle({
+  recording,
+  transitionFrameCount,
+  tailSourceRows,
+  recycleClipIndex,
+  recycleRecording,
+  recycleShapeTransforms,
+  pipeLeafOffsets,
+  leavesPerPipeByPipe,
+}) {
+  if (recycleClipIndex === null) {
+    return Object.freeze({
+      rows: Object.freeze([]),
+      shapeAssignments: Object.freeze([]),
+      leafAssignments: Object.freeze([]),
+    });
+  }
+  if (!recycleRecording || recycleShapeTransforms.length !== pipeLeafOffsets.length ||
+      tailSourceRows.length !== transitionFrameCount) {
+    throw new Error("Prepared cssPipes recycled bank is incomplete");
+  }
+  const completionFrameByPipe = pipeLeafOffsets.map((_, pipe) => {
+    const sourceFrame = Math.max(...recording.snakeTail.bandRows
+      .filter((row) => row[0] === pipe)
+      .map((row) => row[3]));
+    const frame = tailSourceRows.findIndex(([start, count]) =>
+      sourceFrame >= start && sourceFrame < start + count);
+    if (frame < 0) throw new Error(`Prepared recycled pipe ${pipe} has no completion frame`);
+    return frame;
+  });
+  const connectedLeavesByPipe = pipeLeafOffsets.map((offset, pipe) => {
+    const end = offset + leavesPerPipeByPipe[pipe];
+    const leaves = [];
+    const connected = recycleRecording.experiment.connectedInitial.leaves;
+    for (let index = 0; index < connected.length; index += 3) {
+      const leaf = connected[index];
+      if (leaf >= offset && leaf < end) leaves.push(leaf, connected[index + 1], 0);
+    }
+    return Object.freeze(leaves);
+  });
+  const shapeAssignments = [];
+  const leafAssignments = [];
+  const rows = Array.from({ length: transitionFrameCount }, (_, frame) => {
+    const shapeOffset = shapeAssignments.length / 2;
+    const leafOffset = leafAssignments.length / 3;
+    for (let pipe = 0; pipe < completionFrameByPipe.length; pipe += 1) {
+      if (completionFrameByPipe[pipe] !== frame) continue;
+      shapeAssignments.push(pipe, recycleShapeTransforms[pipe]);
+      leafAssignments.push(...connectedLeavesByPipe[pipe]);
+    }
+    return Object.freeze([
+      shapeOffset,
+      shapeAssignments.length / 2 - shapeOffset,
+      leafOffset,
+      leafAssignments.length / 3 - leafOffset,
+    ]);
+  });
+  if (shapeAssignments.length / 2 !== pipeLeafOffsets.length ||
+      leafAssignments.length / 3 !==
+        recycleRecording.experiment.connectedInitial.leaves.length / 3) {
+    throw new Error("Prepared cssPipes recycled bank did not cover its connected seed");
+  }
+  return Object.freeze({
+    rows: Object.freeze(rows),
+    shapeAssignments: Object.freeze(shapeAssignments),
+    leafAssignments: Object.freeze(leafAssignments),
+  });
+}
+
+function buildPreparedZSeedLoopTrack({
+  entry,
+  recording,
+  nextEntry,
+  nextRecording,
+  recycleClipIndex,
+  recycleRecording,
+  recycleShapeTransforms,
+  clipIndex,
+  viewportProfile,
+  chainIndex,
+  chainLength,
+  previousClipIndex,
+  nextClipIndex,
+  shapeTransforms,
+  nextShapeTransforms,
+  pipeLeafOffsets,
+  leavesPerPipeByPipe,
+  internTransform,
+}) {
+  const openingFrameCount = Math.min(
+    CSSPIPES_PREBAKE_CONFIG.snakeFramesPerSeed,
+    recording.sourceFrameCount - 1,
+  );
+  const transitionFrameCount = nextRecording
+    ? Math.min(
+      CSSPIPES_PREBAKE_CONFIG.snakeFramesPerSeed,
+      recording.snakeTail.sourceFrameCount - 1,
+      nextRecording.sourceFrameCount - 1,
+    )
+    : 0;
+  const tailSourceRows = nextClipIndex === null
+    ? Object.freeze([])
+    : buildPreparedSourceSchedule(
+      recording.snakeTail.sourceFrameCount,
+      transitionFrameCount,
+      "ascending",
+    );
+  const headSourceRows = nextClipIndex === null
+    ? Object.freeze([])
+    : buildPreparedSourceSchedule(
+      nextRecording.sourceFrameCount,
+      transitionFrameCount,
+      "descending",
+    );
+  const recycledBank = buildPreparedBankRecycle({
+    recording,
+    transitionFrameCount,
+    tailSourceRows,
+    recycleClipIndex,
+    recycleRecording,
+    recycleShapeTransforms,
+    pipeLeafOffsets,
+    leavesPerPipeByPipe,
+  });
+  return Object.freeze({
+    schema: "csspipes-prepared-z-seed-loop-track@6",
+    clipIndex,
+    viewportProfile,
+    chainIndex,
+    chainLength,
+    previousClipIndex,
+    nextClipIndex,
+    terminal: nextClipIndex === null,
+    seedOriginTransform: internTransform("none"),
+    sourceFrameCount: recording.sourceFrameCount,
+    openingFrameCount,
+    openingHeadRows: buildPreparedSourceSchedule(
+      recording.sourceFrameCount,
+      openingFrameCount,
+      "descending",
+    ),
+    transitionFrameCount,
+    tailSourceRows,
+    headSourceRows,
+    recycleClipIndex,
+    recycleRows: recycledBank.rows,
+    recycleShapeAssignments: recycledBank.shapeAssignments,
+    recycleLeafAssignments: recycledBank.leafAssignments,
+    recycleMode: "prepare-hidden-pipe-when-outgoing-pipe-empties",
+    tailDirection: "start-to-tip",
+    headDirection: "start-to-tip",
+    visibleHandoffState: "one-moving-tail-cap-and-one-moving-head-cap",
+    cameraMode: "prepared-static-profile-camera",
+    cameraTravelPixels: 0,
+    cameraDuringPlayback: "hold-static-profile-camera",
+    nextCycle: nextClipIndex === null
+      ? "clean-opening-restart"
+      : "next-prepared-forward-seed",
+    chainDirection: entry.chainDirection,
+    chainChapter: entry.chainChapter,
+    modelTransform: internTransform(entry.chainCamera.transform),
+    shapeTransforms: Object.freeze(shapeTransforms),
+    nextShapeTransforms: Object.freeze(nextShapeTransforms ?? []),
+    nextConnectedInitialLeafCount: nextRecording
+      ? nextRecording.experiment.connectedInitial.leaves.length / 3
+      : 0,
+    nextRouteHash: nextEntry?.fullPipe.routeHash ?? null,
+  });
+}
+
+function buildPreparedZSeedLoopTracks({
+  accepted,
+  clips,
+  viewportPlaylists,
+  pipeLeafOffsets,
+  leavesPerPipeByPipe,
+  internTransform,
+}) {
+  const tracks = Array(clips.length);
+  let maximumStartToPreviousTipError = 0;
+  let maximumStartRingToPreviousTipError = 0;
+  let maximumAdjacentNonHandoffCellOverlapCount = 0;
+  let preparedHandoffCount = 0;
+  for (const [viewportProfile, playlist] of Object.entries(viewportPlaylists)) {
+    for (let chainIndex = 0; chainIndex < playlist.length; chainIndex += 1) {
+      const clipIndex = playlist[chainIndex];
+      const nextClipIndex = playlist[chainIndex + 1] ?? null;
+      const recycleClipIndex = playlist[chainIndex + 2] ?? null;
+      if (nextClipIndex !== null) {
+        const currentCells = generatedCellKeys(accepted[clipIndex].generated);
+        const nextCells = generatedCellKeys(accepted[nextClipIndex].generated);
+        const handoffCells = new Set(accepted[clipIndex].generated.walkers.map(
+          (walker) => cellKey(walker.cell),
+        ));
+        const nonHandoffOverlapCount = [...nextCells].filter((key) =>
+          currentCells.has(key) && !handoffCells.has(key)).length;
+        maximumAdjacentNonHandoffCellOverlapCount = Math.max(
+          maximumAdjacentNonHandoffCellOverlapCount,
+          nonHandoffOverlapCount,
+        );
+        for (let sourcePipe = 0;
+          sourcePipe < CSSPIPES_PREBAKE_CONFIG.pipeCount;
+          sourcePipe += 1) {
+          const tip = preparedPipeCapPoint(accepted[clipIndex], sourcePipe, "tip");
+          const start = preparedPipeCapPoint(accepted[nextClipIndex], sourcePipe, "start");
+          const tipRing = preparedPipeCapRingPoints(
+            accepted[clipIndex],
+            sourcePipe,
+            "tip",
+          );
+          const startRing = preparedPipeCapRingPoints(
+            accepted[nextClipIndex],
+            sourcePipe,
+            "start",
+          );
+          maximumStartToPreviousTipError = Math.max(
+            maximumStartToPreviousTipError,
+            Math.hypot(...tip.map((value, axis) => value - start[axis])),
+          );
+          maximumStartRingToPreviousTipError = Math.max(
+            maximumStartRingToPreviousTipError,
+            preparedRingSetError(tipRing, startRing),
+          );
+          preparedHandoffCount += 1;
+        }
+      }
+      const shapeTransforms = accepted[clipIndex].weldedMeshesByPipe.map((mesh) =>
+        internTransform(mesh.rootTransform));
+      const nextShapeTransforms = nextClipIndex === null
+        ? []
+        : accepted[nextClipIndex].weldedMeshesByPipe.map((mesh) =>
+          internTransform(mesh.rootTransform));
+      const recycleShapeTransforms = recycleClipIndex === null
+        ? []
+        : accepted[recycleClipIndex].weldedMeshesByPipe.map((mesh) =>
+          internTransform(mesh.rootTransform));
+      tracks[clipIndex] = buildPreparedZSeedLoopTrack({
+        entry: accepted[clipIndex],
+        recording: clips[clipIndex].recording,
+        nextEntry: nextClipIndex === null ? null : accepted[nextClipIndex],
+        nextRecording: nextClipIndex === null ? null : clips[nextClipIndex].recording,
+        recycleClipIndex,
+        recycleRecording: recycleClipIndex === null ? null : clips[recycleClipIndex].recording,
+        recycleShapeTransforms,
+        clipIndex,
+        viewportProfile,
+        chainIndex,
+        chainLength: playlist.length,
+        previousClipIndex: playlist[chainIndex - 1] ?? null,
+        nextClipIndex,
+        shapeTransforms,
+        nextShapeTransforms,
+        pipeLeafOffsets,
+        leavesPerPipeByPipe,
+        internTransform,
+      });
+    }
+  }
+  if (tracks.some((track) => !track)) {
+    throw new Error("Prepared cssPipes static-camera seed loop is incomplete");
+  }
+  if (maximumStartToPreviousTipError > 1e-8) {
+    throw new Error(
+      `Prepared cssPipes seed handoff drifted by ${maximumStartToPreviousTipError}`,
+    );
+  }
+  if (maximumStartRingToPreviousTipError > 1e-8) {
+    throw new Error(
+      `Prepared cssPipes full-pipe ring handoff drifted by ${maximumStartRingToPreviousTipError}`,
+    );
+  }
+  if (maximumAdjacentNonHandoffCellOverlapCount !== 0) {
+    throw new Error(
+      `Prepared cssPipes adjacent seeds overlap in ${maximumAdjacentNonHandoffCellOverlapCount} non-handoff cells`,
+    );
+  }
+  const preparedFullPipeCount = new Set(accepted.map((entry) =>
+    `${entry.viewportProfile}:${entry.chainChapter}:${entry.fullPipe.routeHash}`)).size;
+  return Object.freeze({
+    tracks: Object.freeze(tracks),
+    proof: Object.freeze({
+      schema: "csspipes-prepared-seed-handoff-proof@4",
+      pipeIdentity: "source-pipe-index-across-ranked-retained-root-banks",
+      chainRepresentation: "finite-complete-forward-profile-pipes-sliced-tail-to-head",
+      chapterCount: CSSPIPES_PREBAKE_CONFIG.preparedForwardChainChapterCount,
+      preparedFullPipeCount,
+      preparedSlicesFromCompletePipes: true,
+      fullPipeSegmentsPerSourcePipe:
+        accepted[0].fullPipe.totalSegmentsPerPipe,
+      sliceOrder: "tail-to-head-from-complete-pipe",
+      preparedHandoffCount,
+      preparedShapePlacementCount: clips.length * CSSPIPES_PREBAKE_CONFIG.pipeCount,
+      storageComplexity: "linear-in-prepared-seed-count",
+      maximumStartToPreviousTipError: preparedTransformScalar(
+        maximumStartToPreviousTipError,
+      ),
+      maximumStartRingToPreviousTipError: preparedTransformScalar(
+        maximumStartRingToPreviousTipError,
+      ),
+      adjacentSeedOccupancy: "previous-seed-cells-blocked-except-seven-handoff-cells",
+      maximumAdjacentNonHandoffCellOverlapCount,
+      allSevenPipes: true,
+      profileWrap: "none-clean-opening-restart-after-exhaustion",
+    }),
+  });
+}
+
+function buildPreparedTubeBandDurations(bands) {
+  if (!Array.isArray(bands) || bands.length === 0) {
+    throw new TypeError("Prepared cssPipes timing requires tube bands");
+  }
+  const framesPerWorldUnit = CSSPIPES_PREBAKE_CONFIG.playbackFramesPerSecond /
+    CSSPIPES_PREBAKE_CONFIG.growthWorldUnitsPerSecond;
+  const animatedFraction = 1 - CSSPIPES_PREBAKE_CONFIG.tubeEntryProgress;
+  let cumulativeDistance = 0;
+  let previousEndFrame = 0;
+  return Object.freeze(bands.map((band) => {
+    if (!(band?.centerlineLength > 0)) {
+      throw new TypeError("Prepared cssPipes tube band must have positive centerline length");
+    }
+    cumulativeDistance += band.centerlineLength * animatedFraction;
+    const endFrame = Math.max(
+      previousEndFrame + 1,
+      Math.round(cumulativeDistance * framesPerWorldUnit),
+    );
+    const durationFrames = endFrame - previousEndFrame;
+    previousEndFrame = endFrame;
+    return durationFrames;
+  }));
+}
+
+function synchronizePreparedBandDurations(durations, targetFrameCount) {
+  const sourceFrameCount = durations.reduce((total, count) => total + count, 0);
+  if (!Number.isInteger(targetFrameCount) || targetFrameCount < sourceFrameCount) {
+    throw new RangeError("Prepared cssPipes synchronized duration is invalid");
+  }
+  if (sourceFrameCount === targetFrameCount) return durations;
+  let sourceCursor = 0;
+  let targetCursor = 0;
+  return Object.freeze(durations.map((duration) => {
+    sourceCursor += duration;
+    const targetEnd = Math.round(
+      sourceCursor * targetFrameCount / sourceFrameCount,
+    );
+    const synchronizedDuration = targetEnd - targetCursor;
+    targetCursor = targetEnd;
+    if (synchronizedDuration < 1) {
+      throw new Error("Prepared cssPipes synchronized band lost its motion frame");
+    }
+    return synchronizedDuration;
+  }));
+}
+
+function buildPreparedTube(entry, bandSlotsByPipe, internTransform) {
+  const leavesPerPipeByPipe = bandSlotsByPipe.map((count, pipe) =>
+    preparedPipeLeafCount(
+      count,
+      CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe[pipe],
+    ));
+  const pipeLeafOffsets = leavesPerPipeByPipe.map((_, pipe) =>
+    leavesPerPipeByPipe.slice(0, pipe).reduce((total, count) => total + count, 0));
+  const leafCount = leavesPerPipeByPipe.reduce((total, count) => total + count, 0);
+  const none = internTransform("none");
+  const finalShapeTransforms = entry.weldedMeshesByPipe.map((mesh) =>
+    internTransform(mesh.rootTransform));
+  const finalShapeVisibility = Array(CSSPIPES_PREBAKE_CONFIG.pipeCount).fill(1);
+  const finalLeafTransforms = Array(leafCount).fill(none);
+  const finalLeafVisibility = Array(leafCount).fill(0);
+  const seedLeafTransforms = Array(leafCount).fill(none);
+  const seedLeafVisibility = Array(leafCount).fill(0);
+  const connectedSeedLeafTransforms = Array(leafCount).fill(none);
+  const connectedSeedLeafVisibility = Array(leafCount).fill(0);
+  const handoffStartLeafTransforms = Array(leafCount).fill(none);
+  const handoffStartLeafVisibility = Array(leafCount).fill(0);
+  const unitsByPipe = [];
+  const sourceBandDurationsByPipe = entry.weldedMeshesByPipe.map((mesh) =>
+    buildPreparedTubeBandDurations(mesh.bands));
+  const synchronizedPipeFrameCount = Math.max(...sourceBandDurationsByPipe.map(
+    (durations) => durations.reduce((total, count) => total + count, 0),
+  ));
+
+  for (let pipe = 0; pipe < entry.weldedMeshesByPipe.length; pipe += 1) {
+    const mesh = entry.weldedMeshesByPipe[pipe];
+    const radialSegments = mesh.radialSegments;
+    const bandDurations = synchronizePreparedBandDurations(
+      sourceBandDurationsByPipe[pipe],
+      synchronizedPipeFrameCount,
+    );
+    const wallLeavesPerPipe = bandSlotsByPipe[pipe] * radialSegments;
+    const pipeLeafOffset = pipeLeafOffsets[pipe];
+    const startCapLeafOffset = pipeLeafOffset + wallLeavesPerPipe;
+    const tipCapLeafOffset = startCapLeafOffset + 1;
+    const startCapTransform = internTransform(buildPreparedStartCapRootTransform(mesh));
+    finalLeafTransforms[startCapLeafOffset] = startCapTransform;
+    finalLeafVisibility[startCapLeafOffset] = 1;
+    seedLeafTransforms[startCapLeafOffset] = startCapTransform;
+    seedLeafVisibility[startCapLeafOffset] = 1;
+    handoffStartLeafTransforms[startCapLeafOffset] = startCapTransform;
+    handoffStartLeafVisibility[startCapLeafOffset] = 1;
+    const units = [];
+    for (let band = 0; band < mesh.bands.length; band += 1) {
+      const durationFrames = bandDurations[band];
+      const states = Object.freeze(Array.from(
+        { length: durationFrames + 1 },
+        (_, step) => {
+          const progress = CSSPIPES_PREBAKE_CONFIG.tubeEntryProgress +
+            (1 - CSSPIPES_PREBAKE_CONFIG.tubeEntryProgress) * step / durationFrames;
+          return Object.freeze(
+            buildPreparedBandLeafTransforms(mesh, band, progress).map(internTransform),
+          );
+        },
+      ));
+      const tipCapStates = Object.freeze(Array.from(
+        { length: durationFrames + 1 },
+        (_, step) => {
+          const progress = CSSPIPES_PREBAKE_CONFIG.tubeEntryProgress +
+            (1 - CSSPIPES_PREBAKE_CONFIG.tubeEntryProgress) * step / durationFrames;
+          return internTransform(buildPreparedTipCapRootTransform(mesh, band, progress));
+        },
+      ));
+      const tailStates = Object.freeze(Array.from(
+        { length: durationFrames },
+        (_, step) => {
+          if (step === 0) return states.at(-1);
+          return Object.freeze(buildPreparedBandIntervalLeafTransforms(
+            mesh,
+            band,
+            step / durationFrames,
+            1,
+          ).map(internTransform));
+        },
+      ));
+      const tailCapStates = Object.freeze(Array.from(
+        { length: durationFrames + 1 },
+        (_, step) => {
+          if (step === 0) {
+            return band === 0
+              ? startCapTransform
+              : units.at(-1).tipCapStates.at(-1);
+          }
+          return internTransform(buildPreparedTipCapRootTransform(
+            mesh,
+            band,
+            step / durationFrames,
+          ));
+        },
+      ));
+      const leafOffset = pipeLeafOffset + band * radialSegments;
+      for (let side = 0; side < radialSegments; side += 1) {
+        finalLeafTransforms[leafOffset + side] = states.at(-1)[side];
+        finalLeafVisibility[leafOffset + side] = 1;
+        seedLeafTransforms[leafOffset + side] = states[0][side];
+        seedLeafVisibility[leafOffset + side] = band === 0 ? 1 : 0;
+        connectedSeedLeafTransforms[leafOffset + side] = states[0][side];
+        connectedSeedLeafVisibility[leafOffset + side] = band === 0 ? 1 : 0;
+      }
+      if (band === 0) {
+        seedLeafTransforms[tipCapLeafOffset] = tipCapStates[0];
+        seedLeafVisibility[tipCapLeafOffset] = 1;
+        connectedSeedLeafTransforms[tipCapLeafOffset] = tipCapStates[0];
+        connectedSeedLeafVisibility[tipCapLeafOffset] = 1;
+      }
+      if (band === mesh.bands.length - 1) {
+        finalLeafTransforms[tipCapLeafOffset] = tipCapStates.at(-1);
+        finalLeafVisibility[tipCapLeafOffset] = 1;
+      }
+      units.push(Object.freeze({
+        pipe,
+        band,
+        radialSegments,
+        leafOffset,
+        startCapLeafOffset,
+        tipCapLeafOffset,
+        durationFrames,
+        states,
+        tipCapStates,
+        tailStates,
+        tailCapStates,
+      }));
+    }
+    unitsByPipe.push(Object.freeze(units));
+  }
+
+  return Object.freeze({
+    unitsByPipe: Object.freeze(unitsByPipe),
+    initialVisibleBandCount: CSSPIPES_PREBAKE_CONFIG.pipeCount,
+    initialVisibleLeafCount: CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe.reduce(
+      (total, count) => total + count,
+      CSSPIPES_PREBAKE_CONFIG.pipeCount * CSSPIPES_END_CAP_TARGETS_PER_PIPE,
+    ),
+    retainedEndCapLeafCount: CSSPIPES_PREBAKE_CONFIG.pipeCount *
+      CSSPIPES_END_CAP_LEAVES_PER_PIPE,
+    retainedEndCapTargetCount: CSSPIPES_PREBAKE_CONFIG.pipeCount *
+      CSSPIPES_END_CAP_TARGETS_PER_PIPE,
+    finalState: Object.freeze({
+      rootTransform: none,
+      rootOpacity: 1,
+      shapeTransforms: Object.freeze(finalShapeTransforms),
+      shapeVisibility: Object.freeze(finalShapeVisibility),
+      leafTransforms: Object.freeze(finalLeafTransforms),
+      leafVisibility: Object.freeze(finalLeafVisibility),
+    }),
+    seedState: Object.freeze({
+      rootTransform: none,
+      rootOpacity: 1,
+      shapeTransforms: Object.freeze([...finalShapeTransforms]),
+      shapeVisibility: Object.freeze([...finalShapeVisibility]),
+      leafTransforms: Object.freeze(seedLeafTransforms),
+      leafVisibility: Object.freeze(seedLeafVisibility),
+    }),
+    connectedSeedState: Object.freeze({
+      rootTransform: none,
+      rootOpacity: 1,
+      shapeTransforms: Object.freeze([...finalShapeTransforms]),
+      shapeVisibility: Object.freeze([...finalShapeVisibility]),
+      leafTransforms: Object.freeze(connectedSeedLeafTransforms),
+      leafVisibility: Object.freeze(connectedSeedLeafVisibility),
+    }),
+    handoffStartState: Object.freeze({
+      rootTransform: none,
+      rootOpacity: 1,
+      shapeTransforms: Object.freeze([...finalShapeTransforms]),
+      shapeVisibility: Object.freeze([...finalShapeVisibility]),
+      leafTransforms: Object.freeze(handoffStartLeafTransforms),
+      leafVisibility: Object.freeze(handoffStartLeafVisibility),
+    }),
+  });
+}
+
+function preparedInitialState(state, modelTransform) {
+  return Object.freeze({
+    modelTransform,
+    rootTransform: state.rootTransform,
+    rootOpacity: state.rootOpacity,
+    shapes: Object.freeze(state.shapeTransforms.flatMap(
+      (transform, index) => [index, transform, state.shapeVisibility[index]],
+    )),
+    leaves: Object.freeze(state.leafTransforms.flatMap(
+      (transform, index) => [index, transform, state.leafVisibility[index]],
+    )),
+  });
+}
+
+function preparedSparseInitialState(state, modelTransform) {
+  return Object.freeze({
+    modelTransform,
+    rootTransform: state.rootTransform,
+    rootOpacity: state.rootOpacity,
+    shapes: Object.freeze(state.shapeTransforms.flatMap(
+      (transform, index) => [index, transform, state.shapeVisibility[index]],
+    )),
+    leaves: Object.freeze(state.leafTransforms.flatMap(
+      (transform, index) => state.leafVisibility[index] === 1
+        ? [index, transform, 1]
+        : [],
+    )),
+  });
+}
+
+function buildPreparedGrowEntry(prepared) {
+  const leafTransitions = [];
+  for (let leaf = 0; leaf < prepared.seedState.leafTransforms.length; leaf += 1) {
+    const beforeTransform = prepared.handoffStartState.leafTransforms[leaf];
+    const beforeVisibility = prepared.handoffStartState.leafVisibility[leaf];
+    const afterTransform = prepared.seedState.leafTransforms[leaf];
+    const afterVisibility = prepared.seedState.leafVisibility[leaf];
+    if (beforeTransform === afterTransform && beforeVisibility === afterVisibility) continue;
+    leafTransitions.push(
+      leaf,
+      beforeTransform,
+      beforeVisibility,
+      afterTransform,
+      afterVisibility,
+    );
+  }
+  return Object.freeze({
+    schema: "csspipes-prepared-cap-to-growth-entry@1",
+    row: Object.freeze([0, leafTransitions.length / 5]),
+    leafTransitions: Object.freeze(leafTransitions),
+  });
+}
+
+function buildPreparedExperimentRecording(prepared, modelTransform) {
+  const growEntry = buildPreparedGrowEntry(prepared);
+  return Object.freeze({
+    schema: "csspipes-prepared-visible-tip-handoff@1",
+    initial: preparedInitialState(prepared.handoffStartState, modelTransform),
+    connectedInitial: preparedSparseInitialState(
+      prepared.connectedSeedState,
+      modelTransform,
+    ),
+    growEntry,
+    proof: Object.freeze({
+      initialState: "start-caps-only",
+      connectedInitialState: "first-bands-and-moving-tips-without-internal-caps",
+      connectedSeedStatePrepared: true,
+      growEntryPrepared: true,
+      runtimeGeometrySemantics: false,
+    }),
+  });
+}
+
+function buildPreparedSnakeTailRecording(prepared) {
+  const changes = [];
+  const bandRows = [];
+  let lastFrame = 0;
+  const addLeaf = (frame, leaf, transform, visible) => {
+    (changes[frame] ??= new Map()).set(leaf, Object.freeze([
+      leaf,
+      transform,
+      visible,
+    ]));
+  };
+
+  for (const units of prepared.unitsByPipe) {
+    const first = units[0];
+    addLeaf(0, first.startCapLeafOffset, first.tailCapStates[0], 1);
+    addLeaf(0, first.tipCapLeafOffset, first.tipCapStates.at(-1), 0);
+  }
+
+  for (let pipe = 0; pipe < prepared.unitsByPipe.length; pipe += 1) {
+    const units = prepared.unitsByPipe[pipe];
+    let cursor = pipe * CSSPIPES_PREBAKE_CONFIG.pipeStaggerFrames;
+    for (let unitIndex = 0; unitIndex < units.length; unitIndex += 1) {
+      const unit = units[unitIndex];
+      const radialSegments = unit.radialSegments;
+      const startFrame = cursor;
+      for (let step = 1; step < unit.durationFrames; step += 1) {
+        for (let side = 0; side < radialSegments; side += 1) {
+          addLeaf(
+            startFrame + step,
+            unit.leafOffset + side,
+            unit.tailStates[step][side],
+            1,
+          );
+        }
+        addLeaf(
+          startFrame + step,
+          unit.startCapLeafOffset,
+          unit.tailCapStates[step],
+          1,
+        );
+      }
+      const endFrame = startFrame + unit.durationFrames;
+      for (let side = 0; side < radialSegments; side += 1) {
+        addLeaf(
+          endFrame,
+          unit.leafOffset + side,
+          unit.tailStates.at(-1)[side],
+          0,
+        );
+      }
+      addLeaf(
+        endFrame,
+        unit.startCapLeafOffset,
+        unit.tailCapStates.at(-1),
+        unitIndex === units.length - 1 ? 0 : 1,
+      );
+      bandRows.push(Object.freeze([pipe, unit.band, startFrame, endFrame]));
+      cursor = endFrame;
+      lastFrame = Math.max(lastFrame, endFrame);
+    }
+  }
+
+  const leafAssignments = [];
+  const sourceRows = Array.from({ length: lastFrame + 1 }, (_, frame) => {
+    const assignments = [...(changes[frame]?.values() ?? [])];
+    const offset = leafAssignments.length / 3;
+    for (const assignment of assignments) leafAssignments.push(...assignment);
+    return Object.freeze([offset, assignments.length]);
+  });
+  const visibility = new Uint8Array(prepared.finalState.leafVisibility);
+  for (const row of sourceRows) {
+    for (let index = 0; index < row[1]; index += 1) {
+      const offset = (row[0] + index) * 3;
+      visibility[leafAssignments[offset]] = leafAssignments[offset + 2];
+    }
+  }
+  if (visibility.some((visible) => visible !== 0) || bandRows.some((row, index) => {
+    const next = bandRows[index + 1];
+    return next?.[0] === row[0] && next[2] !== row[3];
+  })) {
+    throw new Error("Prepared cssPipes snake tail did not crop continuously to empty");
+  }
+  return Object.freeze({
+    schema: "csspipes-prepared-snake-tail@1",
+    sourceFrameCount: sourceRows.length,
+    sourceRows: Object.freeze(sourceRows),
+    leafAssignments: Object.freeze(leafAssignments),
+    bandRows: Object.freeze(bandRows),
+    proof: Object.freeze({
+      direction: "start-to-tip",
+      reachesEmpty: true,
+      noBandBoundaryIdleFrames: true,
+      movingTailCapUsesPreparedRows: true,
+      runtimeGeometrySemantics: false,
+    }),
+  });
+}
+
+function buildRetractionRecording(prepared, entry, modelTransform) {
+  const growthChanges = [];
+  const bandRows = [];
+  let lastGrowthFrame = 0;
+  let firstBoundary = null;
+  const addLeaf = (frame, transition) => {
+    (growthChanges[frame] ??= []).push(transition);
+  };
+
+  for (let pipe = 0; pipe < prepared.unitsByPipe.length; pipe += 1) {
+    const units = prepared.unitsByPipe[pipe];
+    let cursor = pipe * CSSPIPES_PREBAKE_CONFIG.pipeStaggerFrames;
+    for (let unitIndex = 0; unitIndex < units.length; unitIndex += 1) {
+      const unit = units[unitIndex];
+      const radialSegments = unit.radialSegments;
+      const startFrame = cursor;
+      if (unitIndex > 0) {
+        const previousUnit = units[unitIndex - 1];
+        for (let side = 0; side < radialSegments; side += 1) {
+          addLeaf(startFrame, Object.freeze([
+            unit.leafOffset + side,
+            unit.states[0][side],
+            1,
+            unit.states[0][side],
+            0,
+          ]));
+        }
+        addLeaf(startFrame, Object.freeze([
+          unit.tipCapLeafOffset,
+          unit.tipCapStates[0],
+          1,
+          previousUnit.tipCapStates.at(-1),
+          1,
+        ]));
+      }
+      for (let step = 1; step <= unit.durationFrames; step += 1) {
+        for (let side = 0; side < radialSegments; side += 1) {
+          addLeaf(startFrame + step, Object.freeze([
+            unit.leafOffset + side,
+            unit.states[step][side],
+            1,
+            unit.states[step - 1][side],
+            1,
+          ]));
+        }
+        addLeaf(startFrame + step, Object.freeze([
+          unit.tipCapLeafOffset,
+          unit.tipCapStates[step],
+          1,
+          unit.tipCapStates[step - 1],
+          1,
+        ]));
+      }
+      const endFrame = startFrame + unit.durationFrames;
+      bandRows.push(Object.freeze([pipe, unit.band, startFrame, endFrame]));
+      if (firstBoundary === null && unitIndex === 1) {
+        firstBoundary = Object.freeze({
+          pipe,
+          leftBand: units[unitIndex - 1].band,
+          rightBand: unit.band,
+          sharedFrame: startFrame,
+          leftLeaf: units[unitIndex - 1].leafOffset,
+          rightLeaf: unit.leafOffset,
+          tipCapLeaf: unit.tipCapLeafOffset,
+        });
+      }
+      cursor = endFrame;
+      lastGrowthFrame = Math.max(lastGrowthFrame, endFrame);
+    }
+  }
+
+  const sourceFrameCount = lastGrowthFrame + 1;
+  const leafTransitions = [];
+  const sourceRows = Array.from({ length: sourceFrameCount }, (_, sourceFrame) => {
+    const growthFrame = sourceFrameCount - sourceFrame - 1;
+    const changes = growthChanges[growthFrame] ?? [];
+    const offset = leafTransitions.length / 5;
+    for (const transition of changes) leafTransitions.push(...transition);
+    return Object.freeze([offset, changes.length]);
+  });
+  const retracted = applyRetractionRows(
+    cloneState(prepared.finalState),
+    sourceRows,
+    leafTransitions,
+    "after",
+  );
+  const replayed = applyRetractionRows(
+    cloneState(prepared.seedState),
+    [...sourceRows].reverse(),
+    leafTransitions,
+    "before",
+  );
+  if (!sameState(retracted, prepared.seedState) ||
+      !sameState(replayed, prepared.finalState)) {
+    throw new Error("Prepared cssPipes continuous-tube retraction did not round-trip");
+  }
+  if (!firstBoundary || bandRows.some((row, index) => {
+    const next = bandRows[index + 1];
+    return next?.[0] === row[0] && next[2] !== row[3];
+  })) {
+    throw new Error("Prepared cssPipes tube-band playback contains a boundary pause");
+  }
+
+  const snakeTail = buildPreparedSnakeTailRecording(prepared);
+  if (snakeTail.sourceFrameCount !== sourceFrameCount) {
+    throw new Error("Prepared cssPipes head and tail frame counts drifted");
+  }
+  const weldCount = entry.weldedMeshesByPipe.reduce(
+    (total, mesh) => total + mesh.welds.length,
+    0,
+  );
+  const payload = {
+    schema: "csspipes-prepared-retraction-recording@2",
+    sourceDirection: "final-to-seed",
+    playbackDirection: "reverse-source-rows",
+    sourceFrameCount,
+    reverseFrameCount: sourceFrameCount,
+    experiment: buildPreparedExperimentRecording(prepared, modelTransform),
+    snakeTail,
+    sourceRows: Object.freeze(sourceRows),
+    leafTransitions: Object.freeze(leafTransitions),
+    bandRows: Object.freeze(bandRows),
+    proof: Object.freeze({
+      finalStateSha256: stateDigest(prepared.finalState),
+      seedStateSha256: stateDigest(prepared.seedState),
+      retractionReachesSeed: true,
+      reversePlaybackReachesFinal: true,
+      sourceRowsConsumedDescending: true,
+      topology: "one-continuous-shared-ring-tube-per-pipe",
+      noBandBoundaryIdleFrames: true,
+      constantPreparedWorldSpeed: true,
+      timingSource: "prepared-cumulative-centerline-distance",
+      growthWorldUnitsPerSecond: CSSPIPES_PREBAKE_CONFIG.growthWorldUnitsPerSecond,
+      retainedEndCapLeafCount: prepared.retainedEndCapLeafCount,
+      retainedEndCapTargetCount: prepared.retainedEndCapTargetCount,
+      movingTipCapUsesPreparedRows: true,
+      weldedSharedRingCount: weldCount,
+      firstBoundary,
+    }),
+  };
+  return Object.freeze({
+    ...payload,
+    contentHash: createHash("sha256").update(JSON.stringify(payload)).digest("hex"),
+  });
+}
+
+function preparedCellPoint(cell, preparedCenter) {
+  return cell.map((value, axis) =>
+    (value - preparedCenter[axis]) * CSSPIPES_PREBAKE_CONFIG.stepLength);
+}
+
+function preparedChainCellAllowed(cell, preparedCenter, camera) {
+  const [x, y] = projectPreparedPoint(
+    preparedCellPoint(cell, preparedCenter),
+    camera.state.target,
+    camera.state.zoom,
+  );
+  const marginX = CSSPIPES_SOURCE_VIEWPORT.width * 0.06;
+  const marginY = CSSPIPES_SOURCE_VIEWPORT.height * 0.06;
+  return Number.isFinite(x) && Number.isFinite(y) &&
+    x >= -marginX && x <= CSSPIPES_SOURCE_VIEWPORT.width + marginX &&
+    y >= -marginY && y <= CSSPIPES_SOURCE_VIEWPORT.height + marginY;
+}
+
+function preparedChainEndpointsVisible(generated, preparedCenter, camera) {
+  const safeMinX = CSSPIPES_SOURCE_VIEWPORT.width *
+    CSSPIPES_PREBAKE_CONFIG.preparedChainEndpointSafeMarginXRatio;
+  const safeMaxX = CSSPIPES_SOURCE_VIEWPORT.width - safeMinX;
+  const safeMinY = CSSPIPES_SOURCE_VIEWPORT.height *
+    CSSPIPES_PREBAKE_CONFIG.preparedChainEndpointSafeMarginYRatio;
+  const safeMaxY = CSSPIPES_SOURCE_VIEWPORT.height - safeMinY;
+  return generated.walkers.every((walker) => {
+    const points = [walker.segments[0].start, walker.segments.at(-1).end];
+    return points.every((cell) => {
+      const [x, y] = projectPreparedPoint(
+        preparedCellPoint(cell, preparedCenter),
+        camera.state.target,
+        camera.state.zoom,
+      );
+      return x >= safeMinX && x <= safeMaxX && y >= safeMinY && y <= safeMaxY;
+    });
+  });
+}
+
+function inspectPreparedEntry({
+  seed,
+  generated,
+  viewportProfile,
+  preparedCenter,
+  chainCamera = null,
+  chainDirection = "forward",
+  chainChapter = 0,
+}) {
+  const localPoints = generated.points.map((point) =>
+    preparedCellPoint(point, preparedCenter));
+  const camera = fitCamera(localPoints);
+  const cameraQualification = preparedCameraQualification(camera);
+  if (!cameraQualification.qualified) return null;
+  const screenOccupancy = preparedScreenOccupancy(localPoints, camera);
+  if (!screenOccupancy.qualified) return null;
+  const preparedChainCamera = chainCamera ?? camera;
+  const chainScreenOccupancy = preparedScreenOccupancy(
+    localPoints,
+    preparedChainCamera,
+  );
+  if (!chainScreenOccupancy.qualified ||
+      !preparedChainEndpointsVisible(generated, preparedCenter, preparedChainCamera)) {
+    return null;
+  }
+  const sourceRuns = generated.walkers.map((walker, sourcePipe) => Object.freeze({
+    sourcePipe,
+    runs: compileMaximalRuns(walker.segments),
+  }));
+  const rankedRuns = [...new Set(CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe)]
+    .flatMap((radialSegments) => sourceRuns
+      .filter((entry) =>
+        CSSPIPES_PREBAKE_CONFIG.radialSegmentsBySourcePipe[entry.sourcePipe] ===
+          radialSegments)
+      .sort((left, right) =>
+        right.runs.length - left.runs.length || left.sourcePipe - right.sourcePipe));
+  if (rankedRuns.some((entry, pipe) =>
+    entry.runs.length * 2 - 1 > CSSPIPES_PREBAKE_CONFIG.preparedBandSlotsByPipe[pipe])) {
+    return null;
+  }
+  const runsByPipe = rankedRuns.map((entry) => entry.runs);
+  const sourcePipeBySlot = Object.freeze(rankedRuns.map((entry) => entry.sourcePipe));
+  return Object.freeze({
+    seed,
+    generated,
+    preparedCenter: Object.freeze([...preparedCenter]),
+    camera,
+    cameraQualification,
+    screenOccupancy,
+    chainCamera: preparedChainCamera,
+    chainScreenOccupancy,
+    chainDirection,
+    chainChapter,
+    viewportProfile,
+    runsByPipe,
+    sourcePipeBySlot,
+  });
+}
+
+function completePreparedEntry(
+  inspected,
+  initialFramesBySourcePipe,
+  fullPipe,
+) {
+  if (!inspected || !Array.isArray(initialFramesBySourcePipe) ||
+      initialFramesBySourcePipe.length !== CSSPIPES_PREBAKE_CONFIG.pipeCount ||
+      !fullPipe?.routeHash) {
+    throw new Error("Prepared cssPipes slice is missing its complete-pipe authority");
+  }
+  const weldedMeshesByPipe = inspected.runsByPipe.map((runs, pipe) => {
+    const sourcePipe = inspected.sourcePipeBySlot[pipe];
+    return buildWeldedPipeMesh(
+      runs,
+      inspected.preparedCenter,
+      pipe,
+      { initialFrame: initialFramesBySourcePipe[sourcePipe] },
+    );
+  });
+  return Object.freeze({
+    ...inspected,
+    fullPipe: Object.freeze({ ...fullPipe }),
+    weldedMeshesByPipe: Object.freeze(weldedMeshesByPipe),
+  });
+}
+
+function buildAcceptedPreparedEntries() {
+  const accepted = [];
+  let candidate = 0;
+  for (const profile of Object.values(CSSPIPES_VIEWPORT_PROFILES)) {
+    const chapterCount = CSSPIPES_PREBAKE_CONFIG.preparedForwardChainChapterCount;
+    if (!Number.isInteger(chapterCount) || chapterCount < 1 ||
+        profile.seedCount % chapterCount !== 0) {
+      throw new Error(
+        "Prepared cssPipes forward chapters must divide the profile seed count",
+      );
+    }
+    const forwardSeedCount = profile.seedCount / chapterCount;
+    let profilePreparedCenter = null;
+    let profileChainCamera = null;
+    let profileStartCells = null;
+    for (let chapter = 0; chapter < chapterCount; chapter += 1) {
+      const candidateForward = [];
+      let backtracks = 0;
+      while (candidateForward.length < forwardSeedCount) {
+        const previous = candidateForward.at(-1) ?? null;
+        const starts = previous
+          ? previous.generated.walkers.map((walker) => walker.cell)
+          : profileStartCells;
+        const initialDirections = previous
+          ? previous.generated.walkers.map((walker) => walker.direction)
+          : null;
+        const allowedCell = profilePreparedCenter && profileChainCamera
+          ? (cell) => preparedChainCellAllowed(
+            cell,
+            profilePreparedCenter,
+            profileChainCamera,
+          )
+          : undefined;
+        let inspected = null;
+        let seed = null;
+        let generated = null;
+        let attempts = 0;
+        while (!inspected && attempts < 2_000) {
+          if (candidate > 2_000_000) {
+            throw new Error("Prepared cssPipes chain candidate ceiling was exhausted");
+          }
+          seed = candidateSeed(candidate);
+          candidate += 1;
+          attempts += 1;
+          generated = generateCandidate(seed, {
+            requireFreeContinuation: true,
+            ...(starts ? {
+              starts,
+              initialDirections,
+              forceInitialDirections: true,
+            } : {}),
+            ...(allowedCell ? { allowedCell } : {}),
+            ...(!starts ? { returnToStarts: true } : {}),
+            ...(profileStartCells ? { endpointTargets: profileStartCells } : {}),
+            ...(previous ? {
+              blockedCellKeys: generatedCellKeys(previous.generated),
+            } : {}),
+          });
+          if (!generated) continue;
+          inspected = inspectPreparedEntry({
+            seed,
+            generated,
+            viewportProfile: profile.id,
+            preparedCenter: profilePreparedCenter ?? generated.center,
+            chainCamera: profileChainCamera,
+            chainDirection: "forward",
+            chainChapter: chapter,
+          });
+        }
+        if (!inspected) {
+          if (candidateForward.length <= 1 || backtracks >= 2_000) {
+            throw new Error(
+              `Could not complete prepared ${profile.id} full pipe ${chapter}`,
+            );
+          }
+          candidateForward.pop();
+          backtracks += 1;
+          continue;
+        }
+        if (!profilePreparedCenter) {
+          profilePreparedCenter = inspected.preparedCenter;
+          profileChainCamera = inspected.chainCamera;
+          profileStartCells = inspected.generated.walkers.map(
+            (walker) => Object.freeze([...walker.segments[0].start]),
+          );
+        }
+        candidateForward.push(Object.freeze({ seed, generated }));
+      }
+
+      const fullForwardRoute = concatenateGeneratedCheckpoints(candidateForward);
+      const fullForwardRouteHash = preparedFullRouteHash(fullForwardRoute);
+      const fullForwardMeshes = fullForwardRoute.walkers.map((walker, sourcePipe) =>
+        buildWeldedPipeMesh(
+          compileMaximalRuns(walker.segments),
+          profilePreparedCenter,
+          sourcePipe,
+        ));
+      const forwardFrames = fullForwardRoute.walkers.map((walker, sourcePipe) =>
+        buildPreparedTransportedFrames(
+          walker.segments,
+          preparedPipeRing(fullForwardMeshes[sourcePipe], "start").frame,
+        ));
+      const forwardSlices = sliceGeneratedRouteBackwards(
+        fullForwardRoute,
+        CSSPIPES_PREBAKE_CONFIG.segmentsPerPipe,
+      );
+      const forward = forwardSlices.map((slice, sliceIndex) => {
+        const inspected = inspectPreparedEntry({
+          seed: candidateForward[sliceIndex].seed,
+          generated: slice.generated,
+          viewportProfile: profile.id,
+          preparedCenter: profilePreparedCenter,
+          chainCamera: profileChainCamera,
+          chainDirection: "forward",
+          chainChapter: chapter,
+        });
+        if (!inspected) {
+          throw new Error(
+            `Prepared ${profile.id} full pipe produced an invalid forward slice ${sliceIndex}`,
+          );
+        }
+        return completePreparedEntry(
+          inspected,
+          forwardFrames.map((frames) => frames[slice.fullSegmentStart]),
+          {
+            schema: "csspipes-complete-pipe-slice@1",
+            routeHash: fullForwardRouteHash,
+            meshHashes: Object.freeze(fullForwardMeshes.map((mesh) => mesh.hash)),
+            preparedBeforeSlicing: true,
+            sliceOrder: "tail-to-head-from-complete-pipe",
+            direction: "forward",
+            totalSegmentsPerPipe: fullForwardRoute.walkers[0].segments.length,
+            fullSegmentStart: slice.fullSegmentStart,
+            sliceIndex,
+            sliceCount: forwardSlices.length,
+          },
+        );
+      });
+
+      accepted.push(...forward);
+    }
+  }
+  return Object.freeze({
+    accepted: Object.freeze(accepted),
+    candidateSeedsExamined: candidate,
+  });
+}
+
+function buildPreparedClip(entry, clipIndex, bandSlotsByPipe, internTransform) {
+  const prepared = buildPreparedTube(entry, bandSlotsByPipe, internTransform);
+  const materialSelection = buildPreparedMaterialSelection(
+    entry.seed,
+    entry.sourcePipeBySlot,
+  );
+  const materialIndicesByPipe = materialSelection.materialIndicesByPipe;
+  const recording = buildRetractionRecording(
+    prepared,
+    entry,
+    internTransform(entry.camera.transform),
+  );
+  const bandCountsByPipe = entry.weldedMeshesByPipe.map((mesh) => mesh.bands.length);
+  const bandCount = bandCountsByPipe.reduce((total, count) => total + count, 0);
+  const wallLeafCount = bandCountsByPipe.reduce(
+    (total, count, pipe) => total +
+      count * CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe[pipe],
+    0,
+  );
+  const retainedEndCapLeafCount = CSSPIPES_PREBAKE_CONFIG.pipeCount *
+    CSSPIPES_END_CAP_LEAVES_PER_PIPE;
+  const retainedEndCapTargetCount = CSSPIPES_PREBAKE_CONFIG.pipeCount *
+    CSSPIPES_END_CAP_TARGETS_PER_PIPE;
+  const weldedMesh = Object.freeze({
+    schema: "csspipes-final-continuous-tubes@3",
+    preparationDirection: "complete-tubes-to-seed-retraction",
+    playbackDirection: "reverse-prepared-retraction",
+    meshHashes: Object.freeze(entry.weldedMeshesByPipe.map((mesh) => mesh.hash)),
+    vertexCount: entry.weldedMeshesByPipe.reduce(
+      (total, mesh) => total + mesh.vertices.length,
+      0,
+    ),
+    polygonCount: entry.weldedMeshesByPipe.reduce(
+      (total, mesh) => total + mesh.polygons.length,
+      0,
+    ),
+    bandCount,
+    endCapPolygonCount: entry.weldedMeshesByPipe.reduce(
+      (total, mesh) => total + mesh.caps.reduce(
+        (capTotal, cap) => capTotal + cap.polygons.length,
+        0,
+      ),
+      0,
+    ),
+    weldCount: entry.weldedMeshesByPipe.reduce(
+      (total, mesh) => total + mesh.welds.length,
+      0,
+    ),
+    reverseRetractionBandCounts: Object.freeze(
+      entry.weldedMeshesByPipe.map((mesh) => mesh.reverseRetractionBandIds.length),
+    ),
+  });
+  return Object.freeze({
+    id: `clip-${String(clipIndex).padStart(3, "0")}`,
+    seed: entry.seed,
+    viewportProfile: entry.viewportProfile,
+    recording,
+    initialVisibleBandCount: prepared.initialVisibleBandCount,
+    initialVisibleLeafCount: prepared.initialVisibleLeafCount,
+    finalVisibleLeafCount: wallLeafCount + retainedEndCapTargetCount,
+    initialVisibleSurfaceLeafCount:
+      CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe.reduce(
+        (total, count) => total + count,
+        CSSPIPES_PREBAKE_CONFIG.pipeCount * CSSPIPES_END_CAP_LEAVES_PER_PIPE,
+      ),
+    finalVisibleSurfaceLeafCount: wallLeafCount + retainedEndCapLeafCount,
+    bandCount,
+    bandCountsByPipe: Object.freeze(bandCountsByPipe),
+    sourcePipeBySlot: entry.sourcePipeBySlot,
+    materialIndicesByPipe,
+    materialDiversity: materialSelection.diversity,
+    chainDirection: entry.chainDirection,
+    chainChapter: entry.chainChapter,
+    chainScreenOccupancy: entry.chainScreenOccupancy,
+    fullPipe: entry.fullPipe,
+    weldedMesh,
+    camera: entry.camera,
+    cameraQualification: entry.cameraQualification,
+    screenOccupancy: entry.screenOccupancy,
+    bounds: Object.freeze({
+      min: Object.freeze([...entry.generated.min]),
+      max: Object.freeze([...entry.generated.max]),
+      span: Object.freeze([...entry.generated.span]),
+      preparedCenter: Object.freeze([...entry.preparedCenter]),
+    }),
+  });
+}
+
+export function buildPreparedClipLibrary() {
+  const { accepted, candidateSeedsExamined } = buildAcceptedPreparedEntries();
+
+  const bandSlotsByPipe = Object.freeze(Array.from(
+    { length: CSSPIPES_PREBAKE_CONFIG.pipeCount },
+    (_, pipe) => Math.max(...accepted.map(
+      (entry) => entry.weldedMeshesByPipe[pipe].bands.length,
+    )),
+  ));
+  if (bandSlotsByPipe.some(
+    (count, pipe) => count !== CSSPIPES_PREBAKE_CONFIG.preparedBandSlotsByPipe[pipe],
+  )) {
+    throw new Error(
+      `Prepared band capacity drifted: ${bandSlotsByPipe.join(",")}`,
+    );
+  }
+  const bandSlotsPerPipe = Math.max(...bandSlotsByPipe);
+  const bandSlotCount = bandSlotsByPipe.reduce((total, count) => total + count, 0);
+  const wallLeafTargetCount = bandSlotsByPipe.reduce(
+    (total, count, pipe) => total +
+      count * CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe[pipe],
+    0,
+  );
+  const retainedEndCapLeafCount = CSSPIPES_PREBAKE_CONFIG.pipeCount *
+    CSSPIPES_END_CAP_LEAVES_PER_PIPE;
+  const retainedEndCapTargetCount = CSSPIPES_PREBAKE_CONFIG.pipeCount *
+    CSSPIPES_END_CAP_TARGETS_PER_PIPE;
+  const leavesPerPipeByPipe = Object.freeze(bandSlotsByPipe.map((count, pipe) =>
+    preparedPipeLeafCount(
+      count,
+      CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe[pipe],
+    )));
+  const leavesPerPipe = Math.max(...leavesPerPipeByPipe);
+  const pipeLeafOffsets = Object.freeze(leavesPerPipeByPipe.map((_, pipe) =>
+    leavesPerPipeByPipe.slice(0, pipe).reduce((total, count) => total + count, 0)));
+  const leafTargetCount = leavesPerPipeByPipe.reduce(
+    (total, count) => total + count,
+    0,
+  );
+  if (wallLeafTargetCount > CSSPIPES_PREBAKE_CONFIG.logicalSegmentCount *
+      Math.max(...CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe)) {
+    throw new Error(
+      `Prepared continuous-tube bank ${bandSlotCount} exceeded the logical segment ceiling ${CSSPIPES_PREBAKE_CONFIG.logicalSegmentCount}`,
+    );
+  }
+
+  const transforms = [];
+  const transformIndices = new Map();
+  const internTransform = (transform) => {
+    let index = transformIndices.get(transform);
+    if (index === undefined) {
+      index = transforms.length;
+      transforms.push(transform);
+      transformIndices.set(transform, index);
+    }
+    return index;
+  };
+  const clips = accepted.map((entry, clipIndex) =>
+    buildPreparedClip(entry, clipIndex, bandSlotsByPipe, internTransform));
+
+  const bandCounts = clips.map((clip) => clip.bandCount);
+  const viewportPlaylists = Object.freeze(Object.fromEntries(
+    Object.values(CSSPIPES_VIEWPORT_PROFILES).map((profile) => {
+      const indices = clips.flatMap((clip, clipIndex) =>
+        clip.viewportProfile === profile.id ? [clipIndex] : []);
+      if (indices.length !== profile.seedCount) {
+        throw new Error(`Prepared ${profile.id} seed pool has ${indices.length}/${profile.seedCount} clips`);
+      }
+      return [profile.id, Object.freeze(indices)];
+    }),
+  ));
+  const preparedZSeedLoop = buildPreparedZSeedLoopTracks({
+    accepted,
+    clips,
+    viewportPlaylists,
+    pipeLeafOffsets,
+    leavesPerPipeByPipe,
+    internTransform,
+  });
+  const zSeedLoopTracks = preparedZSeedLoop.tracks;
+  const libraryHash = createHash("sha256").update(JSON.stringify({
+    transforms,
+    clips: clips.map((clip) => [
+      clip.seed,
+      clip.recording.contentHash,
+      clip.weldedMesh.meshHashes,
+      clip.camera.transform,
+      clip.viewportProfile,
+      clip.screenOccupancy,
+      clip.materialIndicesByPipe,
+      clip.materialDiversity,
+    ]),
+    bandSlotsByPipe,
+    viewportPlaylists,
+    zSeedLoopTracks,
+    zSeedLoopHandoffProof: preparedZSeedLoop.proof,
+  })).digest("hex");
+  return Object.freeze({
+    schema: "csspipes-prebaked-playback@12",
+    mode: "prepared-continuous-tube-retractions-played-in-reverse",
+    libraryHash,
+    clipCount: clips.length,
+    pipeCount: CSSPIPES_PREBAKE_CONFIG.pipeCount,
+    sourceTicksPerSecond: CSSPIPES_PREBAKE_CONFIG.sourceTicksPerSecond,
+    logicalSegmentCount: CSSPIPES_PREBAKE_CONFIG.logicalSegmentCount,
+    bandSlotsPerPipe,
+    bandSlotsByPipe,
+    bandSlotCount,
+    leavesPerPipe,
+    leavesPerPipeByPipe,
+    pipeLeafOffsets,
+    wallLeafTargetCount,
+    retainedEndCapLeafCount,
+    retainedEndCapTargetCount,
+    radialSegments: CSSPIPES_PREBAKE_CONFIG.radialSegments,
+    radialSegmentsByPipe: CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe,
+    radialSegmentsBySourcePipe:
+      CSSPIPES_PREBAKE_CONFIG.radialSegmentsBySourcePipe,
+    endCapLeavesPerEnd: CSSPIPES_END_CAP_LEAVES_PER_END,
+    endCapVerticesPerEnd: CSSPIPES_END_CAP_VERTICES_PER_END,
+    endCapVerticesByPipe: CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe,
+    retainedPipeRootCount: CSSPIPES_PREBAKE_CONFIG.pipeCount,
+    retainedRootCount: CSSPIPES_PREBAKE_CONFIG.pipeCount,
+    leafTargetCount,
+    retainedBankCount: 2,
+    totalRetainedRootCount: CSSPIPES_PREBAKE_CONFIG.pipeCount * 2,
+    totalLeafTargetCount: leafTargetCount * 2,
+    playbackFramesPerSecond: CSSPIPES_PREBAKE_CONFIG.playbackFramesPerSecond,
+    preparation: Object.freeze({
+      topology: "continuous-shared-ring-tube-meshes",
+      tubeBankPacking: "facet-family-then-descending-prepared-band-complexity",
+      construction: "build-complete-tubes-then-retract-tip-to-seed",
+      recording: "complete-tube-to-seed-retraction",
+      playback: "reverse-source-rows",
+      runtimeTopologyWork: false,
+      runtimeGeometrySemantics: false,
+      runtimeTubePacking: false,
+    }),
+    morph: Object.freeze({
+      package: "@layoutit/polycss-morph",
+      version: "0.2.11",
+      target: "createPolyMorphPreparedDomTarget",
+      frameDurationMilliseconds: CSSPIPES_PREBAKE_CONFIG.frameMorphDurationMilliseconds,
+      easing: CSSPIPES_PREBAKE_CONFIG.morphEasing,
+      growthWorldUnitsPerSecond: CSSPIPES_PREBAKE_CONFIG.growthWorldUnitsPerSecond,
+      bandTimingSource: "prepared-cumulative-centerline-distance",
+      leafTransformSource: "prepared-zero-bleed-quad-and-cap-root-matrices",
+    }),
+    materials: Object.freeze({
+      paletteSchema: CSSPIPES_PRODUCT_PALETTE.schema,
+      materialCount: CSSPIPES_PALETTE.length,
+      selection: "fixed-seven-color-product-palette-by-source-pipe",
+      replacement: false,
+      bindingsPerClip: CSSPIPES_PREBAKE_CONFIG.pipeCount,
+      diversity: Object.freeze({
+        schema: "csspipes-prepared-fixed-materials@1",
+        colorSpace: "OKLab-from-prepared-CSS-sRGB",
+        fixedIndices: MATERIAL_FIXED_INDICES,
+        minimumPairDistance: Number(
+          minimumMaterialOklabDistance(MATERIAL_FIXED_INDICES).toFixed(6),
+        ),
+        sourcePipeStable: true,
+      }),
+      runtimeRandomness: false,
+      runtimePerLeafColorWrites: 0,
+    }),
+    transforms: Object.freeze(transforms),
+    experiments: Object.freeze({
+      schema: "csspipes-prepared-experiments@1",
+      defaultMode: "z-seed-loop",
+      zSeedLoop: Object.freeze({
+        schema: "csspipes-prepared-z-seed-loop@7",
+        defaultEnabled: true,
+        runtimeCameraMath: false,
+        runtimeChainMath: false,
+        runtimeGeometrySemantics: false,
+        playback: "grow-once-then-simultaneous-prepared-head-and-tail",
+        seedOriginHandoff: "seven-next-start-rings-welded-to-seven-previous-tip-rings",
+        chainPlacement: "finite-prepared-complete-forward-pipe-backward-slices",
+        chainChapterCount: CSSPIPES_PREBAKE_CONFIG.preparedForwardChainChapterCount,
+        cameraMode: "one-prepared-static-camera-per-viewport-profile",
+        profileWrap: "none-clean-opening-restart-after-exhaustion",
+        startingSeed: "browser-crypto-cursor-into-prepared-chain",
+        retainedBankCount: 2,
+        snakeFramesPerSeed: CSSPIPES_PREBAKE_CONFIG.snakeFramesPerSeed,
+        tailStorage: "inline-in-canonical-scene-transform-table",
+        handoffProof: preparedZSeedLoop.proof,
+        trackCount: zSeedLoopTracks.length,
+        tracks: Object.freeze(zSeedLoopTracks),
+      }),
+    }),
+    viewportProfiles: CSSPIPES_VIEWPORT_PROFILES,
+    viewportPlaylists,
+    clips: Object.freeze(clips),
+    metrics: Object.freeze({
+      candidateSeedsExamined,
+      acceptedSeeds: clips.length,
+      preparedViewportSeedPools: Object.freeze(Object.fromEntries(
+        Object.entries(viewportPlaylists).map(([profile, playlist]) => [profile, playlist.length]),
+      )),
+      maximumPreparedCameraOverscanRatio: Math.max(
+        ...clips.map((clip) => clip.cameraQualification.overscanRatio),
+      ),
+      minimumPreparedScreenOccupiedCellCount: Math.min(
+        ...clips.map((clip) => clip.screenOccupancy.occupiedCellCount),
+      ),
+      minimumPreparedChainScreenOccupiedCellCount: Math.min(
+        ...clips.map((clip) => clip.chainScreenOccupancy.occupiedCellCount),
+      ),
+      preparedMaterialDuplicateCount: clips.reduce(
+        (total, clip) => total + clip.materialDiversity.repeatedMaterialCount,
+        0,
+      ),
+      minimumPreparedMaterialOklabDistance: Math.min(
+        ...clips.map((clip) => clip.materialDiversity.minimumOklabDistance),
+      ),
+      preparedTransformStates: transforms.length,
+      preparedSnakeTailAssignments: clips.reduce(
+        (total, clip) => total + clip.recording.snakeTail.leafAssignments.length / 3,
+        0,
+      ),
+      preparedSnakeTailFrames: clips.reduce(
+        (total, clip) => total + clip.recording.snakeTail.sourceFrameCount,
+        0,
+      ),
+      preparedRecordingFrames: clips.reduce((total, clip) =>
+        total + clip.recording.sourceFrameCount, 0),
+      preparedLeafTransitions: clips.reduce((total, clip) =>
+        total + clip.recording.leafTransitions.length / 5, 0),
+      preparedWeldedMeshVertices: clips.reduce(
+        (total, clip) => total + clip.weldedMesh.vertexCount,
+        0,
+      ),
+      preparedWeldedMeshPolygons: clips.reduce(
+        (total, clip) => total + clip.weldedMesh.polygonCount,
+        0,
+      ),
+      preparedWeldedJoints: clips.reduce(
+        (total, clip) => total + clip.weldedMesh.weldCount,
+        0,
+      ),
+      preparedEndCapPolygons: clips.reduce(
+        (total, clip) => total + clip.weldedMesh.endCapPolygonCount,
+        0,
+      ),
+      uniformBandSlotCount: bandSlotsPerPipe * CSSPIPES_PREBAKE_CONFIG.pipeCount,
+      packedBandSlotSavings:
+        bandSlotsPerPipe * CSSPIPES_PREBAKE_CONFIG.pipeCount - bandSlotCount,
+      packedWallLeafSavings:
+        bandSlotsPerPipe * CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe.reduce(
+          (total, count) => total + count,
+          0,
+        ) - wallLeafTargetCount,
+      mergedEndCapLeafSavings: 2 *
+        CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe.reduce(
+          (total, count) => total + count - CSSPIPES_END_CAP_LEAVES_PER_END,
+          0,
+        ),
+      totalSurfaceLeafSavings:
+        bandSlotsPerPipe * CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe.reduce(
+          (total, count) => total + count,
+          0,
+        ) - wallLeafTargetCount + 2 *
+        CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe.reduce(
+          (total, count) => total + count - CSSPIPES_END_CAP_LEAVES_PER_END,
+          0,
+        ),
+      minBandsPerClip: Math.min(...bandCounts),
+      maxBandsPerClip: Math.max(...bandCounts),
+      averageBandsPerClip: Number((bandCounts.reduce((total, count) => total + count, 0) /
+        bandCounts.length).toFixed(3)),
+      runtimePathGeneration: false,
+      runtimeGeometrySemantics: false,
+      runtimeContract: "publish retained indices from descending prepared retraction rows",
+    }),
+  });
+}

--- a/src/adapters/3dpipes/src/prepare/csspipes/preparedLighting.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/preparedLighting.mjs
@@ -1,0 +1,168 @@
+import { createHash } from "node:crypto";
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { PNG } from "pngjs";
+import {
+  CSSPIPES_PALETTE,
+  CSSPIPES_PREBAKE_CONFIG,
+  CSSPIPES_PRODUCT_MATERIALS,
+  CSSPIPES_PRODUCT_PALETTE,
+} from "./endlessTubes.mjs";
+import { CSSPIPES_GENERATED_PUBLIC_ROOT } from "./paths.mjs";
+
+const CSSPIPES_LIGHTING_PATH = resolve(
+  CSSPIPES_GENERATED_PUBLIC_ROOT,
+  "assets/pipe-space-texels.png",
+);
+
+const FIELD_SIZE = 8;
+const LEAF_SIZE = 64;
+const SHADE = Object.freeze([1.08, 0.88, 0.6, 0.42, 0.58, 0.9]);
+const SPECULAR_INTENSITY = 0.18;
+const OPENGL_SHININESS_SCALE = 128;
+
+function parseHex(color) {
+  const match = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/iu.exec(color);
+  if (!match) throw new TypeError(`Invalid cssPipes palette color ${color}`);
+  return match.slice(1).map((value) => Number.parseInt(value, 16));
+}
+
+function channel(value) {
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+function srgbToLinear(value) {
+  return value <= 0.04045
+    ? value / 12.92
+    : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+function linearToSrgb(value) {
+  const clamped = Math.max(0, Math.min(1, value));
+  return clamped <= 0.0031308
+    ? clamped * 12.92
+    : 1.055 * clamped ** (1 / 2.4) - 0.055;
+}
+
+function preparedSpecularLobe(side, x, radialSegments, shininess) {
+  const facetAngle = side * Math.PI * 2 / radialSegments;
+  const texelAngle = ((x + 0.5) / FIELD_SIZE - 0.5) *
+    Math.PI * 2 / radialSegments;
+  const halfVectorDot = Math.max(0, Math.cos(facetAngle + texelAngle));
+  return SPECULAR_INTENSITY *
+    halfVectorDot ** Math.max(1, shininess * OPENGL_SHININESS_SCALE);
+}
+
+function preparedDiffuseShade(side, radialSegments) {
+  const position = side * SHADE.length / radialSegments;
+  const left = Math.floor(position) % SHADE.length;
+  const right = (left + 1) % SHADE.length;
+  const blend = position - Math.floor(position);
+  return SHADE[left] + (SHADE[right] - SHADE[left]) * blend;
+}
+
+export function buildPipeSpaceTexelLighting() {
+  const faceCount = CSSPIPES_PALETTE.length * CSSPIPES_PREBAKE_CONFIG.radialSegments;
+  const width = faceCount * FIELD_SIZE;
+  const height = FIELD_SIZE;
+  const png = new PNG({ width, height, colorType: 6 });
+  const faces = [];
+  for (let materialIndex = 0; materialIndex < CSSPIPES_PALETTE.length; materialIndex += 1) {
+    const base = parseHex(CSSPIPES_PALETTE[materialIndex]);
+    const material = CSSPIPES_PRODUCT_MATERIALS[materialIndex];
+    const materialRadialSegments =
+      CSSPIPES_PREBAKE_CONFIG.radialSegmentsBySourcePipe[materialIndex];
+    for (let side = 0; side < CSSPIPES_PREBAKE_CONFIG.radialSegments; side += 1) {
+      const faceIndex = materialIndex * CSSPIPES_PREBAKE_CONFIG.radialSegments + side;
+      for (let y = 0; y < FIELD_SIZE; y += 1) {
+        for (let x = 0; x < FIELD_SIZE; x += 1) {
+          const fieldCenter = (FIELD_SIZE - 1) / 2;
+          const centerHighlight = 0.92 + 0.11 *
+            (1 - Math.abs(x - fieldCenter) / fieldCenter);
+          const vertical = 1.03 - y * 0.075 / (FIELD_SIZE - 1);
+          const brightness = preparedDiffuseShade(
+            side,
+            materialRadialSegments,
+          ) * centerHighlight * vertical;
+          const specular = preparedSpecularLobe(
+            side,
+            x,
+            materialRadialSegments,
+            material.shininess,
+          );
+          const offset = (y * width + faceIndex * FIELD_SIZE + x) * 4;
+          for (let colorChannel = 0; colorChannel < 3; colorChannel += 1) {
+            const diffuseSrgb = Math.max(0, Math.min(1,
+              base[colorChannel] / 255 * brightness));
+            const litLinear = srgbToLinear(diffuseSrgb) +
+              material.specular[colorChannel] * specular;
+            png.data[offset + colorChannel] = channel(linearToSrgb(litLinear) * 255);
+          }
+          png.data[offset + 3] = 255;
+        }
+      }
+      faces.push(Object.freeze({
+        materialIndex,
+        symbol: material.symbol,
+        side,
+        radialSegments: materialRadialSegments,
+        faceIndex,
+        backgroundPositionX: `${-faceIndex * LEAF_SIZE}px`,
+      }));
+    }
+  }
+  const bytes = PNG.sync.write(png, { colorType: 6, inputColorType: 6 });
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  const contract = Object.freeze({
+    schema: "csspipes-prepared-space-texel-lighting@1",
+    techniqueReference: "cssGraphics Mario fixed-page prepared space-texel surface",
+    assetUrl: "/csspipes/assets/pipe-space-texels.png",
+    assetSha256: sha256,
+    encoding: "PNG-RGBA8",
+    fieldWidth: FIELD_SIZE,
+    fieldHeight: FIELD_SIZE,
+    atlasWidth: width,
+    atlasHeight: height,
+    leafWidth: LEAF_SIZE,
+    leafHeight: LEAF_SIZE,
+    backgroundSize: `${width * (LEAF_SIZE / FIELD_SIZE)}px ${LEAF_SIZE}px`,
+    palette: CSSPIPES_PRODUCT_PALETTE,
+    materialColors: CSSPIPES_PALETTE,
+    materialFieldStride: CSSPIPES_PREBAKE_CONFIG.radialSegments,
+    materialCssStride: CSSPIPES_PREBAKE_CONFIG.radialSegments * LEAF_SIZE,
+    specular: Object.freeze({
+      schema: "csspipes-prepared-specular-space-texel@1",
+      model: "prepared-blinn-phong-half-vector",
+      materialTerms: "fixed-product-material-specular-rgb-and-shininess",
+      sourceColorSpace: "linear-light",
+      intensity: SPECULAR_INTENSITY,
+      shininessScale: OPENGL_SHININESS_SCALE,
+      halfVectorFacet: 0,
+      runtimeDynamic: false,
+    }),
+    faces: Object.freeze(faces),
+    runtime: Object.freeze({
+      lightingCalculations: 0,
+      backgroundImageWrites: 0,
+      sequentialBackgroundPositionWrites: 0,
+      materialRandomSelections: 0,
+      perLeafMaterialWrites: 0,
+      topologyMutation: false,
+    }),
+  });
+  return Object.freeze({ contract, bytes });
+}
+
+export async function writePipeSpaceTexelLighting(
+  prepared = buildPipeSpaceTexelLighting(),
+) {
+  await mkdir(dirname(CSSPIPES_LIGHTING_PATH), { recursive: true });
+  const temporary = `${CSSPIPES_LIGHTING_PATH}.tmp`;
+  await writeFile(temporary, prepared.bytes);
+  await rename(temporary, CSSPIPES_LIGHTING_PATH);
+  return Object.freeze({
+    outputPath: CSSPIPES_LIGHTING_PATH,
+    bytes: prepared.bytes.length,
+    contract: prepared.contract,
+  });
+}

--- a/src/adapters/3dpipes/src/prepare/csspipes/preparedMaterialBindings.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/preparedMaterialBindings.mjs
@@ -1,0 +1,100 @@
+const MATERIAL_OFFSET_PROPERTY = "--csspipes-material-offset";
+const MATERIAL_COLOR_PROPERTY = "--csspipes-material-color";
+
+function validateMaterialIndices(indices, pipeCount, materialCount, label) {
+  if (!Array.isArray(indices) || indices.length !== pipeCount ||
+      indices.some((index) => !Number.isInteger(index) ||
+        index < 0 || index >= materialCount)) {
+    throw new TypeError(`${label} must bind one prepared material per pipe`);
+  }
+}
+
+function materialDeclaration(lighting, materialIndex) {
+  const color = lighting.materialColors[materialIndex];
+  const field = lighting.faces[materialIndex * lighting.materialFieldStride];
+  if (!/^#[0-9a-f]{6}$/iu.test(color) ||
+      field?.materialIndex !== materialIndex || field?.side !== 0 ||
+      typeof field.backgroundPositionX !== "string") {
+    throw new Error(`Prepared material ${materialIndex} has no stable atlas origin`);
+  }
+  return `${MATERIAL_OFFSET_PROPERTY}: ${field.backgroundPositionX}; ` +
+    `${MATERIAL_COLOR_PROPERTY}: ${color};`;
+}
+
+export function buildPreparedMaterialBindings(scene) {
+  const playback = scene?.playback;
+  const lighting = scene?.lighting;
+  const pipeCount = playback?.pipeCount;
+  const retainedBankCount = playback?.retainedBankCount;
+  const materialCount = lighting?.materialColors?.length;
+  if (!Number.isInteger(pipeCount) || pipeCount < 1 ||
+      !Number.isInteger(retainedBankCount) || retainedBankCount < 1 ||
+      !Number.isInteger(materialCount) || materialCount < pipeCount ||
+      playback.materials?.materialCount !== materialCount ||
+      lighting.materialFieldStride !== playback.radialSegments ||
+      lighting.faces?.length !== materialCount * playback.radialSegments ||
+      playback.clips?.length !== playback.clipCount) {
+    throw new Error("Prepared clip material bindings are incomplete");
+  }
+
+  const rows = [];
+  const usage = new Uint32Array(materialCount);
+  for (let side = 0; side < playback.radialSegments; side += 1) {
+    rows.push(
+      `[data-csspipes-pipe-root] [data-csspipes-surface="wall"]` +
+      `[data-csspipes-cylinder-side="${side}"] { ` +
+      `background-position-x: calc(var(${MATERIAL_OFFSET_PROPERTY}) - ` +
+      `${side * lighting.leafWidth}px) !important; }`,
+    );
+  }
+  rows.push(
+    `[data-csspipes-pipe-root] [data-csspipes-surface="end-cap"] { ` +
+    `color: var(${MATERIAL_COLOR_PROPERTY}) !important; }`,
+  );
+  const fallback = playback.clips[0]?.materialIndicesByPipe;
+  validateMaterialIndices(fallback, pipeCount, materialCount, "Fallback clip");
+  for (let bank = 0; bank < retainedBankCount; bank += 1) {
+    for (let pipe = 0; pipe < pipeCount; pipe += 1) {
+      rows.push(
+        `[data-csspipes-playback-root] > ` +
+        `[data-csspipes-bank-index="${bank}"]` +
+        `[data-csspipes-pipe-root="${pipe}"] { ` +
+        `${materialDeclaration(lighting, fallback[pipe])} }`,
+      );
+    }
+  }
+
+  for (let clipIndex = 0; clipIndex < playback.clips.length; clipIndex += 1) {
+    const indices = playback.clips[clipIndex].materialIndicesByPipe;
+    validateMaterialIndices(
+      indices,
+      pipeCount,
+      materialCount,
+      `Prepared clip ${clipIndex}`,
+    );
+    for (let bank = 0; bank < retainedBankCount; bank += 1) {
+      for (let pipe = 0; pipe < pipeCount; pipe += 1) {
+        const materialIndex = indices[pipe];
+        if (bank === 0) usage[materialIndex] += 1;
+        rows.push(
+          `[data-csspipes-playback-root] > ` +
+          `[data-csspipes-bank-index="${bank}"]` +
+          `[data-csspipes-pipe-root="${pipe}"]` +
+          `[data-csspipes-material-clip="${clipIndex}"] { ` +
+          `${materialDeclaration(lighting, materialIndex)} }`,
+        );
+      }
+    }
+  }
+
+  return Object.freeze({
+    schema: "csspipes-prepared-material-bindings@2",
+    selectorAttribute: "data-csspipes-material-clip",
+    bindingCount: playback.clipCount * pipeCount * retainedBankCount,
+    fallbackBindingCount: pipeCount * retainedBankCount,
+    materialUsage: Object.freeze([...usage]),
+    css: `${rows.join("\n")}\n`,
+    runtimeRandomness: false,
+    runtimePerLeafColorWrites: 0,
+  });
+}

--- a/src/adapters/3dpipes/src/prepare/csspipes/preparedPlaybackChunks.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/preparedPlaybackChunks.mjs
@@ -1,0 +1,236 @@
+import { createHash } from "node:crypto";
+import { gzipSync } from "node:zlib";
+
+const sha256 = (text) => createHash("sha256").update(text).digest("hex");
+
+function createTransformLocalizer(transforms) {
+  const localTransforms = [];
+  const localIndices = new Map();
+  return Object.freeze({
+    transforms: localTransforms,
+    intern(globalIndex) {
+      if (!Number.isInteger(globalIndex) || typeof transforms[globalIndex] !== "string") {
+        throw new Error(`Prepared global transform ${globalIndex} is invalid`);
+      }
+      let localIndex = localIndices.get(globalIndex);
+      if (localIndex === undefined) {
+        localIndex = localTransforms.length;
+        localTransforms.push(transforms[globalIndex]);
+        localIndices.set(globalIndex, localIndex);
+      }
+      return localIndex;
+    },
+    lookup(globalIndex) {
+      const localIndex = localIndices.get(globalIndex);
+      if (localIndex === undefined) {
+        throw new Error(`Prepared transform ${globalIndex} is outside its clip chunk`);
+      }
+      return localIndex;
+    },
+  });
+}
+
+function remapStrided(values, stride, transformColumns, localize) {
+  const remapped = [...values];
+  for (let offset = 0; offset < remapped.length; offset += stride) {
+    for (const column of transformColumns) {
+      remapped[offset + column] = localize(remapped[offset + column]);
+    }
+  }
+  return Object.freeze(remapped);
+}
+
+function localizeInitialState(initial, localize) {
+  return Object.freeze({
+    ...initial,
+    modelTransform: localize(initial.modelTransform),
+    rootTransform: localize(initial.rootTransform),
+    shapes: remapStrided(initial.shapes, 3, [1], localize),
+    leaves: remapStrided(initial.leaves, 3, [1], localize),
+  });
+}
+
+function localizeRecording(recording, localize) {
+  return Object.freeze({
+    ...recording,
+    experiment: Object.freeze({
+      ...recording.experiment,
+      initial: localizeInitialState(recording.experiment.initial, localize),
+      connectedInitial: localizeInitialState(
+        recording.experiment.connectedInitial,
+        localize,
+      ),
+      growEntry: Object.freeze({
+        ...recording.experiment.growEntry,
+        leafTransitions: remapStrided(
+          recording.experiment.growEntry.leafTransitions,
+          5,
+          [1, 3],
+          localize,
+        ),
+      }),
+    }),
+    snakeTail: Object.freeze({
+      ...recording.snakeTail,
+      leafAssignments: remapStrided(
+        recording.snakeTail.leafAssignments,
+        3,
+        [1],
+        localize,
+      ),
+    }),
+    leafTransitions: remapStrided(
+      recording.leafTransitions,
+      5,
+      [1, 3],
+      localize,
+    ),
+  });
+}
+
+function buildClipChunks(playback) {
+  const tracks = playback.experiments.zSeedLoop.tracks;
+  const localizers = playback.clips.map(() =>
+    createTransformLocalizer(playback.transforms));
+  const chunks = playback.clips.map((clip, clipIndex) => {
+    const track = tracks[clipIndex];
+    const localizer = localizers[clipIndex];
+    const recording = localizeRecording(clip.recording, localizer.intern);
+    const placement = Object.freeze({
+      seedOriginTransform: localizer.intern(track.seedOriginTransform),
+      modelTransform: localizer.intern(track.modelTransform),
+      shapeTransforms: Object.freeze(track.shapeTransforms.map(localizer.intern)),
+    });
+    return Object.freeze({
+      schema: "csspipes-prepared-clip-chunk@1",
+      clipIndex,
+      clipId: clip.id,
+      transforms: Object.freeze(localizer.transforms),
+      placement,
+      recording,
+    });
+  });
+  return Object.freeze({ chunks: Object.freeze(chunks), localizers });
+}
+
+function buildShellTrack(track, localizers) {
+  const {
+    seedOriginTransform: _seedOriginTransform,
+    modelTransform: _modelTransform,
+    shapeTransforms: _shapeTransforms,
+    nextShapeTransforms: _nextShapeTransforms,
+    recycleShapeAssignments,
+    recycleLeafAssignments,
+    ...metadata
+  } = track;
+  const recycle = track.recycleClipIndex === null
+    ? null
+    : localizers[track.recycleClipIndex];
+  return Object.freeze({
+    ...metadata,
+    recycleShapeAssignments: recycle
+      ? remapStrided(recycleShapeAssignments, 2, [1], recycle.lookup)
+      : recycleShapeAssignments,
+    recycleLeafAssignments: recycle
+      ? remapStrided(recycleLeafAssignments, 3, [1], recycle.lookup)
+      : recycleLeafAssignments,
+    transformDomains: Object.freeze({
+      currentPlacement: "current-clip-chunk",
+      nextPlacement: "next-clip-chunk",
+      recycleAssignments: "recycle-clip-chunk",
+    }),
+  });
+}
+
+function clipMetadata(clip, descriptor) {
+  const { recording, ...metadata } = clip;
+  return Object.freeze({
+    ...metadata,
+    recording: Object.freeze({
+      schema: recording.schema,
+      contentHash: recording.contentHash,
+      sourceFrameCount: recording.sourceFrameCount,
+      reverseFrameCount: recording.reverseFrameCount,
+    }),
+    chunk: descriptor,
+  });
+}
+
+export function buildPreparedPlaybackPackage(scene) {
+  const playback = scene.playback;
+  const { chunks: preparedChunks, localizers } = buildClipChunks(playback);
+  const chunkFiles = preparedChunks.map((chunk) => {
+    const text = `${JSON.stringify(chunk)}\n`;
+    const payload = gzipSync(text, { level: 9 });
+    const hash = sha256(payload);
+    const url = `/csspipes/clips/clip-${String(chunk.clipIndex).padStart(3, "0")}-${hash.slice(0, 16)}.json.gz`;
+    return Object.freeze({
+      clipIndex: chunk.clipIndex,
+      url,
+      sha256: hash,
+      bytes: Buffer.byteLength(text),
+      storedBytes: payload.byteLength,
+      transformCount: chunk.transforms.length,
+      payload,
+    });
+  });
+  const descriptors = Object.freeze(chunkFiles.map((file) => Object.freeze({
+    clipIndex: file.clipIndex,
+    url: file.url,
+    sha256: file.sha256,
+    bytes: file.bytes,
+    storedBytes: file.storedBytes,
+    encoding: "gzip",
+    transformCount: file.transformCount,
+  })));
+  const shellTracks = Object.freeze(playback.experiments.zSeedLoop.tracks.map(
+    (track) => buildShellTrack(track, localizers),
+  ));
+  const {
+    transforms: _transforms,
+    clips: _clips,
+    experiments,
+    ...playbackMetadata
+  } = playback;
+  const shellPlayback = Object.freeze({
+    ...playbackMetadata,
+    schema: "csspipes-prebaked-playback@13",
+    preparation: Object.freeze({
+      ...playback.preparation,
+      clipStorage: "content-addressed-gzip-local-transform-chunks",
+      runtimeLookaheadClipCount: 4,
+    }),
+    clipChunks: Object.freeze({
+      schema: "csspipes-prepared-clip-chunks@1",
+      count: descriptors.length,
+      runtimeLookaheadClipCount: 4,
+      descriptors,
+      totalBytes: chunkFiles.reduce((total, file) => total + file.bytes, 0),
+      totalStoredBytes: chunkFiles.reduce(
+        (total, file) => total + file.storedBytes,
+        0,
+      ),
+      maximumBytes: Math.max(...chunkFiles.map((file) => file.bytes)),
+      maximumStoredBytes: Math.max(...chunkFiles.map((file) => file.storedBytes)),
+      maximumTransformCount: Math.max(
+        ...chunkFiles.map((file) => file.transformCount),
+      ),
+    }),
+    experiments: Object.freeze({
+      ...experiments,
+      zSeedLoop: Object.freeze({
+        ...experiments.zSeedLoop,
+        tailStorage: "inline-in-content-addressed-clip-chunks",
+        tracks: shellTracks,
+      }),
+    }),
+    clips: Object.freeze(playback.clips.map((clip, index) =>
+      clipMetadata(clip, descriptors[index]))),
+  });
+  const shellScene = Object.freeze({
+    ...scene,
+    schema: "csspipes-prebaked-scene@12",
+    playback: shellPlayback,
+  });
+  return Object.freeze({ scene: shellScene, chunks: Object.freeze(chunkFiles) });
+}

--- a/src/adapters/3dpipes/src/prepare/csspipes/preparedSnapshotAtlas.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/preparedSnapshotAtlas.mjs
@@ -1,0 +1,21 @@
+const INLINE_ATLAS = /background-image:\s*url\(&quot;(data:image\/png;base64,[A-Za-z0-9+/=]+)&quot;\);\s*/gu;
+
+export function hoistPreparedSnapshotAtlas(html, expectedWallLeafCount) {
+  if (typeof html !== "string" || !Number.isInteger(expectedWallLeafCount) ||
+      expectedWallLeafCount < 1) {
+    throw new TypeError("Prepared snapshot atlas input is invalid");
+  }
+  const matches = [...html.matchAll(INLINE_ATLAS)];
+  const atlases = new Set(matches.map((match) => match[1]));
+  if (matches.length !== expectedWallLeafCount || atlases.size !== 1) {
+    throw new Error(
+      `Prepared snapshot expected one atlas on ${expectedWallLeafCount} wall leaves`,
+    );
+  }
+  const [atlas] = atlases;
+  const sharedStyle =
+    `<style data-csspipes-prepared-shared-atlas="true">` +
+    `[data-csspipes-surface="wall"][data-csspipes-material-binding="prepared-clip"] { ` +
+    `background-image: url("${atlas}"); }</style>`;
+  return html.replace(INLINE_ATLAS, "").replace("</head>", `${sharedStyle}</head>`);
+}

--- a/src/adapters/3dpipes/src/prepare/csspipes/sceneBuilder.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/sceneBuilder.mjs
@@ -1,0 +1,171 @@
+import {
+  buildPreparedPipeMeshes,
+  CSSPIPES_CAMERA_CONTRACT,
+  CSSPIPES_HISTORICAL_PALETTE,
+  CSSPIPES_PALETTE,
+  CSSPIPES_PREBAKE_CONFIG,
+  CSSPIPES_PRODUCT_PALETTE,
+  CSSPIPES_SOURCE_VIEWPORT,
+  CSSPIPES_VIEWPORT_PROFILES,
+} from "./endlessTubes.mjs";
+import { buildPreparedClipLibrary } from "./preparedClips.mjs";
+import { buildPipeSpaceTexelLighting } from "./preparedLighting.mjs";
+import { CSSPIPES_PRODUCT } from "./slicePlan.mjs";
+
+export async function buildCssPipesScene({
+  lightingBundle = buildPipeSpaceTexelLighting(),
+} = {}) {
+  const playback = buildPreparedClipLibrary();
+  const fallbackMaterialIndices = playback.clips[0].materialIndicesByPipe;
+  const fallbackPipeColors = Object.freeze(
+    fallbackMaterialIndices.map((index) => CSSPIPES_PALETTE[index]),
+  );
+  const pipeMeshes = buildPreparedPipeMeshes(
+    playback.bandSlotsByPipe,
+    fallbackPipeColors,
+  );
+  const lighting = Object.freeze({
+    ...lightingBundle.contract,
+    fallbackMaterialIndices,
+    fallbackPipeColors,
+    clipBindings: Object.freeze({
+      schema: "csspipes-prepared-material-bindings@2",
+      selectorAttribute: "data-csspipes-material-clip",
+      bindingCount:
+        playback.clipCount * playback.pipeCount * playback.retainedBankCount,
+      runtimeRandomness: false,
+      runtimePerLeafColorWrites: 0,
+    }),
+  });
+  const preparedLeafCountPerBank = pipeMeshes.reduce(
+    (total, pipe) => total + pipe.polygons.length,
+    0,
+  );
+  const preparedLeafCount = preparedLeafCountPerBank * playback.retainedBankCount;
+  if (preparedLeafCountPerBank !== playback.wallLeafTargetCount +
+      playback.retainedEndCapLeafCount) {
+    throw new Error("cssPipes retained tube leaf bank drifted from its prepared playback");
+  }
+  return Object.freeze({
+    schema: "csspipes-prebaked-scene@11",
+    id: CSSPIPES_PRODUCT.id,
+    route: CSSPIPES_PRODUCT.route,
+    renderer: Object.freeze({
+      package: "@layoutit/polycss",
+      version: "0.2.11",
+      primitives: Object.freeze([
+        "@layoutit/polycss#createPolyCylinder",
+      ]),
+      representation: "two-retained-banks-of-continuous-shared-ring-morphed-tube-meshes",
+      morph: playback.morph,
+      seamBleed: 0,
+      merge: false,
+      meshResolution: "lossless",
+      stableDom: true,
+      runtimeTopologyWork: false,
+      runtimeDomGrowth: false,
+    }),
+    camera: Object.freeze({
+      ...CSSPIPES_CAMERA_CONTRACT,
+      sourceViewport: CSSPIPES_SOURCE_VIEWPORT,
+      responsivePresentation: Object.freeze({
+        schema: "csspipes-responsive-presentation@1",
+        selection: "host-orientation-selects-prepared-seed-pool",
+        profiles: CSSPIPES_VIEWPORT_PROFILES,
+      }),
+      ...playback.clips[0].camera.state,
+    }),
+    provenance: Object.freeze({
+      classification: "original-generative-polycss-artwork",
+      inspiration: Object.freeze(["XScreenSaver pipes.c", "Windows 3D Pipes"]),
+      productAuthority: "cssPipes authored 64-clip pre-baked library",
+      paletteAuthority: CSSPIPES_PRODUCT_PALETTE,
+      historicalPaletteRecord: CSSPIPES_HISTORICAL_PALETTE,
+      rendererAuthority: "@layoutit/polycss 0.2.11 cylinder plus @layoutit/polycss-morph 0.2.11 prepared-DOM target APIs",
+      parityClaim: false,
+    }),
+    preBake: Object.freeze({
+      ...CSSPIPES_PREBAKE_CONFIG,
+      bandSlotsPerPipe: playback.bandSlotsPerPipe,
+      bandSlotsByPipe: playback.bandSlotsByPipe,
+      bandSlotCount: playback.bandSlotCount,
+      retainedPipeRootCount: playback.retainedPipeRootCount,
+      retainedRootCount: playback.retainedRootCount,
+      retainedBankCount: playback.retainedBankCount,
+      totalRetainedRootCount: playback.totalRetainedRootCount,
+    }),
+    playback,
+    lighting,
+    pipeMeshes,
+    metrics: Object.freeze({
+      clipCount: playback.clipCount,
+      pipeMeshCount: pipeMeshes.length,
+      pipeMeshInstanceCount: pipeMeshes.length * playback.retainedBankCount,
+      bandSlotCount: playback.bandSlotCount,
+      bandSlotsPerPipe: playback.bandSlotsPerPipe,
+      bandSlotsByPipe: playback.bandSlotsByPipe,
+      retainedPipeRootCount: playback.retainedPipeRootCount,
+      retainedRootCount: playback.retainedRootCount,
+      retainedBankCount: playback.retainedBankCount,
+      totalRetainedRootCount: playback.totalRetainedRootCount,
+      preparedLogicalSegmentCount: CSSPIPES_PREBAKE_CONFIG.logicalSegmentCount,
+      preparedPolygonCount: preparedLeafCount,
+      preparedLeafCount,
+      preparedLeafCountPerBank,
+      preparedWallLeafCount: playback.wallLeafTargetCount * playback.retainedBankCount,
+      preparedEndCapLeafCount:
+        playback.retainedEndCapLeafCount * playback.retainedBankCount,
+      triangleEquivalentCount: playback.retainedBankCount * (
+        playback.wallLeafTargetCount * 2 +
+        2 * playback.endCapVerticesByPipe.reduce(
+          (total, count) => total + count - 2,
+          0,
+        )
+      ),
+      preparedTransformStates: playback.metrics.preparedTransformStates,
+      preparedRecordingFrames: playback.metrics.preparedRecordingFrames,
+      preparedLeafTransitions: playback.metrics.preparedLeafTransitions,
+      preparedRootMorphTargets: playback.totalRetainedRootCount,
+      preparedLeafMorphTargets: playback.totalLeafTargetCount,
+      preparedMorphTargets:
+        playback.totalRetainedRootCount + playback.totalLeafTargetCount,
+      preparedSnakeTailAssignments: playback.metrics.preparedSnakeTailAssignments,
+      preparedSnakeTailFrames: playback.metrics.preparedSnakeTailFrames,
+      preparedWeldedMeshVertices: playback.metrics.preparedWeldedMeshVertices,
+      preparedWeldedMeshPolygons: playback.metrics.preparedWeldedMeshPolygons,
+      preparedWeldedJoints: playback.metrics.preparedWeldedJoints,
+      preparedEndCapPolygons: playback.metrics.preparedEndCapPolygons,
+      uniformBandSlotCount: playback.metrics.uniformBandSlotCount,
+      packedBandSlotSavings: playback.metrics.packedBandSlotSavings,
+      packedWallLeafSavings: playback.metrics.packedWallLeafSavings,
+      mergedEndCapLeafSavings: playback.metrics.mergedEndCapLeafSavings,
+      totalSurfaceLeafSavings: playback.metrics.totalSurfaceLeafSavings,
+      minBandsPerClip: playback.metrics.minBandsPerClip,
+      maxBandsPerClip: playback.metrics.maxBandsPerClip,
+      averageBandsPerClip: playback.metrics.averageBandsPerClip,
+      preparedLightingFields: lighting.faces.length,
+      preparedMaterialBindings: lighting.clipBindings.bindingCount,
+      preparedMaterialDuplicateCount: playback.metrics.preparedMaterialDuplicateCount,
+      minimumPreparedMaterialOklabDistance:
+        playback.metrics.minimumPreparedMaterialOklabDistance,
+      minimumPreparedScreenOccupiedCellCount:
+        playback.metrics.minimumPreparedScreenOccupiedCellCount,
+      runtimePolygonConstructionCount: 0,
+      runtimePathGeneration: false,
+      runtimeGeometrySemantics: false,
+      runtimeDomGrowth: false,
+    }),
+    warnings: Object.freeze([
+      "cssPipes is pipes.c and Windows 3D Pipes inspired artwork, not a behavioral or visual port",
+      "each prepared clip builds every complete connected tube first and records its tip-to-seed retraction",
+      "the optional Snake experiment replays inline prepared tail rows in one retained bank while the next prepared head grows in the other",
+      "preparation groups tubes by fixed facet family, then ranks each family by band complexity into seven retained roots",
+      "the browser replays those retained-leaf rows in reverse and has no straight, turn, or elbow operation",
+      "every adjacent tube band shares the same prepared four-, five-, six-, or seven-vertex ring and every leaf matrix uses seamBleed 0",
+      "projective tube quads explicitly zero both seamBleed and the projective guard bleed fallback",
+      "each PolyCSS cylinder cap fan is merged during preparation into one solid matching-facet leaf with the existing polygon fallback",
+      "each pipe retains one fixed start-cap leaf and one prepared moving tip-cap leaf",
+      "every clip uses the same fixed seven-color product palette, including authored amber, cool slate, and vivid purple, bound by source-pipe identity through static prepared CSS",
+    ]),
+  });
+}

--- a/src/adapters/3dpipes/src/prepare/csspipes/slicePlan.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/slicePlan.mjs
@@ -1,0 +1,8 @@
+export const CSSPIPES_PRODUCT = Object.freeze({
+  id: "pipes-clips",
+  route: "/",
+  visibleFamilies: Object.freeze(["tube"]),
+  merge: false,
+  meshResolution: "lossless",
+  stableDom: true,
+});

--- a/src/adapters/3dpipes/src/prepare/csspipes/weldedTubeMesh.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/weldedTubeMesh.mjs
@@ -1,0 +1,478 @@
+import { createHash } from "node:crypto";
+import {
+  buildPolyMeshTransform,
+  computeTextureAtlasPlanPublic,
+  DEFAULT_TILE,
+  formatMatrix3d,
+} from "@layoutit/polycss";
+import { CSSPIPES_PREBAKE_CONFIG } from "./endlessTubes.mjs";
+
+const clean = (value) => Math.abs(value) < 1e-12 ? 0 : value;
+const ZERO_PROJECTIVE_BLEED_GUARDS = Object.freeze({ bleed: 0 });
+const vector = (values) => Object.freeze(values.map(clean));
+const add = (left, right) => vector(left.map((value, axis) => value + right[axis]));
+const subtract = (left, right) => vector(left.map((value, axis) => value - right[axis]));
+const scale = (value, amount) => vector(value.map((axis) => axis * amount));
+const dot = (left, right) => left.reduce(
+  (total, value, axis) => total + value * right[axis],
+  0,
+);
+const cross = (left, right) => vector([
+  left[1] * right[2] - left[2] * right[1],
+  left[2] * right[0] - left[0] * right[2],
+  left[0] * right[1] - left[1] * right[0],
+]);
+const sameVector = (left, right) => left.every(
+  (value, axis) => Math.abs(value - right[axis]) < 1e-8,
+);
+
+function localPoint(cell, origin) {
+  return vector(cell.map((value, axis) =>
+    (value - origin[axis]) * CSSPIPES_PREBAKE_CONFIG.stepLength));
+}
+
+function initialFrame(direction) {
+  const u = direction[2] === 0
+    ? vector([0, 0, 1])
+    : vector([1, 0, 0]);
+  const v = cross(direction, u);
+  return Object.freeze({ u, v, direction: vector(direction) });
+}
+
+function preparedFrame(frame) {
+  if (!frame || !Array.isArray(frame.u) || !Array.isArray(frame.v) ||
+      !Array.isArray(frame.direction) || frame.u.length !== 3 ||
+      frame.v.length !== 3 || frame.direction.length !== 3) {
+    throw new TypeError("Prepared cssPipes tube frame is incomplete");
+  }
+  return Object.freeze({
+    u: vector(frame.u),
+    v: vector(frame.v),
+    direction: vector(frame.direction),
+  });
+}
+
+function quarterTurn(value, normal) {
+  return add(cross(normal, value), scale(normal, dot(normal, value)));
+}
+
+function transportFrame(frame, nextDirectionValue) {
+  const nextDirection = vector(nextDirectionValue);
+  if (sameVector(frame.direction, nextDirection)) return frame;
+  const normal = cross(frame.direction, nextDirection);
+  if (dot(frame.direction, nextDirection) !== 0 || Math.hypot(...normal) !== 1) {
+    throw new Error("Prepared cssPipes path junction is not a right-angle turn");
+  }
+  return Object.freeze({
+    u: quarterTurn(frame.u, normal),
+    v: quarterTurn(frame.v, normal),
+    direction: nextDirection,
+  });
+}
+
+export function buildPreparedTransportedFrames(segments, startingFrame = null) {
+  if (!Array.isArray(segments) || segments.length === 0) {
+    throw new TypeError("Prepared cssPipes frame transport requires path segments");
+  }
+  let frame = startingFrame
+    ? preparedFrame(startingFrame)
+    : initialFrame(segments[0].direction.delta);
+  if (!sameVector(frame.direction, segments[0].direction.delta)) {
+    throw new Error("Prepared cssPipes starting frame does not follow its full pipe");
+  }
+  const frames = [];
+  for (const segment of segments) {
+    frame = transportFrame(frame, segment.direction.delta);
+    frames.push(frame);
+  }
+  return Object.freeze(frames);
+}
+
+function ringFactory(vertices, radialSegments) {
+  return (id, center, frame) => {
+    const ringVertices = Array.from(
+      { length: radialSegments },
+      (_, side) => {
+        const angle = side * Math.PI * 2 / radialSegments;
+        return add(center, add(
+          scale(frame.u, CSSPIPES_PREBAKE_CONFIG.tubeRadius * Math.cos(angle)),
+          scale(frame.v, CSSPIPES_PREBAKE_CONFIG.tubeRadius * Math.sin(angle)),
+        ));
+      },
+    );
+    const vertexIndices = ringVertices.map((vertexValue) => {
+      const index = vertices.length;
+      vertices.push(vertexValue);
+      return index;
+    });
+    return Object.freeze({
+      id,
+      center,
+      frame,
+      vertices: Object.freeze(ringVertices),
+      vertexIndices: Object.freeze(vertexIndices),
+    });
+  };
+}
+
+function bandPolygons(band, pipeIndex, radialSegments) {
+  return Object.freeze(Array.from(
+    { length: radialSegments },
+    (_, side) => {
+      const next = (side + 1) % radialSegments;
+      return Object.freeze({
+        id: `${band.id}-side-${String(side).padStart(2, "0")}`,
+        pipe: pipeIndex,
+        band: band.index,
+        side,
+        vertexIndices: Object.freeze([
+          band.startRing.vertexIndices[side],
+          band.startRing.vertexIndices[next],
+          band.endRing.vertexIndices[next],
+          band.endRing.vertexIndices[side],
+        ]),
+      });
+    },
+  ));
+}
+
+function capPolygons(ring, pipeIndex, cap) {
+  const vertexIndices = cap === "tip"
+    ? [...ring.vertexIndices]
+    : [...ring.vertexIndices].reverse();
+  return Object.freeze([Object.freeze({
+    id: `pipe-${pipeIndex}-${cap}-cap`,
+    pipe: pipeIndex,
+    cap,
+    polygon: 0,
+    ring,
+    vertexIndices: Object.freeze(vertexIndices),
+  })]);
+}
+
+export function buildWeldedPipeMesh(
+  runs,
+  preparedCenter,
+  pipeIndex = 0,
+  options = {},
+) {
+  if (!Array.isArray(runs) || runs.length === 0) {
+    throw new TypeError("Prepared welded cssPipes mesh requires maximal runs");
+  }
+  if (!Array.isArray(preparedCenter) || preparedCenter.length !== 3) {
+    throw new TypeError("Prepared welded cssPipes mesh requires a three-axis center");
+  }
+
+  const sourceOrigin = vector(runs[0].start);
+  const rootPosition = vector(sourceOrigin.map((value, axis) =>
+    (value - preparedCenter[axis]) * CSSPIPES_PREBAKE_CONFIG.stepLength));
+  const rootTransform = buildPolyMeshTransform({ position: rootPosition }) ?? "none";
+  const radialSegments = CSSPIPES_PREBAKE_CONFIG.radialSegmentsByPipe[pipeIndex];
+  const vertices = [];
+  const makeRing = ringFactory(vertices, radialSegments);
+  const bands = [];
+  const welds = [];
+  let frame = options.initialFrame
+    ? preparedFrame(options.initialFrame)
+    : initialFrame(runs[0].direction.delta);
+  if (!sameVector(frame.direction, runs[0].direction.delta)) {
+    throw new Error("Prepared cssPipes sliced mesh lost its full-pipe frame");
+  }
+  let startRing = makeRing(
+    `pipe-${pipeIndex}-ring-000`,
+    localPoint(runs[0].start, sourceOrigin),
+    frame,
+  );
+  const firstRing = startRing;
+  let ringIndex = 1;
+
+  const appendBand = (
+    nextRing,
+    sourceRunIndex,
+    preparedCenterlineLength = Math.hypot(...subtract(nextRing.center, startRing.center)),
+  ) => {
+    const index = bands.length;
+    const centerlineLength = preparedCenterlineLength;
+    if (!(centerlineLength > 0)) {
+      throw new Error("Prepared welded cssPipes tube band must have positive length");
+    }
+    const mutable = {
+      id: `pipe-${pipeIndex}-band-${String(index).padStart(3, "0")}`,
+      index,
+      role: "tube-band",
+      sourceRunIndex,
+      centerlineLength,
+      startRing,
+      endRing: nextRing,
+    };
+    mutable.polygons = bandPolygons(mutable, pipeIndex, radialSegments);
+    const band = Object.freeze(mutable);
+    if (bands.length > 0) {
+      const previous = bands.at(-1);
+      if (previous.endRing !== band.startRing) {
+        throw new Error("Prepared cssPipes adjacent tube bands lost shared ring identity");
+      }
+      welds.push(Object.freeze({
+        ringId: band.startRing.id,
+        leftBandId: previous.id,
+        rightBandId: band.id,
+      }));
+    }
+    bands.push(band);
+    startRing = nextRing;
+    return band;
+  };
+
+  for (let runIndex = 0; runIndex < runs.length; runIndex += 1) {
+    const run = runs[runIndex];
+    if (!sameVector(frame.direction, run.direction.delta)) {
+      throw new Error("Prepared cssPipes transported tube frame drifted from its path");
+    }
+    const hasNext = runIndex < runs.length - 1;
+    const corner = localPoint(run.end, sourceOrigin);
+    const runEnd = hasNext
+      ? subtract(corner, scale(frame.direction, CSSPIPES_PREBAKE_CONFIG.turnRadius))
+      : corner;
+    const runEndRing = makeRing(
+      `pipe-${pipeIndex}-ring-${String(ringIndex).padStart(3, "0")}`,
+      runEnd,
+      frame,
+    );
+    ringIndex += 1;
+    appendBand(runEndRing, runIndex);
+    if (!hasNext) continue;
+
+    const nextDirection = vector(runs[runIndex + 1].direction.delta);
+    const nextFrame = transportFrame(frame, nextDirection);
+    const nextCenter = add(
+      corner,
+      scale(nextDirection, CSSPIPES_PREBAKE_CONFIG.turnRadius),
+    );
+    const nextRing = makeRing(
+      `pipe-${pipeIndex}-ring-${String(ringIndex).padStart(3, "0")}`,
+      nextCenter,
+      nextFrame,
+    );
+    ringIndex += 1;
+    appendBand(
+      nextRing,
+      runIndex,
+      CSSPIPES_PREBAKE_CONFIG.turnRadius * Math.PI / 2,
+    );
+    frame = nextFrame;
+  }
+
+  const finalRing = startRing;
+  const caps = Object.freeze([
+    Object.freeze({
+      id: `pipe-${pipeIndex}-start-cap`,
+      cap: "start",
+      ring: firstRing,
+      polygons: capPolygons(firstRing, pipeIndex, "start"),
+    }),
+    Object.freeze({
+      id: `pipe-${pipeIndex}-tip-cap`,
+      cap: "tip",
+      ring: finalRing,
+      polygons: capPolygons(finalRing, pipeIndex, "tip"),
+    }),
+  ]);
+  const wallPolygons = bands.flatMap((band) => band.polygons);
+  const endCapPolygons = caps.flatMap((cap) => cap.polygons);
+  const polygons = [...wallPolygons, ...endCapPolygons];
+  const reverseRetractionBandIds = Object.freeze(bands.map((band) => band.id).reverse());
+  if (bands.length !== runs.length * 2 - 1 || welds.length !== bands.length - 1 ||
+      wallPolygons.length !== bands.length * radialSegments ||
+      endCapPolygons.length !== 2 ||
+      endCapPolygons.some((polygon) =>
+        polygon.vertexIndices.length !== radialSegments)) {
+    throw new Error("Prepared cssPipes welded tube census drifted");
+  }
+  const hash = createHash("sha256").update(JSON.stringify({
+    rootPosition,
+    vertices,
+    polygons: polygons.map((polygon) => polygon.vertexIndices),
+    bands: bands.map((band) => [
+      band.startRing.id,
+      band.endRing.id,
+      band.centerlineLength,
+    ]),
+    caps: caps.map((cap) => cap.polygons.map((polygon) => polygon.vertexIndices)),
+    reverseRetractionBandIds,
+  })).digest("hex");
+  return Object.freeze({
+    schema: "csspipes-welded-pipe-mesh@3",
+    pipe: pipeIndex,
+    radialSegments,
+    sourceOrigin,
+    preparedCenter: vector(preparedCenter),
+    rootPosition,
+    rootTransform,
+    vertices: Object.freeze(vertices),
+    polygons: Object.freeze(polygons),
+    bands: Object.freeze(bands),
+    caps,
+    welds: Object.freeze(welds),
+    reverseRetractionBandIds,
+    hash,
+  });
+}
+
+function ringVerticesAtProgress(band, progress) {
+  return band.endRing.vertices.map((vertexValue, vertexIndex) =>
+    vector(vertexValue.map((value, axis) =>
+      band.startRing.vertices[vertexIndex][axis] +
+      (value - band.startRing.vertices[vertexIndex][axis]) * progress)));
+}
+
+function bandPolygonAtInterval(
+  band,
+  side,
+  startProgress,
+  endProgress,
+  options = {},
+) {
+  const radialSegments = band.startRing.vertices.length;
+  const next = (side + 1) % radialSegments;
+  const start = ringVerticesAtProgress(band, startProgress);
+  const end = ringVerticesAtProgress(band, endProgress);
+  const vertices = [
+    start[side],
+    start[next],
+    end[next],
+    end[side],
+  ];
+  const textureVertices = options.rotateTextureHalfTurn
+    ? [...vertices.slice(2), ...vertices.slice(0, 2)]
+    : vertices;
+  return Object.freeze({
+    color: "#ffffff",
+    vertices: Object.freeze(textureVertices),
+  });
+}
+
+function ringAtProgress(band, progress) {
+  const u = vector(band.endRing.frame.u.map((value, axis) =>
+    band.startRing.frame.u[axis] + (value - band.startRing.frame.u[axis]) * progress));
+  const v = vector(band.endRing.frame.v.map((value, axis) =>
+    band.startRing.frame.v[axis] + (value - band.startRing.frame.v[axis]) * progress));
+  const directionValue = cross(u, v);
+  const directionLength = Math.hypot(...directionValue);
+  if (!(directionLength > 0)) {
+    throw new Error("Prepared cssPipes cap frame became singular");
+  }
+  return Object.freeze({
+    center: vector(band.endRing.center.map((value, axis) =>
+      band.startRing.center[axis] + (value - band.startRing.center[axis]) * progress)),
+    frame: Object.freeze({
+      u,
+      v,
+      direction: scale(directionValue, 1 / directionLength),
+    }),
+    vertices: Object.freeze(band.endRing.vertices.map((vertexValue, vertexIndex) =>
+      vector(vertexValue.map((value, axis) =>
+        band.startRing.vertices[vertexIndex][axis] +
+        (value - band.startRing.vertices[vertexIndex][axis]) * progress)))),
+  });
+}
+
+function preparedCapRootTransform(ring) {
+  const { u, v, direction } = ring.frame;
+  return formatMatrix3d([
+    v[1], v[0], v[2], 0,
+    u[1], u[0], u[2], 0,
+    direction[1], direction[0], direction[2], 0,
+    ring.center[1] * DEFAULT_TILE,
+    ring.center[0] * DEFAULT_TILE,
+    ring.center[2] * DEFAULT_TILE,
+    1,
+  ].join(","), 8);
+}
+
+export function buildPreparedStartCapRootTransform(mesh) {
+  const ring = mesh?.caps?.find((cap) => cap.cap === "start")?.ring;
+  if (!ring) throw new TypeError("Prepared cssPipes start cap ring is missing");
+  return preparedCapRootTransform(ring);
+}
+
+export function buildPreparedTipCapRootTransform(mesh, bandIndex, progress) {
+  const band = mesh?.bands?.[bandIndex];
+  if (!band || !Number.isFinite(progress) || progress <= 0 || progress > 1) {
+    throw new RangeError("Prepared cssPipes tip-cap progress must be within (0, 1]");
+  }
+  return preparedCapRootTransform(ringAtProgress(band, progress));
+}
+
+function assertPlanarBandPolygon(polygon, bandIndex, side) {
+  const [a, b, c, d] = polygon.vertices;
+  const ab = subtract(b, a);
+  const ac = subtract(c, a);
+  const ad = subtract(d, a);
+  const normal = cross(ab, ac);
+  const normalLength = Math.hypot(...normal);
+  const distance = normalLength > 1e-12
+    ? Math.abs(dot(normal, ad)) / normalLength
+    : Number.POSITIVE_INFINITY;
+  if (!Number.isFinite(distance) || distance > 1e-8) {
+    throw new Error(
+      `Prepared cssPipes tube band ${bandIndex} side ${side} is not exactly coplanar`,
+    );
+  }
+}
+
+export function buildPreparedBandLeafTransforms(
+  mesh,
+  bandIndex,
+  progress,
+  options = {},
+) {
+  return buildPreparedBandIntervalLeafTransforms(
+    mesh,
+    bandIndex,
+    0,
+    progress,
+    options,
+  );
+}
+
+export function buildPreparedBandIntervalLeafTransforms(
+  mesh,
+  bandIndex,
+  startProgress,
+  endProgress,
+  options = {},
+) {
+  const band = mesh?.bands?.[bandIndex];
+  if (!band || !Number.isFinite(startProgress) || !Number.isFinite(endProgress) ||
+      startProgress < 0 || startProgress >= 1 ||
+      endProgress <= 0 || endProgress > 1 || startProgress >= endProgress) {
+    throw new RangeError(
+      "Prepared cssPipes tube-band interval must satisfy 0 <= start < end <= 1",
+    );
+  }
+  return Object.freeze(Array.from(
+    { length: mesh.radialSegments },
+    (_, side) => {
+      const polygon = bandPolygonAtInterval(
+        band,
+        side,
+        startProgress,
+        endProgress,
+        options,
+      );
+      assertPlanarBandPolygon(polygon, bandIndex, side);
+      const plan = computeTextureAtlasPlanPublic(
+        polygon,
+        side,
+        { seamBleed: 0 },
+        ZERO_PROJECTIVE_BLEED_GUARDS,
+      );
+      if (!plan || typeof plan.projectiveMatrix !== "string" || plan.bleedRatio !== 0) {
+        throw new Error(
+          `PolyCSS tube band ${bandIndex} side ${side} lost its zero-bleed projective plan`,
+        );
+      }
+      return formatMatrix3d(plan.projectiveMatrix, 8);
+    },
+  ));
+}

--- a/src/adapters/3dpipes/src/prepare/csspipes/writeManifest.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/writeManifest.mjs
@@ -1,0 +1,90 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { gzipSync } from "node:zlib";
+import {
+  CSSPIPES_MANIFEST_PATH,
+  CSSPIPES_PREPARE_SCENE_PATH,
+  CSSPIPES_PREPARE_SNAPSHOT_PATH,
+  CSSPIPES_SCENE_PATH,
+  CSSPIPES_SNAPSHOT_PATH,
+} from "./paths.mjs";
+
+const sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+export async function writeCssPipesManifest(scene, snapshotMetrics) {
+  const [prepareSceneBytes, snapshotBytes] = await Promise.all([
+    readFile(CSSPIPES_PREPARE_SCENE_PATH),
+    readFile(CSSPIPES_PREPARE_SNAPSHOT_PATH),
+  ]);
+  const prepareScene = JSON.parse(prepareSceneBytes.toString("utf8"));
+  if (!Array.isArray(prepareScene.pipeMeshes) ||
+      prepareScene.pipeMeshes.length !== prepareScene.playback?.pipeCount) {
+    throw new Error("Prepared cssPipes snapshot geometry is incomplete");
+  }
+  const { pipeMeshes: _prepareOnlyPipeMeshes, ...runtimeScene } = prepareScene;
+  const runtimeSceneBytes = Buffer.from(`${JSON.stringify(runtimeScene)}\n`);
+  const compressedScene = gzipSync(runtimeSceneBytes, { level: 9 });
+  const compressedSnapshot = gzipSync(snapshotBytes, { level: 9 });
+  const manifest = {
+    schema: "csspipes-manifest@1",
+    status: "ready",
+    title: "cssPipes — prepared PolyCSS pipe clips",
+    scaffoldMode: "original-pipes-inspired-generative-artwork",
+    artifactMode: "prepared-polycss-snapshot-plus-reverse-recordings",
+    generatedAssetRoot: "/csspipes/",
+    defaultRoute: "/",
+    defaultScene: scene.id,
+    provenance: scene.provenance,
+    renderer: scene.renderer,
+    scenes: [{
+      id: scene.id,
+      label: "32 desktop + 32 mobile prepared 3D pipe clips",
+      sceneUrl: "/csspipes/scenes/pipes-clips.scene.json.gz",
+      sceneSha256: sha256(compressedScene),
+      snapshotUrl: "/csspipes/scenes/pipes-clips.polycss.html.gz",
+      snapshotSha256: sha256(compressedSnapshot),
+      metrics: {
+        preparedLeafCount: scene.metrics.preparedLeafCount,
+        retainedRootCount: scene.metrics.retainedRootCount,
+        clipCount: scene.metrics.clipCount,
+        mountedLeafCount: snapshotMetrics.mountedLeaves,
+        snapshotPipeRootCount: snapshotMetrics.pipeRootCount,
+        snapshotShapeTargetCount: snapshotMetrics.shapeTargetCount,
+        snapshotLeafTargetCount: snapshotMetrics.leafTargetCount,
+        preparedBandSlotCount: snapshotMetrics.bandSlotCount,
+        preparedMaterialBindingCount: snapshotMetrics.materialBindingCount,
+        atlasPageCount: 1,
+        unresolvedTextureCount: 0,
+      },
+      warnings: scene.warnings,
+    }],
+  };
+  const text = `${JSON.stringify(manifest, null, 2)}\n`;
+  const forbiddenLocalPaths = [
+    ["", "Users", ""].join("/"),
+    ["file:", "", ""].join("/"),
+  ];
+  if (forbiddenLocalPaths.some((token) => text.includes(token))) {
+    throw new Error("cssPipes manifest contains a local absolute path");
+  }
+  await mkdir(dirname(CSSPIPES_MANIFEST_PATH), { recursive: true });
+  await Promise.all([
+    writeCompressed(CSSPIPES_SCENE_PATH, compressedScene),
+    writeCompressed(CSSPIPES_SNAPSHOT_PATH, compressedSnapshot),
+  ]);
+  const temporary = `${CSSPIPES_MANIFEST_PATH}.tmp`;
+  await writeFile(temporary, text);
+  await rename(temporary, CSSPIPES_MANIFEST_PATH);
+  await Promise.all([
+    unlink(CSSPIPES_PREPARE_SCENE_PATH),
+    unlink(CSSPIPES_PREPARE_SNAPSHOT_PATH),
+  ]);
+  return Object.freeze({ manifest, text, sha256: sha256(text) });
+}
+
+async function writeCompressed(path, bytes) {
+  const temporary = `${path}.tmp`;
+  await writeFile(temporary, bytes);
+  await rename(temporary, path);
+}

--- a/src/adapters/3dpipes/src/prepare/csspipes/writeScene.mjs
+++ b/src/adapters/3dpipes/src/prepare/csspipes/writeScene.mjs
@@ -1,0 +1,44 @@
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+import { buildPreparedPlaybackPackage } from "./preparedPlaybackChunks.mjs";
+import { CSSPIPES_CLIPS_ROOT, CSSPIPES_PREPARE_SCENE_PATH } from "./paths.mjs";
+
+function serializeCssPipesScene(scene) {
+  const text = `${JSON.stringify(scene)}\n`;
+  const forbiddenLocalPaths = [
+    ["", "Users", ""].join("/"),
+    ["file:", "", ""].join("/"),
+  ];
+  if (forbiddenLocalPaths.some((token) => text.includes(token))) {
+    throw new Error("Prepared cssPipes scene contains a local absolute path");
+  }
+  return text;
+}
+
+export async function writeCssPipesScene(scene, outputPath = CSSPIPES_PREPARE_SCENE_PATH) {
+  const prepared = buildPreparedPlaybackPackage(scene);
+  const text = serializeCssPipesScene(prepared.scene);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await mkdir(CSSPIPES_CLIPS_ROOT, { recursive: true });
+  await Promise.all(prepared.chunks.map(async (chunk) => {
+    const path = resolve(CSSPIPES_CLIPS_ROOT, basename(chunk.url));
+    const temporaryChunk = `${path}.tmp`;
+    await writeFile(temporaryChunk, chunk.payload);
+    await rename(temporaryChunk, path);
+  }));
+  const temporary = `${outputPath}.tmp`;
+  await writeFile(temporary, text);
+  await rename(temporary, outputPath);
+  return Object.freeze({
+    outputPath,
+    bytes: Buffer.byteLength(text),
+    text,
+    scene: prepared.scene,
+    chunkCount: prepared.chunks.length,
+    chunkBytes: prepared.chunks.reduce((total, chunk) => total + chunk.bytes, 0),
+    storedChunkBytes: prepared.chunks.reduce(
+      (total, chunk) => total + chunk.storedBytes,
+      0,
+    ),
+  });
+}

--- a/src/adapters/3dpipes/tools/polycss-snapshot-page.html
+++ b/src/adapters/3dpipes/tools/polycss-snapshot-page.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>cssPipes prepared PolyCSS snapshot</title>
+    <style>
+      html, body, #scene { width: 100%; height: 100%; margin: 0; overflow: hidden; background: #05070a; }
+      #scene { position: relative; }
+    </style>
+  </head>
+  <body>
+    <main id="scene" aria-label="cssPipes prepared PolyCSS snapshot scene"></main>
+    <script type="module" src="/tools/polycss-snapshot-page.mjs"></script>
+  </body>
+</html>

--- a/src/adapters/3dpipes/tools/polycss-snapshot-page.mjs
+++ b/src/adapters/3dpipes/tools/polycss-snapshot-page.mjs
@@ -1,0 +1,268 @@
+import {
+  collectPolyRenderStats,
+  createPolyPerspectiveCamera,
+  createPolyScene,
+  exportPolySceneSnapshot,
+} from "@layoutit/polycss";
+import { buildPreparedMaterialBindings } from
+  "../src/prepare/csspipes/preparedMaterialBindings.mjs";
+import { hoistPreparedSnapshotAtlas } from
+  "../src/prepare/csspipes/preparedSnapshotAtlas.mjs";
+
+const host = document.querySelector("#scene");
+const sceneUrl = new URLSearchParams(location.search).get("sceneUrl");
+
+main().catch((error) => {
+  globalThis.__cssPipesSnapshot = {
+    status: "error",
+    error: error?.stack || error?.message || String(error),
+  };
+});
+
+function rootStyle(element, visible = true) {
+  Object.assign(element.style, {
+    position: "absolute",
+    left: "0",
+    top: "0",
+    width: "0",
+    height: "0",
+    transformOrigin: "0 0 0",
+    transformStyle: "preserve-3d",
+    visibility: visible ? "visible" : "hidden",
+  });
+}
+
+function applySpaceTexels(element, lighting, fallbackMaterialIndices) {
+  for (const face of element.querySelectorAll("[data-csspipes-face]")) {
+    const pipe = Number(face.getAttribute("data-csspipes-pipe"));
+    const materialIndex = fallbackMaterialIndices?.[pipe];
+    const color = lighting.materialColors?.[materialIndex];
+    const materialOrigin = lighting.faces?.[
+      materialIndex * lighting.materialFieldStride
+    ];
+    if (!Number.isInteger(materialIndex) || typeof color !== "string" ||
+        materialOrigin?.materialIndex !== materialIndex || materialOrigin?.side !== 0) {
+      throw new Error(`Prepared fallback material is missing for pipe ${pipe}`);
+    }
+    if (face.getAttribute("data-csspipes-surface") === "end-cap") {
+      Object.assign(face.style, {
+        color: `var(--csspipes-material-color, ${color})`,
+        backfaceVisibility: "visible",
+        transition: "none",
+      });
+      face.dataset.csspipesCapColor = color;
+      face.dataset.csspipesMaterialBinding = "prepared-clip";
+      continue;
+    }
+    const side = Number(face.getAttribute("data-csspipes-cylinder-side"));
+    const field = lighting.faces[
+      materialIndex * lighting.materialFieldStride + side
+    ];
+    if (!field || field.materialIndex !== materialIndex || field.side !== side) {
+      throw new Error(
+        `Prepared space-texel field is missing for material ${materialIndex} side ${side}`,
+      );
+    }
+    Object.assign(face.style, {
+      backgroundImage: `url("${lighting.assetUrl}")`,
+      backgroundColor: "transparent",
+      backgroundRepeat: "no-repeat",
+      backgroundPositionX:
+        `calc(var(--csspipes-material-offset, ${materialOrigin.backgroundPositionX}) - ` +
+        `${side * lighting.leafWidth}px)`,
+      backgroundPositionY: "0px",
+      backgroundSize: lighting.backgroundSize,
+      backfaceVisibility: "visible",
+      transition: "none",
+    });
+    face.dataset.csspipesMaterialBinding = "prepared-clip";
+  }
+}
+
+function preparePlaybackLeaves(pipeRoot, pipe, bank, playback) {
+  const bandSlotsPerPipe = playback.bandSlotsByPipe?.[pipe];
+  const radialSegments = playback.radialSegmentsByPipe?.[pipe];
+  const wallLeavesPerPipe = bandSlotsPerPipe * radialSegments;
+  const expected = playback.leavesPerPipeByPipe?.[pipe];
+  const leafIndexOffset = playback.pipeLeafOffsets?.[pipe];
+  if (!Number.isInteger(bandSlotsPerPipe) || bandSlotsPerPipe < 1 ||
+      !Number.isInteger(wallLeavesPerPipe) ||
+      !Number.isInteger(radialSegments) || radialSegments < 3 ||
+      expected !== wallLeavesPerPipe + 2 ||
+      !Number.isInteger(leafIndexOffset) || leafIndexOffset < 0) {
+    throw new Error("Prepared continuous tube cap-target census drifted");
+  }
+  const wallLeaves = [
+    ...pipeRoot.querySelectorAll('[data-csspipes-surface="wall"]'),
+  ];
+  if (wallLeaves.length !== wallLeavesPerPipe) {
+    throw new Error("Prepared continuous tube wall-leaf count drifted");
+  }
+  const capRoots = ["start", "tip"].map((cap, capIndex) => {
+    const faces = [
+      ...pipeRoot.querySelectorAll(`[data-csspipes-surface="end-cap"][data-csspipes-cap="${cap}"]`),
+    ];
+    if (faces.length !== playback.endCapLeavesPerEnd) {
+      throw new Error(`Prepared continuous tube ${cap} cap census drifted`);
+    }
+    const capRoot = document.createElement("div");
+    capRoot.dataset.csspipesCapRoot = cap;
+    capRoot.dataset.csspipesPipe = String(pipe);
+    capRoot.dataset.csspipesBankIndex = String(bank);
+    capRoot.dataset.csspipesLeafSlot = String(wallLeavesPerPipe + capIndex);
+    capRoot.dataset.csspipesTopology = "shared-ring-end-cap";
+    capRoot.dataset.csspipesVisible = "false";
+    rootStyle(capRoot, false);
+    for (const face of faces) {
+      face.dataset.csspipesVisible = "true";
+      capRoot.append(face);
+    }
+    pipeRoot.append(capRoot);
+    return capRoot;
+  });
+  const leaves = [...wallLeaves, ...capRoots].sort((left, right) =>
+    Number(left.getAttribute("data-csspipes-leaf-slot")) -
+    Number(right.getAttribute("data-csspipes-leaf-slot")));
+  if (leaves.length !== expected) throw new Error("Prepared continuous tube leaf count drifted");
+  for (let localIndex = 0; localIndex < leaves.length; localIndex += 1) {
+    const leaf = leaves[localIndex];
+    if (Number(leaf.getAttribute("data-csspipes-leaf-slot")) !== localIndex) {
+      throw new Error("Prepared continuous tube leaf slots are not contiguous");
+    }
+    leaf.dataset.csspipesLeafIndex = String(leafIndexOffset + localIndex);
+    leaf.dataset.csspipesBankIndex = String(bank);
+    leaf.dataset.csspipesMorph = "prepared-continuous-tube-retraction";
+    if (leaf.getAttribute("data-csspipes-surface") === "wall") {
+      leaf.dataset.csspipesSeamBleed = "0";
+    }
+    leaf.dataset.csspipesVisible = "false";
+    leaf.style.visibility = "hidden";
+  }
+}
+
+async function main() {
+  if (!(host instanceof HTMLElement) || !sceneUrl?.startsWith("/csspipes/")) {
+    throw new Error("cssPipes snapshot page requires a generated sceneUrl");
+  }
+  const response = await fetch(sceneUrl, { cache: "no-store" });
+  if (!response.ok) throw new Error(`Prepared scene request failed (${response.status})`);
+  const sceneData = await response.json();
+  if (sceneData.schema !== "csspipes-prebaked-scene@12" ||
+      sceneData.playback?.schema !== "csspipes-prebaked-playback@13" ||
+      sceneData.pipeMeshes?.length !== sceneData.playback.pipeCount) {
+    throw new Error("Prepared cssPipes continuous-tube scene is invalid");
+  }
+  const lightingResponse = await fetch(sceneData.lighting.assetUrl, { cache: "no-store" });
+  if (!lightingResponse.ok) throw new Error("Prepared cssPipes space-texel atlas is unavailable");
+  const camera = createPolyPerspectiveCamera({
+    perspective: sceneData.camera.perspective,
+    zoom: sceneData.camera.zoom,
+    rotX: sceneData.camera.rotX,
+    rotY: sceneData.camera.rotY,
+    target: sceneData.camera.target,
+    distance: sceneData.camera.distance,
+  });
+  const scene = createPolyScene(host, {
+    camera,
+    ambientLight: { color: "#ffffff", intensity: Math.PI },
+    directionalLight: { direction: [0, -1, 1], color: "#ffffff", intensity: 0 },
+    textureLighting: "baked",
+    textureQuality: 1,
+    textureLeafSizing: "canonical",
+    textureBackend: "atlas",
+    textureProjection: "affine",
+    seamBleed: 0,
+    autoCenter: false,
+  });
+  try {
+    const handles = Array.from(
+      { length: sceneData.playback.retainedBankCount },
+      (_, bank) => sceneData.pipeMeshes.map((pipe) => ({
+        bank,
+        pipe,
+        mesh: scene.add({
+          polygons: pipe.polygons.map((face) => face.polygon),
+          objectUrls: [], warnings: [], dispose() {},
+        }, {
+          id: `${pipe.id}-bank-${bank}`,
+          merge: false,
+          meshResolution: "lossless",
+          stableDom: true,
+          excludeFromAutoCenter: true,
+        }),
+      })),
+    ).flat();
+    const sceneRoot = host.querySelector(".polycss-scene");
+    if (!(sceneRoot instanceof HTMLElement)) throw new Error("PolyCSS scene root was not mounted");
+    const playbackRoot = document.createElement("div");
+    playbackRoot.dataset.csspipesPlaybackRoot = "true";
+    rootStyle(playbackRoot);
+    playbackRoot.style.opacity = "1";
+    sceneRoot.append(playbackRoot);
+
+    for (const { bank, pipe, mesh } of handles) {
+      const pipeRoot = document.createElement("div");
+      pipeRoot.dataset.csspipesPipeRoot = String(pipe.pipe);
+      pipeRoot.dataset.csspipesPipe = String(pipe.pipe);
+      pipeRoot.dataset.csspipesBankIndex = String(bank);
+      pipeRoot.dataset.csspipesShapeIndex = String(pipe.pipe);
+      pipeRoot.dataset.csspipesVisible = "false";
+      pipeRoot.dataset.csspipesTopology = "continuous-shared-ring-tube";
+      rootStyle(pipeRoot, false);
+      pipeRoot.append(mesh.element);
+      applySpaceTexels(
+        pipeRoot,
+        sceneData.lighting,
+        sceneData.playback.clips[0].materialIndicesByPipe,
+      );
+      preparePlaybackLeaves(pipeRoot, pipe.pipe, bank, sceneData.playback);
+      playbackRoot.append(pipeRoot);
+    }
+
+    scene.applyCamera();
+    await scene.whenTexturesReady();
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const stats = collectPolyRenderStats(host, sceneData.metrics.preparedLeafCount);
+    const mountedLeaves = host.querySelectorAll("[data-csspipes-face]").length;
+    const shapeTargetCount = host.querySelectorAll("[data-csspipes-shape-index]").length;
+    const leafTargetCount = host.querySelectorAll("[data-csspipes-leaf-index]").length;
+    const pipeRootCount = host.querySelectorAll("[data-csspipes-pipe-root]").length;
+    if (mountedLeaves !== sceneData.metrics.preparedLeafCount ||
+        shapeTargetCount !== sceneData.playback.totalRetainedRootCount ||
+        leafTargetCount !== sceneData.playback.totalLeafTargetCount ||
+        pipeRootCount !== sceneData.playback.totalRetainedRootCount) {
+      throw new Error("Prepared continuous tube retained graph drifted");
+    }
+    const exportedHtml = await exportPolySceneSnapshot(host, {
+      title: "cssPipes - prepared continuous PolyCSS tubes",
+    });
+    const sharedAtlasHtml = hoistPreparedSnapshotAtlas(
+      exportedHtml,
+      sceneData.metrics.preparedWallLeafCount,
+    );
+    const materialBindings = buildPreparedMaterialBindings(sceneData);
+    const materialStyle =
+      `<style data-csspipes-prepared-material-bindings="${materialBindings.bindingCount}">` +
+      `${materialBindings.css}</style>`;
+    const html = sharedAtlasHtml.replace("</head>", `${materialStyle}</head>`);
+    if (!html.includes("polycss-scene") || /<script\b/i.test(html)) {
+      throw new Error("Prepared PolyCSS snapshot failed script/scene sanitization");
+    }
+    globalThis.__cssPipesSnapshot = {
+      status: "ready",
+      html,
+      stats,
+      mountedLeaves,
+      slotCount: pipeRootCount,
+      shapeTargetCount,
+      leafTargetCount,
+      pipeRootCount,
+      bandSlotCount: sceneData.playback.bandSlotCount,
+      materialBindingCount: materialBindings.bindingCount,
+      materialUsage: materialBindings.materialUsage,
+      sceneId: sceneData.id,
+    };
+  } finally {
+    scene.destroy?.();
+  }
+}

--- a/src/adapters/3dpipes/tools/prepare-csspipes.mjs
+++ b/src/adapters/3dpipes/tools/prepare-csspipes.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  rename,
+  rm,
+} from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CSSPIPES_ADAPTER_ROOT,
+  CSSPIPES_GENERATED_PUBLIC_ROOT,
+  CSSPIPES_REPO_ROOT,
+} from "../src/prepare/csspipes/paths.mjs";
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const PREPARE_CHILD = "CSSPIPES_PREPARE_IN_PLACE";
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: CSSPIPES_REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 300_000,
+    ...options,
+  });
+  process.stdout.write(result.stdout ?? "");
+  process.stderr.write(result.stderr ?? "");
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+async function prepareInPlace() {
+  const { prepareCssPipesScene } = await import(
+    "../src/prepare/csspipes/prepare.mjs"
+  );
+  const prepared = await prepareCssPipesScene();
+  console.log(
+    `Prepared ${prepared.scene.id}: ${prepared.scene.metrics.clipCount} clips, ${prepared.scene.metrics.preparedLeafCount} retained leaves`,
+  );
+  run(process.execPath, [resolve(CSSPIPES_ADAPTER_ROOT, "tools/prepare-polycss-snapshot.mjs")]);
+  run(process.execPath, [resolve(CSSPIPES_ADAPTER_ROOT, "tools/verify-generated-artifacts.mjs")], {
+    maxBuffer: 4 * 1024 * 1024,
+  });
+}
+
+async function publishPreparedDirectory() {
+  const generatedRoot = resolve(CSSPIPES_REPO_ROOT, "build/generated");
+  await mkdir(generatedRoot, { recursive: true });
+  const stagingRoot = await mkdtemp(resolve(generatedRoot, ".csspipes-prepare-"));
+  const stagingPublicDir = resolve(stagingRoot, "public");
+  const stagedProductRoot = resolve(stagingPublicDir, "csspipes");
+  const backupRoot = `${CSSPIPES_GENERATED_PUBLIC_ROOT}.backup-${process.pid}`;
+  try {
+    run(process.execPath, [SCRIPT_PATH], {
+      env: {
+        ...process.env,
+        [PREPARE_CHILD]: "1",
+        CSSPIPES_GENERATED_PUBLIC_DIR: stagingPublicDir,
+      },
+    });
+    await mkdir(dirname(CSSPIPES_GENERATED_PUBLIC_ROOT), { recursive: true });
+    const hadPrevious = await exists(CSSPIPES_GENERATED_PUBLIC_ROOT);
+    if (hadPrevious) await rename(CSSPIPES_GENERATED_PUBLIC_ROOT, backupRoot);
+    try {
+      await rename(stagedProductRoot, CSSPIPES_GENERATED_PUBLIC_ROOT);
+    } catch (error) {
+      if (hadPrevious) await rename(backupRoot, CSSPIPES_GENERATED_PUBLIC_ROOT);
+      throw error;
+    }
+    if (hadPrevious) await rm(backupRoot, { recursive: true, force: true });
+    console.log("Published verified cssPipes artifacts atomically");
+  } finally {
+    await rm(stagingRoot, { recursive: true, force: true });
+  }
+}
+
+if (process.env[PREPARE_CHILD] === "1") {
+  await prepareInPlace();
+} else {
+  await publishPreparedDirectory();
+}

--- a/src/adapters/3dpipes/tools/prepare-polycss-snapshot.mjs
+++ b/src/adapters/3dpipes/tools/prepare-polycss-snapshot.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { dirname, resolve } from "node:path";
+import { chromium } from "playwright";
+import {
+  CSSPIPES_ADAPTER_ROOT,
+  CSSPIPES_PREPARE_SCENE_PATH,
+  CSSPIPES_PREPARE_SNAPSHOT_PATH,
+} from "../src/prepare/csspipes/paths.mjs";
+import { writeCssPipesManifest } from "../src/prepare/csspipes/writeManifest.mjs";
+
+const scene = JSON.parse(await readFile(CSSPIPES_PREPARE_SCENE_PATH, "utf8"));
+const port = await freePort();
+let output = "";
+const server = spawn("pnpm", [
+  "exec", "vite", "--config", resolve(CSSPIPES_ADAPTER_ROOT, "vite.config.mjs"),
+  "--host", "127.0.0.1", "--port", String(port), "--strictPort",
+], { stdio: ["ignore", "pipe", "pipe"] });
+server.stdout.on("data", (chunk) => { output += chunk.toString(); });
+server.stderr.on("data", (chunk) => { output += chunk.toString(); });
+
+try {
+  await waitForServer(server, () => output, port);
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage({
+      viewport: scene.camera.sourceViewport,
+      deviceScaleFactor: 1,
+    });
+    const errors = [];
+    page.on("console", (message) => { if (message.type() === "error") errors.push(message.text()); });
+    page.on("pageerror", (error) => errors.push(error.message));
+    const sceneUrl = "/csspipes/scenes/pipes-clips.scene.prepare.json";
+    const url = `http://127.0.0.1:${port}/tools/polycss-snapshot-page.html?sceneUrl=${encodeURIComponent(sceneUrl)}`;
+    await page.goto(url, { waitUntil: "networkidle", timeout: 120_000 });
+    await page.waitForFunction(
+      () => ["ready", "error"].includes(globalThis.__cssPipesSnapshot?.status),
+      null,
+      { timeout: 120_000 },
+    );
+    const snapshot = await page.evaluate(() => globalThis.__cssPipesSnapshot);
+    if (snapshot.status === "error") throw new Error(snapshot.error);
+    if (errors.length) throw new Error(`Snapshot page errors:\n${errors.join("\n")}`);
+    const html = `${snapshot.html.trimEnd()}\n`;
+    if (/<script\b|<canvas\b|<svg\b/i.test(html) || /\/(?:Users|home)\//.test(html)) {
+      throw new Error("Snapshot contains a forbidden runtime surface or local path");
+    }
+    if ((html.match(/class="[^"]*polycss-scene/g) ?? []).length !== 1) {
+      throw new Error("Snapshot must retain exactly one .polycss-scene");
+    }
+    await mkdir(dirname(CSSPIPES_PREPARE_SNAPSHOT_PATH), { recursive: true });
+    const temporary = `${CSSPIPES_PREPARE_SNAPSHOT_PATH}.tmp`;
+    await writeFile(temporary, html);
+    await rename(temporary, CSSPIPES_PREPARE_SNAPSHOT_PATH);
+    const manifest = await writeCssPipesManifest(scene, snapshot);
+    console.log(
+      `Prepared stable PolyCSS snapshot: ${snapshot.mountedLeaves} leaves, ${snapshot.pipeRootCount} continuous tube roots, manifest ${manifest.sha256}`,
+    );
+  } finally {
+    await browser.close();
+  }
+} finally {
+  server.kill("SIGTERM");
+}
+
+async function freePort() {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => error ? reject(error) : resolve(port));
+    });
+  });
+}
+
+async function waitForServer(server, getOutput, port) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (server.exitCode !== null) throw new Error(`Vite exited early:\n${getOutput()}`);
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/tools/polycss-snapshot-page.html`);
+      if (response.ok) return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out starting snapshot Vite server:\n${getOutput()}`);
+}

--- a/src/adapters/3dpipes/tools/verify-generated-artifacts.mjs
+++ b/src/adapters/3dpipes/tools/verify-generated-artifacts.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { gunzipSync } from "node:zlib";
+import {
+  selectDefaultScene,
+  validateCssPipesManifest,
+} from "../src/csspipes/manifestClient.mjs";
+import {
+  CSSPIPES_GENERATED_PUBLIC_ROOT,
+  CSSPIPES_MANIFEST_PATH,
+} from "../src/prepare/csspipes/paths.mjs";
+
+const SHA256 = /^[0-9a-f]{64}$/u;
+
+function generatedPath(url) {
+  return resolve(CSSPIPES_GENERATED_PUBLIC_ROOT, `.${url.slice("/csspipes".length)}`);
+}
+
+async function hashFile(path) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+async function assertHash(path, expected, label) {
+  if (!SHA256.test(expected)) throw new Error(`${label} has no valid SHA-256`);
+  const actual = await hashFile(path);
+  if (actual !== expected) {
+    throw new Error(`${label} hash mismatch: expected ${expected}, received ${actual}`);
+  }
+  return actual;
+}
+
+export async function verifyGeneratedCssPipesArtifacts() {
+  const manifest = validateCssPipesManifest(
+    JSON.parse(await readFile(CSSPIPES_MANIFEST_PATH, "utf8")),
+  );
+  const descriptor = selectDefaultScene(manifest);
+  const scenePath = generatedPath(descriptor.sceneUrl);
+  const snapshotPath = generatedPath(descriptor.snapshotUrl);
+  const atlasPath = resolve(
+    CSSPIPES_GENERATED_PUBLIC_ROOT,
+    "assets/pipe-space-texels.png",
+  );
+  const [sceneSha256, snapshotSha256, atlasSha256, sceneBytes] = await Promise.all([
+    assertHash(scenePath, descriptor.sceneSha256, "prepared scene"),
+    assertHash(snapshotPath, descriptor.snapshotSha256, "prepared snapshot"),
+    hashFile(atlasPath),
+    readFile(scenePath),
+  ]);
+  const sceneText = gunzipSync(sceneBytes).toString("utf8");
+  const scene = JSON.parse(sceneText);
+  if (scene.schema !== "csspipes-prebaked-scene@12" ||
+      scene.playback?.schema !== "csspipes-prebaked-playback@13" ||
+      scene.id !== descriptor.id || Object.hasOwn(scene, "pipeMeshes")) {
+    throw new Error("Prepared scene header does not match its manifest descriptor");
+  }
+  const chunks = scene.playback.clipChunks;
+  if (chunks?.schema !== "csspipes-prepared-clip-chunks@1" ||
+      chunks.count !== scene.playback.clipCount ||
+      chunks.descriptors?.length !== chunks.count) {
+    throw new Error("Prepared scene clip storage contract is incomplete");
+  }
+  await Promise.all(chunks.descriptors.map(async (chunk, index) => {
+    if (chunk.clipIndex !== index) {
+      throw new Error(`Prepared clip descriptor ${index} is out of order`);
+    }
+    await assertHash(generatedPath(chunk.url), chunk.sha256, `prepared clip ${index}`);
+  }));
+  const atlasHashToken = `\"assetSha256\":\"${atlasSha256}\"`;
+  const atlasUrlToken = "\"assetUrl\":\"/csspipes/assets/pipe-space-texels.png\"";
+  const atlasHashBindings = sceneText.split(atlasHashToken).length - 1;
+  const atlasUrlBindings = sceneText.split(atlasUrlToken).length - 1;
+  if (atlasHashBindings !== 1 || atlasUrlBindings !== 1) {
+    throw new Error(
+      `Prepared scene lighting binding drifted (${atlasHashBindings} hashes, ${atlasUrlBindings} URLs)`,
+    );
+  }
+  return Object.freeze({
+    sceneSha256,
+    snapshotSha256,
+    atlasSha256,
+    clipCount: chunks.count,
+    clipBytes: chunks.totalBytes,
+  });
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(new URL(import.meta.url).pathname)) {
+  const verified = await verifyGeneratedCssPipesArtifacts();
+  console.log(
+    `Verified generated cssPipes scene ${verified.sceneSha256.slice(0, 12)}, ${verified.clipCount} clips, snapshot ${verified.snapshotSha256.slice(0, 12)}, atlas ${verified.atlasSha256.slice(0, 12)}`,
+  );
+}

--- a/src/adapters/3dpipes/vite.config.mjs
+++ b/src/adapters/3dpipes/vite.config.mjs
@@ -1,0 +1,21 @@
+import { defineConfig } from "vite";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const adapterRoot = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(adapterRoot, "..", "..", "..");
+
+export default defineConfig({
+  root: adapterRoot,
+  publicDir: resolve(
+    process.env.CSSPIPES_GENERATED_PUBLIC_DIR ??
+      resolve(repositoryRoot, "build/generated/public"),
+  ),
+  server: { host: "127.0.0.1" },
+  preview: { host: "127.0.0.1" },
+  build: {
+    target: "es2022",
+    outDir: resolve(repositoryRoot, "dist/3dpipes"),
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add the 3D Pipes PolyCSS artwork under src/adapters/3dpipes
- integrate it into the repository root scripts, dependencies, lockfile, generated-data root, and build output
- preserve prepared mixed-facet connected tubes, two fixed retained-DOM banks, and four-clip streaming
- keep generation, route qualification, welding, lighting, and playback rows at preparation time
- include concise source/material provenance without bundling upstream source, assets, or binaries

## Validation
- deterministic prepare passes: 64 clips, 14 roots, 3,290 retained leaves
- scene 80d1c99557a6, snapshot ad5575001f97, and atlas 533b679bc1e5 remain unchanged
- 3D Pipes production build passes
- cssGraphics typecheck, strict source-only check, and production build pass

## Scope
- 42 files, 6,072 additions
- no nested package or lockfile
- no debug API, audit suite, browser smoke suite, or committed generated output