### PR TITLE
Fix Maze release cache deployment

### DIFF
--- a/scripts/prepare/cssmaze-product-bank.mjs
+++ b/scripts/prepare/cssmaze-product-bank.mjs
@@ -50,13 +50,16 @@ try {
   archiveBytes = await readFile(archivePath);
 } catch (error) {
   if (localArchive || error?.code !== "ENOENT") throw error;
-  const response = await fetch(lock.url, { redirect: "follow" });
-  if (!response.ok) throw new Error(`cssMaze product bank download failed: ${response.status}`);
-  archiveBytes = Buffer.from(await response.arrayBuffer());
+  archiveBytes = await downloadReleaseArchive();
   await mkdir(cacheRoot, { recursive: true });
   await writeFile(archivePath, archiveBytes);
 }
-if (archiveBytes.length !== lock.archiveByteLength || sha256(archiveBytes) !== lock.archiveSha256) {
+if (!matchesArchiveLock(archiveBytes) && !localArchive) {
+  archiveBytes = await downloadReleaseArchive();
+  await mkdir(cacheRoot, { recursive: true });
+  await writeFile(archivePath, archiveBytes);
+}
+if (!matchesArchiveLock(archiveBytes)) {
   throw new Error("cssMaze product bank archive identity mismatch");
 }
 
@@ -101,4 +104,14 @@ try {
 
 function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+function matchesArchiveLock(bytes) {
+  return bytes.length === lock.archiveByteLength && sha256(bytes) === lock.archiveSha256;
+}
+
+async function downloadReleaseArchive() {
+  const response = await fetch(lock.url, { redirect: "follow" });
+  if (!response.ok) throw new Error(`cssMaze product bank download failed: ${response.status}`);
+  return Buffer.from(await response.arrayBuffer());
 }

--- a/src/adapters/maze/prepared-bank.lock.json
+++ b/src/adapters/maze/prepared-bank.lock.json
@@ -1,8 +1,8 @@
 {
   "schema": "cssmaze-prepared-bank-lock@1",
-  "tag": "cssmaze-product-bank-v1",
-  "asset": "cssmaze-product-bank-v1.tar.gz",
-  "url": "https://github.com/layoutit/cssGraphics/releases/download/cssmaze-product-bank-v1/cssmaze-product-bank-v1.tar.gz",
+  "tag": "cssmaze-product-bank-v2",
+  "asset": "cssmaze-product-bank-v2.tar.gz",
+  "url": "https://github.com/layoutit/cssGraphics/releases/download/cssmaze-product-bank-v2/cssmaze-product-bank-v2.tar.gz",
   "archiveByteLength": 6038791,
   "archiveSha256": "303c0da78f635ac29afcd38a6ffb23b0f9dbafd96b51033e883f00d8dc164530",
   "productClosureBytes": 6160686,

--- a/src/adapters/maze/test/cssmaze-assets.test.mjs
+++ b/src/adapters/maze/test/cssmaze-assets.test.mjs
@@ -155,7 +155,7 @@ test("prepared wall atlas preserves source texture brightness", async () => {
 test("product runtime CSS stays on the fast browser path", async () => {
   const css = await readFile(join(root, "src/cssmaze/styles.css"), "utf8");
   const shellGradient = "linear-gradient(180deg, #0b1119 0%, #000 100%)";
-  assert.equal(css.split(shellGradient).length - 1, 3);
+  assert.equal(css.split(shellGradient).length - 1, 2);
   assert.doesNotMatch(css.replaceAll(shellGradient, "none"), /(?:clip-path|mask(?:-image)?|backdrop-filter|box-shadow|text-shadow|(?:linear|radial|conic)-gradient|mix-blend-mode|background-blend-mode)\s*:/iu);
 });
 


### PR DESCRIPTION
## What\n- move cssMaze to an immutable v2 release URL with the exact cleanup product bytes already bound by the lock\n- repair stale release-cache entries by downloading once more and rechecking the lock\n- keep explicit local archive overrides fail-closed\n- align the cssMaze fast-path test with the cleanup shell gradient count\n\n## Why\nGravity Well PR #17 merged successfully, but its production deploy failed because the cssMaze v1 release URL served a CDN-cached artifact version that did not match current main. The deploy preview passed from cache, masking the production failure.\n\n## Verification\n- corrupted-cache recovery reproduces the exact 303c0d archive and complete product closure\n- explicit invalid local archive remains rejected\n- pnpm build:deploy\n- pnpm test:maze\n- pnpm test:maze:assets\n- pnpm verify:maze:bank\n- pnpm test:gravitywell\n- pnpm verify:gravitywell:bank\n- pnpm typecheck\n- pnpm verify:source-only\n- git diff --check