### PR TITLE
Fix gears reload startup

### DIFF
--- a/src/adapters/gears/src/cssgears/client.mjs
+++ b/src/adapters/gears/src/cssgears/client.mjs
@@ -143,7 +143,7 @@ export function mountCssgearsClient() {
       },
     });
     setBodyState("ready");
-    requestAnimationFrame(() => player.resume());
+    player.resume();
     const unloadedIndices = entries.map((_, index) => index)
       .filter((index) => index !== selection.bankIndex);
     if (unloadedIndices.length === 0) {

--- a/src/adapters/gears/tools/smoke-browser.mjs
+++ b/src/adapters/gears/tools/smoke-browser.mjs
@@ -31,6 +31,37 @@ try {
   });
   const browser = await chromium.launch({ channel: "chrome", headless: true });
   try {
+    const startupPage = await browser.newPage({ viewport: { width: 960, height: 540 }, deviceScaleFactor: 1 });
+    await startupPage.addInitScript(() => {
+      const requestFrame = globalThis.requestAnimationFrame.bind(globalThis);
+      let droppedBeforeDomReady = 0;
+      globalThis.requestAnimationFrame = (callback) => {
+        if (document.readyState === "loading") {
+          droppedBeforeDomReady += 1;
+          return 2147483646;
+        }
+        return requestFrame(callback);
+      };
+      globalThis.__cssGearsDroppedStartupFrames = () => droppedBeforeDomReady;
+    });
+    await startupPage.goto("http://127.0.0.1:" + port + "/", { waitUntil: "networkidle" });
+    await startupPage.waitForFunction(
+      () => document.body.classList.contains("error") || window.__cssGearsDebug?.ready,
+      null,
+      { timeout: 30_000 },
+    );
+    const startupTick = await startupPage.evaluate(() => window.__cssGearsDebug.stats().globalTick);
+    await startupPage.waitForTimeout(250);
+    const startup = await startupPage.evaluate((initialTick) => ({
+      droppedBeforeDomReady: window.__cssGearsDroppedStartupFrames(),
+      initialTick,
+      finalTick: window.__cssGearsDebug.stats().globalTick,
+      paused: window.__cssGearsDebug.stats().paused,
+    }), startupTick);
+    await startupPage.close();
+    if (startup.droppedBeforeDomReady !== 0 || startup.paused || startup.finalTick <= startup.initialTick) {
+      throw new Error("cssGears reload startup depends on a pre-DOM-ready animation frame: " + JSON.stringify(startup));
+    }
     const page = await browser.newPage({ viewport: { width: 960, height: 540 }, deviceScaleFactor: 1 });
     const pageErrors = [];
     page.on("pageerror", (error) => pageErrors.push(error.stack || error.message));
@@ -198,7 +229,7 @@ try {
     if (state.status === "error" && !/Run pnpm prepare:cssgears first/.test(state.message)) {
       throw new Error("Unexpected browser error: " + JSON.stringify({ state, pageErrors }));
     }
-    console.log(JSON.stringify({ ...state, mobile, smokeDir, screenshotPath, mobileScreenshotPath, statePath }, null, 2));
+    console.log(JSON.stringify({ ...state, startup, mobile, smokeDir, screenshotPath, mobileScreenshotPath, statePath }, null, 2));
   } finally {
     await browser.close();
   }


### PR DESCRIPTION
## What changed

- start the prepared gears player directly once the retained scene is ready
- remove the single pre-DOM-ready `requestAnimationFrame` bootstrap dependency
- add a browser regression that suppresses pre-DOM-ready animation frames and proves ticks still advance

## Root cause

A reload could reach the ready state while the one bootstrap animation-frame callback was suppressed by browser lifecycle scheduling. Because that callback was the only call to `player.resume()`, the prepared player remained paused at tick 0 indefinitely.

## Impact

Reloads now start the existing deadline-plus-animation-frame prepared transport reliably. Geometry, lighting, retained DOM, timing, and per-frame publication work are unchanged.

## Validation

- `pnpm test:gears`
- `pnpm build:gears`
- `pnpm test:gears:browser`
- `pnpm verify:source-only`

The startup regression advanced tick 24 to 33 in 250 ms with `paused: false` and zero pre-DOM-ready animation-frame requests.
