### PR TITLE
Smooth cssMenger palette cadence

### DIFF
--- a/src/adapters/menger/src/cssmenger/preparedPlayback.mjs
+++ b/src/adapters/menger/src/cssmenger/preparedPlayback.mjs
@@ -18,12 +18,14 @@ export function createCssmengerPreparedPlayer({ playback, planeAtlas, publicatio
   const schedulerLeadMilliseconds = Math.min(4, frameMilliseconds / 4);
   let paused = true;
   let tick = playback.initial.stateIndex;
+  let colorStateIndex = playback.initial.stateIndex;
+  let colorPublicationPhaseTicks = 0;
   let animationFrame = null;
   let delay = null;
   let nextFrameAt = null;
 
-  function publishAxisColor(stateIndex, axis) {
-    const backgroundPositionY = planeAtlas.paletteBackgroundPositionYs[playback.colorRows[stateIndex][axis]];
+  function publishAxisColor(stateIndex, axis, colorStateIndex = stateIndex) {
+    const backgroundPositionY = planeAtlas.paletteBackgroundPositionYs[playback.colorRows[colorStateIndex][axis]];
     const schedule = playback.frontFacingSchedule;
     const segmentIndex = stateIndex * schedule.axisCount + axis;
     const start = schedule.offsets[segmentIndex];
@@ -46,14 +48,21 @@ export function createCssmengerPreparedPlayer({ playback, planeAtlas, publicatio
       }
     }
     tick = stateIndex;
+    colorStateIndex = stateIndex;
+    colorPublicationPhaseTicks = 0;
     return tick;
   }
 
-  function publishAdjacentFast(stateIndex) {
+  function publishAdjacentFast(stateIndex, advancedTickCount) {
     const transform = playback.transforms[stateIndex];
     publicationRoot.style.transform = transform;
-    if ((stateIndex - playback.segmentStartState) % COLOR_PUBLICATION_INTERVAL_TICKS === 0) {
-      for (let axis = 0; axis < 3; axis += 1) publishAxisColor(stateIndex, axis);
+    const elapsedColorTicks = colorPublicationPhaseTicks + advancedTickCount;
+    colorPublicationPhaseTicks = elapsedColorTicks % COLOR_PUBLICATION_INTERVAL_TICKS;
+    if (elapsedColorTicks >= COLOR_PUBLICATION_INTERVAL_TICKS) {
+      colorStateIndex = colorStateIndex >= playback.segmentEndState
+        ? playback.segmentStartState
+        : colorStateIndex + 1;
+      for (let axis = 0; axis < 3; axis += 1) publishAxisColor(stateIndex, axis, colorStateIndex);
     }
     tick = stateIndex;
     return tick;
@@ -76,7 +85,7 @@ export function createCssmengerPreparedPlayer({ playback, planeAtlas, publicatio
     let lastAxisPublishedAt = colorRowResolvedAt;
     for (let axis = 0; axis < 3; axis += 1) {
       const axisStartedAt = profile ? readNow() : 0;
-      const previousBackgroundPositionY = planeAtlas.paletteBackgroundPositionYs[playback.colorRows[tick][axis]];
+      const previousBackgroundPositionY = planeAtlas.paletteBackgroundPositionYs[playback.colorRows[colorStateIndex][axis]];
       const axisComparedAt = profile ? readNow() : 0;
       const axisChanged = adjacentState || tick !== stateIndex;
       const publication = axisChanged
@@ -106,6 +115,8 @@ export function createCssmengerPreparedPlayer({ playback, planeAtlas, publicatio
       }
     }
     tick = stateIndex;
+    colorStateIndex = stateIndex;
+    colorPublicationPhaseTicks = 0;
     if (profile) {
       const publicationCompletedAt = readNow();
       Object.assign(profile, {
@@ -141,10 +152,12 @@ export function createCssmengerPreparedPlayer({ playback, planeAtlas, publicatio
       paused = true;
       return tick;
     }
+    const previousTick = tick;
     const stateIndex = playback.loop
       ? playback.segmentStartState + ((tick - playback.segmentStartState + count) % playback.stateCount)
       : Math.min(playback.segmentEndState, tick + count);
-    if (stateIndex !== tick) publishAdjacentFast(stateIndex);
+    const advancedTickCount = playback.loop ? count : stateIndex - previousTick;
+    if (advancedTickCount > 0) publishAdjacentFast(stateIndex, advancedTickCount);
     if (!playback.loop && tick >= playback.segmentEndState) paused = true;
     return tick;
   }
@@ -250,6 +263,10 @@ export function createCssmengerPreparedPlayer({ playback, planeAtlas, publicatio
         preparedColorPublicationIntervalTicks: COLOR_PUBLICATION_INTERVAL_TICKS,
         preparedColorPublicationDelayMilliseconds: frameMilliseconds * COLOR_PUBLICATION_INTERVAL_TICKS,
         preparedColorPublicationMode: "fixed-prepared-source-state-interval",
+        preparedColorPaletteStepPerPublication: 1,
+        preparedColorPaletteCycleMilliseconds: playback.palette.length * frameMilliseconds *
+          COLOR_PUBLICATION_INTERVAL_TICKS,
+        preparedColorAdvanceMode: "one-adjacent-prepared-palette-row-per-publication",
         preparedFrontFacingAxisSelectionsPerScheduledTick: Object.freeze({
           minimum: 0,
           maximum: 3,

--- a/src/adapters/menger/test/cssmenger-playback.test.mjs
+++ b/src/adapters/menger/test/cssmenger-playback.test.mjs
@@ -120,13 +120,20 @@ test("steady playback holds prepared colors for three source ticks without DOM r
     assert.equal(modelTransformWrites, 4);
     const afterAdvance = player.stats();
     assert.equal(axisColorWrites, 126);
+    assert.equal(leaves[0].style.backgroundPositionY, "-1px");
+    assert.equal(leaves[28].style.backgroundPositionY, "-43px");
+    assert.equal(leaves[56].style.backgroundPositionY, "-85px");
     assert.equal(afterAdvance.runtimeHotPathDomStyleReadCount, 0);
     assert.equal(afterAdvance.runtimeAdjacentPublicationComparisonCount, 0);
     assert.equal(afterAdvance.runtimeHotPathProfilingBranchCount, 0);
+    assert.equal(afterAdvance.preparedColorPaletteStepPerPublication, 1);
+    assert.equal(afterAdvance.preparedColorPaletteCycleMilliseconds, 11_520);
+    assert.equal(afterAdvance.preparedColorAdvanceMode, "one-adjacent-prepared-palette-row-per-publication");
 
-    player.setTick(1);
+    player.setTick(2);
     assert.equal(modelTransformWrites, 5);
     assert.equal(axisColorWrites, 168);
+    assert.equal(leaves[0].style.backgroundPositionY, "-2px");
   } finally {
     if (originalHTMLElement === undefined) delete globalThis.HTMLElement;
     else globalThis.HTMLElement = originalHTMLElement;
@@ -140,7 +147,7 @@ test("finite prepared playback clamps instead of claiming a false loop", () => {
   assert.equal(timelineStateIndexForTick(999, playback), 11);
 });
 
-test("late playback coalesces missed source ticks into one prepared publication", () => {
+test("late playback coalesces non-aligned geometry catch-up without skipping adjacent palette rows", () => {
   const originalHTMLElement = globalThis.HTMLElement;
   let requestedFrame = null;
   let requestedDelay = null;
@@ -168,7 +175,7 @@ test("late playback coalesces missed source ticks into one prepared publication"
   }
   globalThis.HTMLElement = FakeHTMLElement;
   try {
-    const sourcePlayback = buildPreparedMengerPlayback({ stateCount: 5 });
+    const sourcePlayback = buildPreparedMengerPlayback({ stateCount: 12 });
     const playback = {
       ...sourcePlayback,
       frontFacingSchedule: {
@@ -186,6 +193,7 @@ test("late playback coalesces missed source ticks into one prepared publication"
         frontFaceDilationTicks: 1,
       },
     };
+    const leaves = Array.from({ length: 84 }, () => new FakeHTMLElement());
     const player = createCssmengerPreparedPlayer({
       playback,
       planeAtlas: {
@@ -195,7 +203,7 @@ test("late playback coalesces missed source ticks into one prepared publication"
         paletteBackgroundPositionYs: Array.from({ length: 128 }, (_, index) => `${-index}px`),
       },
       publicationRoot: new FakeHTMLElement(),
-      leaves: Array.from({ length: 84 }, () => new FakeHTMLElement()),
+      leaves,
       readNow: () => 0,
       requestFrame: (callback) => { requestedFrame = callback; return 1; },
       cancelFrame: () => {},
@@ -204,11 +212,18 @@ test("late playback coalesces missed source ticks into one prepared publication"
     });
     player.resume();
     requestedDelay();
-    requestedFrame(95);
-    player.pause();
-    assert.equal(player.tick, 3);
+    requestedFrame(125);
+    assert.equal(player.tick, 4);
     assert.equal(modelTransformWrites, 2);
     assert.equal(axisColorWrites, 126);
+    assert.equal(leaves[0].style.backgroundPositionY, "-1px");
+    requestedDelay();
+    requestedFrame(245);
+    player.pause();
+    assert.equal(player.tick, 8);
+    assert.equal(modelTransformWrites, 3);
+    assert.equal(axisColorWrites, 168);
+    assert.equal(leaves[0].style.backgroundPositionY, "-2px");
     assert.equal(player.stats().preparedSchedulerCatchUpMode, "coalesced-latest-prepared-state");
   } finally {
     if (originalHTMLElement === undefined) delete globalThis.HTMLElement;

--- a/src/adapters/menger/tools/smoke-browser.mjs
+++ b/src/adapters/menger/tools/smoke-browser.mjs
@@ -33,6 +33,28 @@ try {
     page.on("console", (message) => { if (message.type() === "error") pageErrors.push(message.text()); });
     await page.goto(route, { waitUntil: "networkidle" });
     await page.waitForFunction(() => ["ready", "error"].includes(document.body.dataset.portStatus), null, { timeout: 30_000 });
+    const colorCadenceEvidence = await page.evaluate(() => {
+      const debug = window.__cssMengerDebug;
+      const leaves = [...document.querySelectorAll(".polycss-camera > .polycss-scene > b, .polycss-camera > .polycss-scene > i, .polycss-camera > .polycss-scene > s")];
+      const schedule = debug.scene.playback.frontFacingSchedule;
+      const publicationStateIndex = 3;
+      const segmentIndex = publicationStateIndex * schedule.axisCount;
+      const sampledLeafIndex = schedule.leafIndices[schedule.offsets[segmentIndex]];
+      const sampledLeaf = leaves[sampledLeafIndex];
+      debug.seek(0);
+      const positions = [sampledLeaf?.style.backgroundPositionY ?? ""];
+      for (let step = 0; step < 3; step += 1) {
+        debug.step();
+        positions.push(sampledLeaf?.style.backgroundPositionY ?? "");
+      }
+      return {
+        sampledLeafIndex,
+        positions,
+        expectedInitial: debug.scene.planeAtlas.paletteBackgroundPositionYs[debug.scene.playback.colorRows[0][0]],
+        expectedAdjacent: debug.scene.planeAtlas.paletteBackgroundPositionYs[debug.scene.playback.colorRows[1][0]],
+        rejectedThreeStepJump: debug.scene.planeAtlas.paletteBackgroundPositionYs[debug.scene.playback.colorRows[3][0]],
+      };
+    });
     await page.evaluate(() => window.__cssMengerDebug.seek(420));
     await page.evaluate(() => new Promise((resolve) =>
       requestAnimationFrame(() => requestAnimationFrame(resolve))));
@@ -121,6 +143,14 @@ try {
         evidence.stats.preparedColorPublicationIntervalTicks !== 3 ||
         evidence.stats.preparedColorPublicationDelayMilliseconds !== 90 ||
         evidence.stats.preparedColorPublicationMode !== "fixed-prepared-source-state-interval" ||
+        evidence.stats.preparedColorPaletteStepPerPublication !== 1 ||
+        evidence.stats.preparedColorPaletteCycleMilliseconds !== 11_520 ||
+        evidence.stats.preparedColorAdvanceMode !== "one-adjacent-prepared-palette-row-per-publication" ||
+        colorCadenceEvidence.positions[0] !== colorCadenceEvidence.expectedInitial ||
+        colorCadenceEvidence.positions[1] !== colorCadenceEvidence.expectedInitial ||
+        colorCadenceEvidence.positions[2] !== colorCadenceEvidence.expectedInitial ||
+        colorCadenceEvidence.positions[3] !== colorCadenceEvidence.expectedAdjacent ||
+        colorCadenceEvidence.positions[3] === colorCadenceEvidence.rejectedThreeStepJump ||
         evidence.stats.preparedFrontFacingAxisSelectionsPerScheduledTick.minimum !== 0 ||
         evidence.stats.preparedFrontFacingAxisSelectionsPerScheduledTick.maximum !== 3 ||
         evidence.stats.preparedFrontFacingAxisSelectionsPerScheduledTick.nominalAverage !== 1 ||
@@ -134,7 +164,7 @@ try {
         evidence.stats.runtimeRecursionCount !== 0 || evidence.stats.runtimeMergeCount !== 0 ||
         evidence.stats.runtimeColorGenerationCount !== 0 || evidence.stats.runtimeRotationCalculationCount !== 0 ||
         evidence.stats.runtimeCameraCalculationCount !== 0 || !evidence.stats.preparedSourceFaceCoverageExact) {
-      throw new Error(`cssMenger browser smoke contract failed: ${JSON.stringify({ evidence, pageErrors })}`);
+      throw new Error(`cssMenger browser smoke contract failed: ${JSON.stringify({ evidence, colorCadenceEvidence, pageErrors })}`);
     }
     await page.screenshot({ path: screenshotPath });
     await page.setViewportSize({ width: 390, height: 844 });
@@ -162,8 +192,8 @@ try {
     await page.evaluate(() => globalThis.__cssMengerDebug.seek(120));
     await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
     await page.screenshot({ path: mobileScreenshotPath });
-    await writeFile(statePath, `${JSON.stringify({ ...evidence, screenshotPath, mobileScreenshotPath, mobileFrames }, null, 2)}\n`);
-    console.log(JSON.stringify({ status: "passed", screenshotPath, mobileScreenshotPath, statePath, mobileFrames, ...evidence }, null, 2));
+    await writeFile(statePath, `${JSON.stringify({ ...evidence, screenshotPath, mobileScreenshotPath, colorCadenceEvidence, mobileFrames }, null, 2)}\n`);
+    console.log(JSON.stringify({ status: "passed", screenshotPath, mobileScreenshotPath, statePath, colorCadenceEvidence, mobileFrames, ...evidence }, null, 2));
   } finally {
     await browser.close();
   }


### PR DESCRIPTION
## What changed

- keep the 90 ms prepared color publication cadence while advancing only one adjacent palette row per visible publication
- preserve latest-state geometry coalescing without palette jumps when delayed frames land off the three-tick boundary
- add focused unit and real-Chrome smoke assertions that reject the previous three-row jump

## Source finding

XScreenSaver initializes two fixed white lights once. Menger material colors advance by one adjacent 128-entry palette row per 30 ms draw. The existing 90 ms browser optimization skipped from row 0 to row 3 and caused the visible flash.

## Validation

- pnpm test:menger
- pnpm test:menger:assets
- pnpm typecheck
- pnpm build:menger
- pnpm test:menger:browser
- CSSMENGER_SOURCE_ROOT=/Users/ekrof/fed/cssMenger/.local/xscreensaver pnpm oracle:menger:native
- pnpm oracle:menger:browser:aa
- CSSMENGER_PERF_CPU_THROTTLE=6 pnpm perf:menger:trace

The 6x CPU trace recorded zero long tasks and zero frames over 16.7 ms with stable 84-leaf DOM and no runtime DOM or geometry work.