### PR TITLE
Fix cssMenger mobile runtime

### DIFF
--- a/src/adapters/menger/src/cssmenger/preparedPlayback.mjs
+++ b/src/adapters/menger/src/cssmenger/preparedPlayback.mjs
@@ -126,14 +126,23 @@ export function createCssmengerPreparedPlayer({ playback, planeAtlas, publicatio
   }
 
   function advanceOne() {
-    if (tick >= playback.segmentEndState) {
-      if (!playback.loop) {
-        paused = true;
-        return tick;
-      }
-      return publishAdjacentFast(playback.segmentStartState);
+    return advancePreparedStates(1);
+  }
+
+  function advancePreparedStates(count) {
+    if (!Number.isSafeInteger(count) || count < 1) {
+      throw new RangeError("cssMenger prepared advance count must be positive");
     }
-    return publishAdjacentFast(tick + 1);
+    if (!playback.loop && tick >= playback.segmentEndState) {
+      paused = true;
+      return tick;
+    }
+    const stateIndex = playback.loop
+      ? playback.segmentStartState + ((tick - playback.segmentStartState + count) % playback.stateCount)
+      : Math.min(playback.segmentEndState, tick + count);
+    if (stateIndex !== tick) publishAdjacentFast(stateIndex);
+    if (!playback.loop && tick >= playback.segmentEndState) paused = true;
+    return tick;
   }
 
   function advanceOneProfiled(profile) {
@@ -163,10 +172,10 @@ export function createCssmengerPreparedPlayer({ playback, planeAtlas, publicatio
   function loopFast(timestamp) {
     animationFrame = null;
     if (paused) return;
-    advanceOne();
+    const elapsedSteps = Math.max(1, Math.floor((timestamp - nextFrameAt) / frameMilliseconds) + 1);
+    advancePreparedStates(elapsedSteps);
     if (paused) return;
-    nextFrameAt += frameMilliseconds;
-    if (nextFrameAt <= timestamp) nextFrameAt = timestamp + frameMilliseconds;
+    nextFrameAt += elapsedSteps * frameMilliseconds;
     scheduleNextDraw();
   }
 
@@ -233,6 +242,7 @@ export function createCssmengerPreparedPlayer({ playback, planeAtlas, publicatio
         runtimeAdjacentPublicationComparisonCount: 0,
         runtimeHotPathProfilingBranchCount: 0,
         runtimeHotPathDebugCounterWritesPerScheduledTick: 0,
+        preparedSchedulerCatchUpMode: "coalesced-latest-prepared-state",
         preparedFrontFacingAxisSelectionsPerScheduledTick: 3,
         preparedFrontFacingLeafWritesPerScheduledTick: Object.freeze({
           minimum: playback.frontFacingSchedule.minimumSelectedLeafCountPerState,

--- a/src/adapters/menger/src/cssmenger/styles.css
+++ b/src/adapters/menger/src/cssmenger/styles.css
@@ -144,4 +144,14 @@ body > .polycss-camera {
   .site-header {
     padding-inline: 12px;
   }
+
+  body > .polycss-camera > .polycss-scene {
+    scale: 1.05 !important;
+  }
+}
+
+@media (min-width: 361px) and (max-width: 430px) {
+  body > .polycss-camera > .polycss-scene {
+    scale: 1.2 !important;
+  }
 }

--- a/src/adapters/menger/test/cssmenger-playback.test.mjs
+++ b/src/adapters/menger/test/cssmenger-playback.test.mjs
@@ -123,6 +123,82 @@ test("finite prepared playback clamps instead of claiming a false loop", () => {
   assert.equal(timelineStateIndexForTick(999, playback), 11);
 });
 
+test("late playback coalesces missed source ticks into one prepared publication", () => {
+  const originalHTMLElement = globalThis.HTMLElement;
+  let requestedFrame = null;
+  let requestedDelay = null;
+  let modelTransformWrites = 0;
+  let axisColorWrites = 0;
+  class FakeHTMLElement {
+    constructor() {
+      let transform = "";
+      let backgroundPositionY = "";
+      this.style = {
+        setProperty: (name, value) => { this.style[name] = value; },
+        getPropertyValue: () => { throw new Error("runtime DOM style read"); },
+      };
+      Object.defineProperties(this.style, {
+        transform: {
+          get: () => transform,
+          set: (value) => { transform = value; modelTransformWrites += 1; },
+        },
+        backgroundPositionY: {
+          get: () => backgroundPositionY,
+          set: (value) => { backgroundPositionY = value; axisColorWrites += 1; },
+        },
+      });
+    }
+  }
+  globalThis.HTMLElement = FakeHTMLElement;
+  try {
+    const sourcePlayback = buildPreparedMengerPlayback({ stateCount: 4 });
+    const playback = {
+      ...sourcePlayback,
+      frontFacingSchedule: {
+        schema: "cssmenger-prepared-front-facing-leaf-schedule@1",
+        encoding: "state-axis-offsets-plus-global-leaf-indices",
+        stateCount: sourcePlayback.stateCount,
+        axisCount: 3,
+        offsets: Array.from({ length: sourcePlayback.stateCount * 3 + 1 }, (_, index) => index * 14),
+        leafIndices: Array.from({ length: sourcePlayback.stateCount }, () =>
+          Array.from({ length: 3 }, (_, axis) =>
+            Array.from({ length: 14 }, (_, index) => axis * 28 + index))).flat(2),
+        minimumSelectedLeafCountPerState: 42,
+        maximumSelectedLeafCountPerState: 42,
+        averageSelectedLeafCountPerState: 42,
+        frontFaceDilationTicks: 1,
+      },
+    };
+    const player = createCssmengerPreparedPlayer({
+      playback,
+      planeAtlas: {
+        schema: "cssmenger-prepared-coplanar-plane-atlas@1",
+        leafCount: 84,
+        paletteStateCount: 128,
+        paletteBackgroundPositionYs: Array.from({ length: 128 }, (_, index) => `${-index}px`),
+      },
+      publicationRoot: new FakeHTMLElement(),
+      leaves: Array.from({ length: 84 }, () => new FakeHTMLElement()),
+      readNow: () => 0,
+      requestFrame: (callback) => { requestedFrame = callback; return 1; },
+      cancelFrame: () => {},
+      requestDelay: (callback) => { requestedDelay = callback; return 2; },
+      cancelDelay: () => {},
+    });
+    player.resume();
+    requestedDelay();
+    requestedFrame(95);
+    player.pause();
+    assert.equal(player.tick, 3);
+    assert.equal(modelTransformWrites, 2);
+    assert.equal(axisColorWrites, 126);
+    assert.equal(player.stats().preparedSchedulerCatchUpMode, "coalesced-latest-prepared-state");
+  } finally {
+    if (originalHTMLElement === undefined) delete globalThis.HTMLElement;
+    else globalThis.HTMLElement = originalHTMLElement;
+  }
+});
+
 function hash(value) {
   return createHash("sha256").update(JSON.stringify(value)).digest("hex");
 }

--- a/src/adapters/menger/tools/smoke-browser.mjs
+++ b/src/adapters/menger/tools/smoke-browser.mjs
@@ -8,8 +8,10 @@ import { adapterRoot, repositoryRoot } from "../src/prepare/cssmenger/paths.mjs"
 
 const smokeDir = join("bench", "results", "cssmenger", "smoke");
 const screenshotPath = join(smokeDir, "default-route.png");
+const mobileScreenshotPath = join(smokeDir, "mobile-default-route.png");
 const statePath = join(smokeDir, "state.json");
 const port = await freePort();
+const route = `http://127.0.0.1:${port}/`;
 let output = "";
 const server = spawn("pnpm", ["exec", "vite", "--config", join(adapterRoot, "vite.config.mjs"), "--host", "127.0.0.1", "--port", String(port), "--strictPort"], {
   cwd: repositoryRoot,
@@ -29,7 +31,7 @@ try {
     const pageErrors = [];
     page.on("pageerror", (error) => pageErrors.push(error.stack || error.message));
     page.on("console", (message) => { if (message.type() === "error") pageErrors.push(message.text()); });
-    await page.goto(`http://127.0.0.1:${port}/`, { waitUntil: "networkidle" });
+    await page.goto(route, { waitUntil: "networkidle" });
     await page.waitForFunction(() => ["ready", "error"].includes(document.body.dataset.portStatus), null, { timeout: 30_000 });
     await page.evaluate(() => window.__cssMengerDebug.seek(420));
     await page.evaluate(() => new Promise((resolve) =>
@@ -101,7 +103,7 @@ try {
         evidence.state.tick !== 420 || !evidence.state.paused || evidence.retainedLeaves !== 84 ||
         evidence.retainedRenderWrappers !== 2 || evidence.retainedModelRoots !== 0 ||
         evidence.retainedAxisRoots !== 0 || evidence.forbiddenElements !== 0 || evidence.visibleSampleCount < 10 ||
-        evidence.shellWordmarkPath !== "/menger" || evidence.shellHomeHref !== "https://css.graphics/" ||
+        evidence.shellWordmarkPath !== "/menger" || evidence.shellHomeHref !== new URL("/", route).href ||
         evidence.shellGithubHref !== "https://github.com/layoutit/cssGraphics" ||
         evidence.backfaceVisibility !== "hidden" ||
         evidence.inheritedPublicationProperties.some(Boolean) ||
@@ -115,6 +117,7 @@ try {
         evidence.stats.runtimeAdjacentPublicationComparisonCount !== 0 ||
         evidence.stats.runtimeHotPathProfilingBranchCount !== 0 ||
         evidence.stats.runtimeHotPathDebugCounterWritesPerScheduledTick !== 0 ||
+        evidence.stats.preparedSchedulerCatchUpMode !== "coalesced-latest-prepared-state" ||
         evidence.stats.preparedFrontFacingAxisSelectionsPerScheduledTick !== 3 ||
         evidence.stats.preparedFrontFacingLeafWritesPerScheduledTick.minimum !== 41 ||
         evidence.stats.preparedFrontFacingLeafWritesPerScheduledTick.maximum !== 50 ||
@@ -126,8 +129,33 @@ try {
       throw new Error(`cssMenger browser smoke contract failed: ${JSON.stringify({ evidence, pageErrors })}`);
     }
     await page.screenshot({ path: screenshotPath });
-    await writeFile(statePath, `${JSON.stringify({ ...evidence, screenshotPath }, null, 2)}\n`);
-    console.log(JSON.stringify({ status: "passed", screenshotPath, statePath, ...evidence }, null, 2));
+    await page.setViewportSize({ width: 390, height: 844 });
+    const mobileFrames = [];
+    for (const tick of [0, 120, 320, 420, 720, 1080, 1439]) {
+      await page.evaluate((nextTick) => globalThis.__cssMengerDebug.seek(nextTick), tick);
+      await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+      mobileFrames.push(await page.evaluate((frameTick) => {
+        const leaves = [...document.querySelectorAll(".polycss-camera > .polycss-scene > b, .polycss-camera > .polycss-scene > i, .polycss-camera > .polycss-scene > s")];
+        const bounds = leaves.map((leaf) => leaf.getBoundingClientRect()).filter((rect) => rect.width > 0 && rect.height > 0);
+        return {
+          tick: frameTick,
+          left: Math.min(...bounds.map((rect) => rect.left)),
+          right: Math.max(...bounds.map((rect) => rect.right)),
+          top: Math.min(...bounds.map((rect) => rect.top)),
+          bottom: Math.max(...bounds.map((rect) => rect.bottom)),
+          computedScale: getComputedStyle(document.querySelector(".polycss-scene")).scale,
+        };
+      }, tick));
+    }
+    if (mobileFrames.some((frame) => frame.left < 0 || frame.right > 390 || frame.top < 50 || frame.bottom > 844 ||
+        frame.computedScale !== "1.2")) {
+      throw new Error(`cssMenger mobile framing contract failed: ${JSON.stringify(mobileFrames)}`);
+    }
+    await page.evaluate(() => globalThis.__cssMengerDebug.seek(120));
+    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+    await page.screenshot({ path: mobileScreenshotPath });
+    await writeFile(statePath, `${JSON.stringify({ ...evidence, screenshotPath, mobileScreenshotPath, mobileFrames }, null, 2)}\n`);
+    console.log(JSON.stringify({ status: "passed", screenshotPath, mobileScreenshotPath, statePath, mobileFrames, ...evidence }, null, 2));
   } finally {
     await browser.close();
   }

--- a/src/adapters/menger/tools/trace-cssmenger-frame-work.mjs
+++ b/src/adapters/menger/tools/trace-cssmenger-frame-work.mjs
@@ -9,8 +9,13 @@ import { adapterRoot, repositoryRoot } from "../src/prepare/cssmenger/paths.mjs"
 const outputDir = join(repositoryRoot, "bench", "results", "cssmenger", "performance");
 const tracePath = join(outputDir, "frame-work-chrome-trace.json");
 const summaryPath = join(outputDir, "frame-work-summary.json");
-const viewport = { width: 960, height: 600 };
-const sampleTick = 320;
+const viewport = {
+  width: positiveInteger("CSSMENGER_PERF_VIEWPORT_WIDTH", 960),
+  height: positiveInteger("CSSMENGER_PERF_VIEWPORT_HEIGHT", 600),
+};
+const deviceScaleFactor = positiveNumber("CSSMENGER_PERF_DEVICE_SCALE_FACTOR", 1);
+const cpuThrottlingRate = positiveNumber("CSSMENGER_PERF_CPU_THROTTLE", 1);
+const sampleTick = nonNegativeInteger("CSSMENGER_PERF_SAMPLE_TICK", 320);
 const port = await freePort();
 const route = `http://127.0.0.1:${port}/`;
 let serverOutput = "";
@@ -29,9 +34,12 @@ try {
   });
   browser = await chromium.launch({ channel: "chrome", headless: true });
   const browserVersion = browser.version();
-  const context = await browser.newContext({ viewport, deviceScaleFactor: 1 });
+  const context = await browser.newContext({ viewport, deviceScaleFactor });
   const page = await context.newPage();
   const cdp = await context.newCDPSession(page);
+  if (cpuThrottlingRate !== 1) {
+    await cdp.send("Emulation.setCPUThrottlingRate", { rate: cpuThrottlingRate });
+  }
   const errors = [];
   page.on("pageerror", (error) => errors.push(error.stack || error.message));
   page.on("console", (message) => {
@@ -199,7 +207,8 @@ try {
     route,
     build: "vite-production-preview",
     browser: { name: "Google Chrome", version: browserVersion, channel: "chrome", headless: true },
-    viewport,
+    viewport: { ...viewport, deviceScaleFactor },
+    cpuThrottlingRate,
     sampleTick,
     publication: result.publication,
     isolatedPublications: result.isolatedPublications,
@@ -336,4 +345,22 @@ async function waitFor(predicate, timeoutMilliseconds, onPoll) {
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new Error(`Timed out waiting for Vite preview.\n${serverOutput}`);
+}
+
+function positiveNumber(name, fallback) {
+  const value = Number(process.env[name] ?? fallback);
+  if (!Number.isFinite(value) || value <= 0) throw new Error(`${name} must be a positive number`);
+  return value;
+}
+
+function positiveInteger(name, fallback) {
+  const value = positiveNumber(name, fallback);
+  if (!Number.isSafeInteger(value)) throw new Error(`${name} must be a positive integer`);
+  return value;
+}
+
+function nonNegativeInteger(name, fallback) {
+  const value = Number(process.env[name] ?? fallback);
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${name} must be a non-negative integer`);
+  return value;
 }

--- a/src/adapters/menger/tools/trace-cssmenger-performance.mjs
+++ b/src/adapters/menger/tools/trace-cssmenger-performance.mjs
@@ -9,9 +9,14 @@ import { adapterRoot, repositoryRoot } from "../src/prepare/cssmenger/paths.mjs"
 const outputDir = join(repositoryRoot, "bench", "results", "cssmenger", "performance");
 const tracePath = join(outputDir, "chrome-trace.json");
 const summaryPath = join(outputDir, "summary.json");
-const durationMilliseconds = 10_000;
-const calibrationDurationMilliseconds = 5_000;
-const viewport = { width: 960, height: 600 };
+const durationMilliseconds = positiveNumber("CSSMENGER_PERF_DURATION_MS", 10_000);
+const calibrationDurationMilliseconds = positiveNumber("CSSMENGER_PERF_CALIBRATION_MS", 5_000);
+const viewport = {
+  width: positiveInteger("CSSMENGER_PERF_VIEWPORT_WIDTH", 960),
+  height: positiveInteger("CSSMENGER_PERF_VIEWPORT_HEIGHT", 600),
+};
+const deviceScaleFactor = positiveNumber("CSSMENGER_PERF_DEVICE_SCALE_FACTOR", 1);
+const cpuThrottlingRate = positiveNumber("CSSMENGER_PERF_CPU_THROTTLE", 1);
 const port = await freePort();
 const route = `http://127.0.0.1:${port}/`;
 let serverOutput = "";
@@ -30,9 +35,12 @@ try {
   });
   browser = await chromium.launch({ channel: "chrome", headless: true });
   const browserVersion = browser.version();
-  const context = await browser.newContext({ viewport, deviceScaleFactor: 1 });
+  const context = await browser.newContext({ viewport, deviceScaleFactor });
   const page = await context.newPage();
   const cdp = await context.newCDPSession(page);
+  if (cpuThrottlingRate !== 1) {
+    await cdp.send("Emulation.setCPUThrottlingRate", { rate: cpuThrottlingRate });
+  }
   const pageErrors = [];
   page.on("pageerror", (error) => pageErrors.push(error.stack || error.message));
   page.on("console", (message) => {
@@ -138,20 +146,23 @@ try {
     globalThis.__cssMengerDebug.resume();
   });
   await page.waitForTimeout(durationMilliseconds);
-  const sample = await page.evaluate(() => {
-    globalThis.__cssMengerDebug.pause();
-    return globalThis.__cssMengerPerformanceSample.stop();
+  const sampledState = await page.evaluate(() => {
+    const sample = globalThis.__cssMengerPerformanceSample.stop();
+    return {
+      sample,
+      state: globalThis.__cssMengerDebug.state(),
+      stats: globalThis.__cssMengerDebug.stats(),
+      stableDom: globalThis.__cssMengerDebug.assertStableDomIdentity(),
+      errors: globalThis.__cssMengerDebug.errors(),
+    };
   });
-  const afterState = await page.evaluate(() => ({
-    state: globalThis.__cssMengerDebug.state(),
-    stats: globalThis.__cssMengerDebug.stats(),
-    stableDom: globalThis.__cssMengerDebug.assertStableDomIdentity(),
-    errors: globalThis.__cssMengerDebug.errors(),
-  }));
   const afterMetrics = metricMap(await cdp.send("Performance.getMetrics"));
   await cdp.send("Tracing.end");
   await tracingComplete;
+  await page.evaluate(() => globalThis.__cssMengerDebug.pause());
 
+  const sample = sampledState.sample;
+  const afterState = sampledState;
   const frameIntervals = sample.frameIntervals.filter((value) => Number.isFinite(value) && value >= 0);
   const longTasks = sample.longTasks.filter((entry) => Number.isFinite(entry.duration));
   const calibrationFrameIntervals = calibrationSample.frameIntervals.filter((value) => Number.isFinite(value) && value >= 0);
@@ -162,7 +173,8 @@ try {
     route,
     build: "vite-production-preview",
     browser: { name: "Google Chrome", version: browserVersion, channel: "chrome", headless: true },
-    viewport,
+    viewport: { ...viewport, deviceScaleFactor },
+    cpuThrottlingRate,
     startup: {
       ...startup,
       readyWallMilliseconds,
@@ -192,10 +204,10 @@ try {
       tickStart: beforeState.state.tick,
       tickEnd: afterState.state.tick,
       preparedStateAdvanceCount: afterState.state.tick - beforeState.state.tick,
-      modelTransformWriteCount: afterState.state.tick - beforeState.state.tick,
-      frontFacingLeafPaletteWriteEstimate: (afterState.state.tick - beforeState.state.tick) *
+      modelTransformWriteCount: null,
+      frontFacingLeafPaletteWriteUpperBound: (afterState.state.tick - beforeState.state.tick) *
         afterState.stats.preparedFrontFacingLeafWritesPerScheduledTick.average,
-      schedulerCallbackCount: afterState.state.tick - beforeState.state.tick,
+      schedulerCallbackCount: null,
       runtimeInstrumentationEnabled: afterState.stats.runtimeInstrumentationEnabled,
       runtimeHotPathDomStyleReadCount: afterState.stats.runtimeHotPathDomStyleReadCount,
       runtimeAdjacentPublicationComparisonCount: afterState.stats.runtimeAdjacentPublicationComparisonCount,
@@ -335,4 +347,16 @@ async function waitFor(predicate, timeoutMilliseconds, onPoll) {
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new Error(`Timed out waiting for Vite preview.\n${serverOutput}`);
+}
+
+function positiveNumber(name, fallback) {
+  const value = Number(process.env[name] ?? fallback);
+  if (!Number.isFinite(value) || value <= 0) throw new Error(`${name} must be a positive number`);
+  return value;
+}
+
+function positiveInteger(name, fallback) {
+  const value = positiveNumber(name, fallback);
+  if (!Number.isSafeInteger(value)) throw new Error(`${name} must be a positive integer`);
+  return value;
 }


### PR DESCRIPTION
## What changed

- fit Menger inside 320-430px mobile viewports without changing desktop framing
- coalesce missed prepared timeline steps into one latest-state publication instead of painting obsolete intermediate states
- add mobile framing coverage across seven representative rotations
- make performance traces configurable for viewport, DPR, CPU throttling, duration, and sample tick

## Root cause

The desktop scene scale overflowed narrow phones, and the scheduler reset its deadline after a late callback while still publishing one stale state at a time. Under mobile pressure that caused clipping and avoidable catch-up painting.

## Validation

- `pnpm test:menger` (10 passing)
- `pnpm test:menger:assets` (4 passing)
- `pnpm test:menger:browser`
- `pnpm build:menger`
- browser A/A oracle: 46/46 exact on final run
- 390x844, DPR 3, 6x CPU: p95 9.2ms, max 9.4ms, no frames over 16.7ms, no long tasks
- stable retained DOM: 84 leaves, 2 roots, no runtime geometry or DOM mutation