### PR TITLE
Guard exact Flower Box lighting playback

### DIFF
--- a/src/adapters/flowerbox/src/cssflower/manifestClient.mjs
+++ b/src/adapters/flowerbox/src/cssflower/manifestClient.mjs
@@ -18,10 +18,13 @@ import {
   CSSFLOWER_LIGHTING_GRID_HEIGHT,
   CSSFLOWER_LIGHTING_GRID_ROWS,
   CSSFLOWER_LIGHTING_GRID_WIDTH,
+  CSSFLOWER_LIGHTING_ADDRESS_SCHEDULE_SCHEMA,
+  CSSFLOWER_LIGHTING_ADDRESS_UPDATE_COUNT,
   CSSFLOWER_LIGHTING_LAYOUT,
   CSSFLOWER_LIGHTING_PAGE_COUNT,
   CSSFLOWER_LIGHTING_PAGE_ROWS,
   CSSFLOWER_LIGHTING_RASTER_MODE,
+  CSSFLOWER_LIGHTING_ROW_SELECTION,
   CSSFLOWER_LIGHTING_SAMPLING,
   CSSFLOWER_LIGHTING_SCHEMA,
   CSSFLOWER_LIGHTING_STATE_SLICE_HEIGHT,
@@ -116,7 +119,7 @@ export async function loadPreparedScene(manifest, routeState) {
       sceneData?.lighting?.backgroundPositionYs?.length !== CSSFLOWER_LIGHTING_PAGE_ROWS ||
       sceneData?.lighting?.backgroundPositionXs?.length !== CSSFLOWER_LIGHTING_PAGE_COUNT ||
       !validPreparedLightingAddressSchedule(sceneData?.lighting?.addressSchedule) ||
-      sceneData?.lighting?.rowSelection !== "prepared-exact-rgb8-sparse-leaf-address-schedule" ||
+      sceneData?.lighting?.rowSelection !== CSSFLOWER_LIGHTING_ROW_SELECTION ||
       sceneData?.lighting?.temporalInterpolation !== false ||
       sceneData?.lighting?.runtimeRootFrameVariables !== 1 ||
       !validPreparedFrontFacingSchedule(sceneData?.playback?.frontFacingSchedule) ||
@@ -168,12 +171,13 @@ export async function loadPreparedScene(manifest, routeState) {
 }
 
 function validPreparedLightingAddressSchedule(schedule) {
-  return schedule?.schema === "cssflower-prepared-exact-sparse-lighting-address-schedule@1" &&
+  return schedule?.schema === CSSFLOWER_LIGHTING_ADDRESS_SCHEDULE_SCHEMA &&
     schedule.stateCount === 360 && schedule.faceCount === 1_200 && schedule.threshold === 0 &&
     schedule.selectionDomain === "prepared-source-vertex-lighting-rgb8-canonical-alpha-edge-mask-and-conjoined-side-boundary-clip-geometry" &&
     schedule.comparison === "exact-three-canonical-point-rgb8-plus-remapped-edge-mask-and-conjoined-side-boundary-clip-geometry-per-retained-triangle" &&
     schedule.cycleBoundaryPolicy === "force-all-faces-to-state-zero-on-each-360-state-wrap" &&
-    Number.isSafeInteger(schedule.updateCount) && schedule.updateCount >= 1_200 &&
+    schedule.updateCount === CSSFLOWER_LIGHTING_ADDRESS_UPDATE_COUNT &&
+    !Object.hasOwn(schedule, "heldStateCount") && !Object.hasOwn(schedule, "publication") &&
     Number.isFinite(schedule.meanUpdatesPerState) && schedule.meanUpdatesPerState > 0 &&
     Number.isSafeInteger(schedule.p95UpdatesPerState) && schedule.p95UpdatesPerState >= 0 &&
     Number.isSafeInteger(schedule.maximumUpdatesPerState) && schedule.maximumUpdatesPerState === 1_200 &&

--- a/src/adapters/flowerbox/src/cssflower/preparedPlayback.mjs
+++ b/src/adapters/flowerbox/src/cssflower/preparedPlayback.mjs
@@ -3,6 +3,8 @@ import {
   CSSFLOWER_FRONT_FACE_DILATION_TICKS,
   CSSFLOWER_FRONT_FACE_SCHEDULE_ENCODING,
   CSSFLOWER_FRONT_FACE_SCHEDULE_SCHEMA,
+  CSSFLOWER_LIGHTING_ADDRESS_SCHEDULE_SCHEMA,
+  CSSFLOWER_LIGHTING_ADDRESS_UPDATE_COUNT,
   CSSFLOWER_VISIBILITY_POLICY,
 } from "./renderContract.mjs";
 
@@ -502,8 +504,10 @@ function validatePlayback({ playback, lighting, transformBlocks, lightingPages, 
 }
 
 function decodePreparedLightingAddressSchedule(schedule) {
-  if (schedule?.schema !== "cssflower-prepared-exact-sparse-lighting-address-schedule@1" ||
+  if (schedule?.schema !== CSSFLOWER_LIGHTING_ADDRESS_SCHEDULE_SCHEMA ||
       schedule.stateCount !== 360 || schedule.faceCount !== 1_200 || schedule.threshold !== 0 ||
+      schedule.updateCount !== CSSFLOWER_LIGHTING_ADDRESS_UPDATE_COUNT ||
+      Object.hasOwn(schedule, "heldStateCount") || Object.hasOwn(schedule, "publication") ||
       schedule.faceIndicesEncoding !== "base64-u16le-state-major-updated-face-indices" ||
       schedule.offsets?.length !== 361 || schedule.offsets[0] !== 0 ||
       schedule.offsets.at(-1) !== schedule.updateCount ||

--- a/src/adapters/flowerbox/src/cssflower/renderContract.mjs
+++ b/src/adapters/flowerbox/src/cssflower/renderContract.mjs
@@ -4,6 +4,11 @@ export const CSSFLOWER_BOUNDARY_SEAM_BLEED = 0.125;
 export const CSSFLOWER_BOUNDARY_SEAM_BLEED_TEXT = String(CSSFLOWER_BOUNDARY_SEAM_BLEED);
 export const CSSFLOWER_SEAM_BLEED_POLICY = "side-local-shared-edges-boundary-ring-0.125";
 export const CSSFLOWER_LIGHTING_SCHEMA = "cssflower-prepared-space-texel-lighting@6";
+export const CSSFLOWER_LIGHTING_ADDRESS_SCHEDULE_SCHEMA =
+  "cssflower-prepared-exact-sparse-lighting-address-schedule@1";
+export const CSSFLOWER_LIGHTING_ADDRESS_UPDATE_COUNT = 263_397;
+export const CSSFLOWER_LIGHTING_ROW_SELECTION =
+  "prepared-exact-rgb8-sparse-leaf-address-schedule";
 export const CSSFLOWER_LIGHTING_LAYOUT = "guttered-leaf-raster-shelves-by-horizontal-page-grid-and-timeline-state-slices";
 export const CSSFLOWER_LIGHTING_RASTER_MODE = "leaf-resolution";
 export const CSSFLOWER_LIGHTING_SAMPLING = "endpoint-aligned-pixel-centers";

--- a/src/adapters/flowerbox/src/prepare/cssflower/compilePreparedCycle.mjs
+++ b/src/adapters/flowerbox/src/prepare/cssflower/compilePreparedCycle.mjs
@@ -17,9 +17,12 @@ import {
   CSSFLOWER_LIGHTING_GRID_HEIGHT,
   CSSFLOWER_LIGHTING_GRID_ROWS,
   CSSFLOWER_LIGHTING_GRID_WIDTH,
+  CSSFLOWER_LIGHTING_ADDRESS_SCHEDULE_SCHEMA,
+  CSSFLOWER_LIGHTING_ADDRESS_UPDATE_COUNT,
   CSSFLOWER_LIGHTING_ALPHA_COVERAGE,
   CSSFLOWER_LIGHTING_LAYOUT,
   CSSFLOWER_LIGHTING_RASTER_MODE,
+  CSSFLOWER_LIGHTING_ROW_SELECTION,
   CSSFLOWER_LIGHTING_SAMPLING,
   CSSFLOWER_LIGHTING_SCHEMA,
   CSSFLOWER_SEAM_BLEED,
@@ -398,7 +401,7 @@ export async function compilePreparedCssflowerCycle({
           backgroundPositionY: `${-placement.contentY}px`,
         });
       })),
-      rowSelection: "prepared-exact-rgb8-sparse-leaf-address-schedule",
+      rowSelection: CSSFLOWER_LIGHTING_ROW_SELECTION,
       temporalInterpolation: false,
       sourceModelviewLighting: "identity-set-positional-light-then-Rx-Ry-Rz-with-normalize-and-infinite-viewer",
       rotationAware: true,
@@ -581,6 +584,9 @@ function buildPreparedLightingAddressSchedule({
     throw new Error("cssFlower sparse lighting schedule did not bind the complete retained target");
   }
   const indices = new Uint16Array(updatedFaceIndices);
+  if (indices.length !== CSSFLOWER_LIGHTING_ADDRESS_UPDATE_COUNT) {
+    throw new Error(`cssFlower exact sparse lighting schedule drifted (${indices.length} updates)`);
+  }
   const indexBytes = Buffer.from(indices.buffer, indices.byteOffset, indices.byteLength);
   const counts = Array.from(
     { length: cycle.stateCount },
@@ -588,7 +594,7 @@ function buildPreparedLightingAddressSchedule({
   );
   const sortedCounts = [...counts].sort((left, right) => left - right);
   return Object.freeze({
-    schema: "cssflower-prepared-exact-sparse-lighting-address-schedule@1",
+    schema: CSSFLOWER_LIGHTING_ADDRESS_SCHEDULE_SCHEMA,
     stateCount: cycle.stateCount,
     faceCount,
     selectionDomain: "prepared-source-vertex-lighting-rgb8-canonical-alpha-edge-mask-and-conjoined-side-boundary-clip-geometry",

--- a/src/adapters/flowerbox/tools/productBank.mjs
+++ b/src/adapters/flowerbox/tools/productBank.mjs
@@ -2,6 +2,11 @@ import { createHash } from "node:crypto";
 import { readFile, readdir, writeFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
+import {
+  CSSFLOWER_LIGHTING_ADDRESS_SCHEDULE_SCHEMA,
+  CSSFLOWER_LIGHTING_ADDRESS_UPDATE_COUNT,
+  CSSFLOWER_LIGHTING_ROW_SELECTION,
+} from "../src/cssflower/renderContract.mjs";
 
 export const FLOWERBOX_PRODUCT_BANK_SCHEMA = "cssflower-product-bank@4";
 
@@ -97,6 +102,12 @@ export async function inspectFlowerboxProductBank(root, { verifyDescriptor = tru
     lighting.pages?.every((page) => page.sourceEncoding === "PNG-RGBA8") &&
     lighting.assetCount === 1 && lighting.faces?.length === 1_200,
   "prepared q83 lighting grid");
+  assert(lighting.rowSelection === CSSFLOWER_LIGHTING_ROW_SELECTION &&
+    lighting.addressSchedule?.schema === CSSFLOWER_LIGHTING_ADDRESS_SCHEDULE_SCHEMA &&
+    lighting.addressSchedule?.updateCount === CSSFLOWER_LIGHTING_ADDRESS_UPDATE_COUNT &&
+    !Object.hasOwn(lighting.addressSchedule, "heldStateCount") &&
+    !Object.hasOwn(lighting.addressSchedule, "publication"),
+  "exact unheld prepared lighting schedule");
   assert(!scene.meshes && !scene.oracle && !playback.stateEvidenceUrl && !transforms.sourceFloat32,
     "product-only scene");
   assert(!manifest.assets?.stateEvidence && !manifest.productionTransport?.assets?.some((asset) =>


### PR DESCRIPTION
## What changed

- bind the exact sparse lighting schedule contract and its 263,397 prepared updates
- reject held-lighting metadata during packaging and browser loading
- keep the merged sparse visibility playback optimization unchanged

## Why

A local performance experiment held lighting across geometry-stable ticks and caused visible uneven lighting. The shipped v9 bank is exact; these guards prevent that experimental schedule from entering a product bank or runtime.

## Checks

- pnpm prepare:flowerbox:artifact
- pnpm verify:flowerbox:bank
- pnpm verify:flowerbox:runtime
- pnpm test:flowerbox:browser
- pnpm build:flowerbox
- pnpm test:flowerbox:deploy