### PR TITLE
Add Gravity Well favicon

### DIFF
--- a/src/adapters/gravitywell/index.html
+++ b/src/adapters/gravitywell/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="XScreenSaver Gravity Well reconstructed as retained 3D HTML and CSS." />
     <meta name="theme-color" content="#000000" />
     <link rel="canonical" href="https://css.graphics/gravitywell/" />
-    <link rel="icon" href="data:," />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <title>css.graphics/gravitywell</title>
   </head>
   <body>

--- a/src/adapters/gravitywell/test/cssgravitywell-runtime-surface.test.mjs
+++ b/src/adapters/gravitywell/test/cssgravitywell-runtime-surface.test.mjs
@@ -21,6 +21,7 @@ test("public product slug is gravitywell everywhere", async () => {
   assert.doesNotMatch(source, /gravity-well/u);
   assert.match(source, /https:\/\/css\.graphics\/gravitywell\//u);
   assert.match(source, /site-wordmark-path">\/gravitywell/u);
+  assert.match(source, /<link rel="icon" href="\/favicon\.ico" sizes="any" \/>/u);
   assert.match(source, /base:\s*deployBuild \? "\/gravitywell\/" : "\/"/u);
   assert.match(source, /identity\.id !== "gravitywell"/u);
   assert.match(source, /"dev:gravitywell"/u);


### PR DESCRIPTION
## What changed

- replace Gravity Well's intentionally empty `data:,` favicon with the shared `/favicon.ico`
- add a regression assertion for the product shell favicon contract

## Why

The shared favicon was already present in the deploy root, but `/gravitywell/` explicitly disabled it in its HTML.

## Validation

- `pnpm test:gravitywell` (11/11)
- `pnpm build:gravitywell`
- `pnpm build:deploy`
- built `/gravitywell/index.html` references `/favicon.ico`
- deployed favicon bytes in the build match `site/public/favicon.ico` exactly
