### PR TITLE
Remove the ElectroPaint header letterbox

### DIFF
--- a/src/adapters/electropaint/src/cssselectropaint/styles.css
+++ b/src/adapters/electropaint/src/cssselectropaint/styles.css
@@ -42,11 +42,9 @@ body.loading::after {
   justify-content: space-between;
   height: 50px;
   padding: 0 12px 0 16px;
-  background: linear-gradient(180deg, #0b1119 0%, #000 100%);
-  background-size: 100% 100vh;
-  background-repeat: no-repeat;
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
+  pointer-events: none;
 }
 
 .site-wordmark {
@@ -54,6 +52,7 @@ body.loading::after {
   align-items: center;
   color: #f0f0f0;
   opacity: 0.72;
+  pointer-events: auto;
   text-decoration: none;
 }
 
@@ -91,6 +90,7 @@ body.loading::after {
   letter-spacing: 0.01em;
   cursor: pointer;
   opacity: 0.72;
+  pointer-events: auto;
   text-decoration: none;
 }
 

--- a/src/adapters/electropaint/test/cssselectropaint-shell.test.mjs
+++ b/src/adapters/electropaint/test/cssselectropaint-shell.test.mjs
@@ -19,5 +19,10 @@ test("product shell identifies the route and avoids alternate or paint-heavy ren
   assert.match(player, /createPolyMorphPreparedDomTarget/u);
   assert.match(player, /shapes:\s*\[\],\s*\n\s*leaves:\s*quads\.map/u);
   assert.match(css, /top:\s*calc\(50% \+ var\(--cssselectropaint-presentation-y, 0px\)\)/u);
+  assert.match(css, /\.site-header \{[^}]*pointer-events:\s*none;/u);
+  assert.doesNotMatch(css, /\.site-header \{[^}]*background:/u);
+  assert.match(css, /\.site-wordmark \{[^}]*pointer-events:\s*auto;/u);
+  assert.match(css, /\.site-action-icon-only \{[^}]*pointer-events:\s*auto;/u);
+  assert.match(css, /#scene \{[^}]*position:\s*absolute;[^}]*inset:\s*0;/u);
   assert.match(client, /PRESENTATION_VERTICAL_OFFSET_SOURCE_PIXELS = -45/u);
 });

--- a/src/adapters/electropaint/tools/smoke-browser.mjs
+++ b/src/adapters/electropaint/tools/smoke-browser.mjs
@@ -82,6 +82,7 @@ try {
       const wrapStepDelta = statDelta(statsBeforeWrapStep, api.stats().player);
       await api.setState(359);
       const rectangles = quads.map((quad) => quad.getBoundingClientRect());
+      const hostRectangle = document.querySelector("#scene").getBoundingClientRect();
       const visualBounds = {
         left: Math.min(...rectangles.map((rectangle) => rectangle.left)),
         top: Math.min(...rectangles.map((rectangle) => rectangle.top)),
@@ -97,6 +98,9 @@ try {
         svgInSceneCount: document.querySelectorAll("#scene svg").length,
         bodyBackgroundImage: getComputedStyle(document.body).backgroundImage,
         sceneBackgroundImage: getComputedStyle(document.querySelector("#scene")).backgroundImage,
+        headerBackgroundColor: getComputedStyle(document.querySelector(".site-header")).backgroundColor,
+        headerBackgroundImage: getComputedStyle(document.querySelector(".site-header")).backgroundImage,
+        headerPointerEvents: getComputedStyle(document.querySelector(".site-header")).pointerEvents,
         transformChanged: before !== after,
         colorfulLeafCount: quads.filter((quad) => {
           const color = getComputedStyle(quad).backgroundColor;
@@ -106,6 +110,7 @@ try {
         visibleLeafCount: rectangles.filter((rectangle) => rectangle.right > 0 && rectangle.bottom > 0 &&
           rectangle.left < innerWidth && rectangle.top < innerHeight).length,
         visualBounds,
+        hostBounds: hostRectangle.toJSON(),
         sparseStepDelta,
         longRunStepDelta,
         middleStepDelta,
@@ -121,7 +126,11 @@ try {
         !evidence.bodyBackgroundImage.includes("linear-gradient") ||
         !evidence.sceneBackgroundImage.includes("linear-gradient") || !evidence.transformChanged ||
         evidence.colorfulLeafCount !== 40 || evidence.outlinedLeafCount !== 40 ||
-        evidence.visibleLeafCount !== 40 || evidence.visualBounds.right - evidence.visualBounds.left < 25 ||
+        evidence.visibleLeafCount !== 40 || evidence.hostBounds.top !== 0 ||
+        evidence.hostBounds.bottom !== 540 ||
+        evidence.headerBackgroundColor !== "rgba(0, 0, 0, 0)" ||
+        evidence.headerBackgroundImage !== "none" || evidence.headerPointerEvents !== "none" ||
+        evidence.visualBounds.right - evidence.visualBounds.left < 25 ||
         evidence.visualBounds.right - evidence.visualBounds.left > 960 ||
         evidence.visualBounds.bottom - evidence.visualBounds.top < 25 ||
         evidence.visualBounds.bottom - evidence.visualBounds.top > 540 || !evidence.stable ||


### PR DESCRIPTION
## What changed

- keep the ElectroPaint scene full-viewport
- remove the opaque fixed-header gradient that covered animation frames
- preserve link hit targets while making the header container non-intercepting
- add shell and production-browser regression checks for a transparent header

## Verification

- pnpm test:electropaint
- pnpm test:electropaint:assets
- pnpm typecheck
- pnpm build:electropaint:deploy
- pnpm test:electropaint:deploy
- headless sweep: four variants, 384 states each, five additional viewport sizes