### PR TITLE
Reduce cssMenger color cadence to 90 ms

### DIFF
--- a/src/adapters/menger/src/cssmenger/preparedPlayback.mjs
+++ b/src/adapters/menger/src/cssmenger/preparedPlayback.mjs
@@ -1,3 +1,5 @@
+export const COLOR_PUBLICATION_INTERVAL_TICKS = 3;
+
 export function timelineStateIndexForTick(tick, playback) {
   if (!Number.isSafeInteger(tick) || tick < 0) throw new RangeError("cssMenger tick must be a non-negative safe integer");
   return playback.loop
@@ -50,7 +52,9 @@ export function createCssmengerPreparedPlayer({ playback, planeAtlas, publicatio
   function publishAdjacentFast(stateIndex) {
     const transform = playback.transforms[stateIndex];
     publicationRoot.style.transform = transform;
-    for (let axis = 0; axis < 3; axis += 1) publishAxisColor(stateIndex, axis);
+    if ((stateIndex - playback.segmentStartState) % COLOR_PUBLICATION_INTERVAL_TICKS === 0) {
+      for (let axis = 0; axis < 3; axis += 1) publishAxisColor(stateIndex, axis);
+    }
     tick = stateIndex;
     return tick;
   }
@@ -243,8 +247,21 @@ export function createCssmengerPreparedPlayer({ playback, planeAtlas, publicatio
         runtimeHotPathProfilingBranchCount: 0,
         runtimeHotPathDebugCounterWritesPerScheduledTick: 0,
         preparedSchedulerCatchUpMode: "coalesced-latest-prepared-state",
-        preparedFrontFacingAxisSelectionsPerScheduledTick: 3,
+        preparedColorPublicationIntervalTicks: COLOR_PUBLICATION_INTERVAL_TICKS,
+        preparedColorPublicationDelayMilliseconds: frameMilliseconds * COLOR_PUBLICATION_INTERVAL_TICKS,
+        preparedColorPublicationMode: "fixed-prepared-source-state-interval",
+        preparedFrontFacingAxisSelectionsPerScheduledTick: Object.freeze({
+          minimum: 0,
+          maximum: 3,
+          nominalAverage: 3 / COLOR_PUBLICATION_INTERVAL_TICKS,
+        }),
         preparedFrontFacingLeafWritesPerScheduledTick: Object.freeze({
+          minimum: 0,
+          maximum: playback.frontFacingSchedule.maximumSelectedLeafCountPerState,
+          nominalAverage: playback.frontFacingSchedule.averageSelectedLeafCountPerState /
+            COLOR_PUBLICATION_INTERVAL_TICKS,
+        }),
+        preparedFrontFacingLeafWritesPerColorPublication: Object.freeze({
           minimum: playback.frontFacingSchedule.minimumSelectedLeafCountPerState,
           maximum: playback.frontFacingSchedule.maximumSelectedLeafCountPerState,
           average: playback.frontFacingSchedule.averageSelectedLeafCountPerState,

--- a/src/adapters/menger/test/cssmenger-playback.test.mjs
+++ b/src/adapters/menger/test/cssmenger-playback.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
-import { createCssmengerPreparedPlayer, timelineStateIndexForTick } from "../src/cssmenger/preparedPlayback.mjs";
+import {
+  COLOR_PUBLICATION_INTERVAL_TICKS,
+  createCssmengerPreparedPlayer,
+  timelineStateIndexForTick,
+} from "../src/cssmenger/preparedPlayback.mjs";
 import { buildPreparedMengerPlayback } from "../src/prepare/cssmenger/sourcePlayback.mjs";
 
 test("prepared XScreenSaver random, palette, and rotator segment is deterministic", () => {
@@ -28,7 +32,7 @@ test("prepared XScreenSaver random, palette, and rotator segment is deterministi
   assert.equal(playback.runtimeRotationCalculation, false);
 });
 
-test("steady playback uses prepared direct writes without DOM style reads or adjacent comparisons", () => {
+test("steady playback holds prepared colors for three source ticks without DOM reads or adjacent comparisons", () => {
   const originalHTMLElement = globalThis.HTMLElement;
   let modelTransformWrites = 0;
   let axisColorWrites = 0;
@@ -56,7 +60,7 @@ test("steady playback uses prepared direct writes without DOM style reads or adj
   }
   globalThis.HTMLElement = FakeHTMLElement;
   try {
-    const sourcePlayback = buildPreparedMengerPlayback({ stateCount: 4 });
+    const sourcePlayback = buildPreparedMengerPlayback({ stateCount: 5 });
     const playback = {
       ...sourcePlayback,
       frontFacingSchedule: {
@@ -97,19 +101,32 @@ test("steady playback uses prepared direct writes without DOM style reads or adj
     assert.equal(defaultStats.runtimeInstrumentationEnabled, false);
     assert.equal(defaultStats.preparedStatesApplied, null);
     assert.equal(defaultStats.runtimeHotPathDebugCounterWritesPerScheduledTick, 0);
+    assert.equal(defaultStats.preparedColorPublicationIntervalTicks, COLOR_PUBLICATION_INTERVAL_TICKS);
+    assert.equal(defaultStats.preparedColorPublicationDelayMilliseconds, 90);
+    assert.deepEqual(defaultStats.preparedFrontFacingAxisSelectionsPerScheduledTick, {
+      minimum: 0,
+      maximum: 3,
+      nominalAverage: 1,
+    });
     assert.equal(modelTransformWrites, 1);
     assert.equal(axisColorWrites, 84);
     player.step();
-    const afterAdvance = player.stats();
     assert.equal(modelTransformWrites, 2);
+    assert.equal(axisColorWrites, 84);
+    player.step();
+    assert.equal(modelTransformWrites, 3);
+    assert.equal(axisColorWrites, 84);
+    player.step();
+    assert.equal(modelTransformWrites, 4);
+    const afterAdvance = player.stats();
     assert.equal(axisColorWrites, 126);
     assert.equal(afterAdvance.runtimeHotPathDomStyleReadCount, 0);
     assert.equal(afterAdvance.runtimeAdjacentPublicationComparisonCount, 0);
     assert.equal(afterAdvance.runtimeHotPathProfilingBranchCount, 0);
 
     player.setTick(1);
-    assert.equal(modelTransformWrites, 2);
-    assert.equal(axisColorWrites, 126);
+    assert.equal(modelTransformWrites, 5);
+    assert.equal(axisColorWrites, 168);
   } finally {
     if (originalHTMLElement === undefined) delete globalThis.HTMLElement;
     else globalThis.HTMLElement = originalHTMLElement;
@@ -151,7 +168,7 @@ test("late playback coalesces missed source ticks into one prepared publication"
   }
   globalThis.HTMLElement = FakeHTMLElement;
   try {
-    const sourcePlayback = buildPreparedMengerPlayback({ stateCount: 4 });
+    const sourcePlayback = buildPreparedMengerPlayback({ stateCount: 5 });
     const playback = {
       ...sourcePlayback,
       frontFacingSchedule: {

--- a/src/adapters/menger/tools/smoke-browser.mjs
+++ b/src/adapters/menger/tools/smoke-browser.mjs
@@ -118,10 +118,18 @@ try {
         evidence.stats.runtimeHotPathProfilingBranchCount !== 0 ||
         evidence.stats.runtimeHotPathDebugCounterWritesPerScheduledTick !== 0 ||
         evidence.stats.preparedSchedulerCatchUpMode !== "coalesced-latest-prepared-state" ||
-        evidence.stats.preparedFrontFacingAxisSelectionsPerScheduledTick !== 3 ||
-        evidence.stats.preparedFrontFacingLeafWritesPerScheduledTick.minimum !== 41 ||
+        evidence.stats.preparedColorPublicationIntervalTicks !== 3 ||
+        evidence.stats.preparedColorPublicationDelayMilliseconds !== 90 ||
+        evidence.stats.preparedColorPublicationMode !== "fixed-prepared-source-state-interval" ||
+        evidence.stats.preparedFrontFacingAxisSelectionsPerScheduledTick.minimum !== 0 ||
+        evidence.stats.preparedFrontFacingAxisSelectionsPerScheduledTick.maximum !== 3 ||
+        evidence.stats.preparedFrontFacingAxisSelectionsPerScheduledTick.nominalAverage !== 1 ||
+        evidence.stats.preparedFrontFacingLeafWritesPerScheduledTick.minimum !== 0 ||
         evidence.stats.preparedFrontFacingLeafWritesPerScheduledTick.maximum !== 50 ||
-        evidence.stats.preparedFrontFacingLeafWritesPerScheduledTick.average !== 42.725 ||
+        evidence.stats.preparedFrontFacingLeafWritesPerScheduledTick.nominalAverage !== 42.725 / 3 ||
+        evidence.stats.preparedFrontFacingLeafWritesPerColorPublication.minimum !== 41 ||
+        evidence.stats.preparedFrontFacingLeafWritesPerColorPublication.maximum !== 50 ||
+        evidence.stats.preparedFrontFacingLeafWritesPerColorPublication.average !== 42.725 ||
         evidence.stats.runtimeDomMutationCount !== 0 || evidence.stats.runtimeGeometryConstructionCount !== 0 ||
         evidence.stats.runtimeRecursionCount !== 0 || evidence.stats.runtimeMergeCount !== 0 ||
         evidence.stats.runtimeColorGenerationCount !== 0 || evidence.stats.runtimeRotationCalculationCount !== 0 ||

--- a/src/adapters/menger/tools/trace-cssmenger-performance.mjs
+++ b/src/adapters/menger/tools/trace-cssmenger-performance.mjs
@@ -205,8 +205,10 @@ try {
       tickEnd: afterState.state.tick,
       preparedStateAdvanceCount: afterState.state.tick - beforeState.state.tick,
       modelTransformWriteCount: null,
-      frontFacingLeafPaletteWriteUpperBound: (afterState.state.tick - beforeState.state.tick) *
-        afterState.stats.preparedFrontFacingLeafWritesPerScheduledTick.average,
+      frontFacingLeafPaletteWriteUpperBound: Math.ceil(
+        (afterState.state.tick - beforeState.state.tick) /
+          afterState.stats.preparedColorPublicationIntervalTicks,
+      ) * afterState.stats.preparedFrontFacingLeafWritesPerColorPublication.maximum,
       schedulerCallbackCount: null,
       runtimeInstrumentationEnabled: afterState.stats.runtimeInstrumentationEnabled,
       runtimeHotPathDomStyleReadCount: afterState.stats.runtimeHotPathDomStyleReadCount,


### PR DESCRIPTION
## Summary
- publish prepared cssMenger palette rows every third 30 ms source state on every viewport
- keep prepared model transforms at the original 30 ms cadence and preserve the stable 84-leaf retained DOM
- expose the cadence in runtime stats and make the performance trace palette-write bound cadence-aware

This intentionally slows live temporal palette changes; exact manual seeks still publish the requested prepared color row.

## Verification
- `pnpm test:menger`
- `pnpm test:menger:assets`
- `pnpm typecheck`
- `pnpm build:menger`
- `pnpm test:menger:browser`
- mobile Chrome 151 trace at 390x844, DPR 3, 6x CPU: 9.1 ms p95, 0 frames over 16.7 ms, 0 long tasks, stable DOM