### PR TITLE
Fix Maze favicon

### DIFF
--- a/src/adapters/maze/index.html
+++ b/src/adapters/maze/index.html
@@ -10,7 +10,7 @@
     <meta name="robots" content="index, follow">
     <meta name="theme-color" content="#000000">
     <link rel="canonical" href="https://css.graphics/maze/">
-    <link rel="icon" href="data:,">
+    <link rel="icon" href="/favicon.ico" sizes="any">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="css.graphics">
     <meta property="og:title" content="css.graphics/maze">

--- a/src/adapters/maze/test/cssmaze-shell.test.mjs
+++ b/src/adapters/maze/test/cssmaze-shell.test.mjs
@@ -10,6 +10,7 @@ const css = readFileSync(resolve(root, "src/cssmaze/styles.css"), "utf8");
 test("css.graphics/maze uses the shipped cssGraphics product shell", () => {
   assert.match(html, /<title>css\.graphics\/maze<\/title>/u);
   assert.match(html, /rel="canonical" href="https:\/\/css\.graphics\/maze\/"/u);
+  assert.match(html, /rel="icon" href="\/favicon\.ico" sizes="any"/u);
   assert.match(html, /class="site-header"/u);
   assert.match(html, /class="site-wordmark" href="https:\/\/css\.graphics\/maze\/"/u);
   assert.match(html, /class="site-wordmark-path">\/maze<\/tspan>/u);


### PR DESCRIPTION
Restores the shared css.graphics favicon on the Maze route and adds a shell regression assertion.\n\nValidated with `pnpm test:maze`, `pnpm build:site`, `pnpm build:maze:deploy`, and `pnpm test:maze:deploy`. A real-Chrome deploy-build probe fetched `/favicon.ico` with HTTP 200, `image/x-icon`, and 15,086 bytes.