### PR TITLE
Predecode cssMenger atlases before canonical reveal

### DIFF
--- a/src/adapters/menger/src/cssmenger/client.mjs
+++ b/src/adapters/menger/src/cssmenger/client.mjs
@@ -4,7 +4,7 @@ import { createCssmengerPreparedPlayer } from "./preparedPlayback.mjs";
 import { mountPreparedPolycssSnapshot } from "./polycssScene.mjs";
 import { selectCssmengerPlaneAtlasProfile } from "./profileSelection.mjs";
 import { loadPreparedMengerPlaneAtlasAsset } from "./preparedPlaneAtlasAsset.mjs";
-import { createRouteState, MOBILE_SCENE_ID } from "./routeState.mjs";
+import { canonicalizeCssmengerRoute, createRouteState, MOBILE_SCENE_ID } from "./routeState.mjs";
 
 export function mountCssmengerClient(host) {
   const state = { ready: false, route: null, manifest: null, sceneData: null, mount: null, errors: [] };
@@ -16,18 +16,15 @@ export function mountCssmengerClient(host) {
   async function main() {
     if (!(host instanceof HTMLElement)) throw new Error("Missing cssMenger host");
     setStatus("loading");
+    canonicalizeCssmengerRoute();
     const route = createRouteState();
     state.route = route;
     state.manifest = await loadPreparedManifest(route);
     const deviceProfile = selectCssmengerPlaneAtlasProfile();
-    const preparedRoute = deviceProfile === "mobile" && !route.sceneExplicit
-      ? { ...route, scene: MOBILE_SCENE_ID }
-      : route;
+    const preparedRoute = { ...route, scene: deviceProfile === "mobile" ? MOBILE_SCENE_ID : route.scene };
     const { entry, sceneData, snapshotHtml } = await loadPreparedScene(state.manifest, preparedRoute);
     const planeAtlasProfile = deviceProfile;
-    const lightingPresentation = route.lighting === "opacity" && deviceProfile === "desktop"
-      ? "css-opacity"
-      : "atlas";
+    const lightingPresentation = deviceProfile === "desktop" ? "css-opacity" : "atlas";
     const planeAtlas = lightingPresentation === "css-opacity"
       ? sceneData.cssOpacityShadowAtlas
       : planeAtlasProfile === "mobile" ? sceneData.mobilePlaneAtlas : sceneData.planeAtlas;
@@ -38,6 +35,7 @@ export function mountCssmengerClient(host) {
     state.sceneData = sceneData;
     state.route = Object.freeze({
       ...route,
+      scene: preparedRoute.scene,
       preparedScene: preparedRoute.scene,
       selectedScene: entry.id,
       selectedDeviceProfile: deviceProfile,
@@ -95,15 +93,7 @@ export function mountCssmengerClient(host) {
 
 function waitForPreparedCssPaint() {
   return new Promise((resolvePaint) => {
-    // A CSS background decode starts after its first requested paint. Waiting
-    // across four display frames keeps that single decode behind the loader.
-    let remainingFrames = 4;
-    function frame() {
-      remainingFrames -= 1;
-      if (remainingFrames === 0) resolvePaint();
-      else requestAnimationFrame(frame);
-    }
-    requestAnimationFrame(frame);
+    requestAnimationFrame(() => requestAnimationFrame(resolvePaint));
   });
 }
 

--- a/src/adapters/menger/src/cssmenger/polycssScene.mjs
+++ b/src/adapters/menger/src/cssmenger/polycssScene.mjs
@@ -25,9 +25,30 @@ export function mountPreparedPolycssSnapshot({
       scene.children.length !== snapshotLeaves.length || scene.querySelector(":scope > i, :scope > s, :scope > div")) {
     throw new Error("Prepared cssMenger snapshot is missing its retained PolyCSS graph");
   }
+  if (!Array.isArray(renderAtlases) || !Array.isArray(renderAtlasAssets) ||
+      renderAtlases.length !== renderAtlasAssets.length || renderAtlases.length < 1 ||
+      renderAtlases.some((atlas, index) => renderAtlasAssets[index]?.sha256 !== atlas?.assetSha256 ||
+        typeof renderAtlasAssets[index].url !== "string" ||
+        renderAtlasAssets[index].decodedImageRetention !== "verified-decoded-object-url-lifetime") ||
+      !["atlas", "css-opacity"].includes(lightingPresentation) ||
+      !["desktop", "mobile"].includes(planeAtlasProfile) || planeAtlas?.profile !== planeAtlasProfile ||
+      (lightingPresentation === "atlas" &&
+        (renderAtlases.length !== 1 || renderAtlases[0] !== planeAtlas) ||
+      lightingPresentation === "css-opacity" &&
+        (renderAtlases.length !== 2 || renderAtlases[0]?.paletteRole !== "css-opacity-base" ||
+          renderAtlases[1]?.presentation !== "css-black-alpha"))) {
+    throw new Error("Prepared cssMenger plane atlas asset is missing or unverified");
+  }
+  const preparedCssText = styles.map((style) => style.textContent).join("\n");
+  for (const atlas of renderAtlases) {
+    if (!preparedCssText.includes(atlas.assetUrl)) {
+      throw new Error(`Prepared cssMenger plane atlas URL is missing from its stylesheet (${atlas.assetUrl})`);
+    }
+  }
   removePreparedSnapshotStyles();
   for (const style of styles) {
     const imported = document.importNode(style, true);
+    imported.textContent = bindVerifiedAtlasUrls(imported.textContent, renderAtlases, renderAtlasAssets);
     document.head.append(imported);
     mountedStyles.push(imported);
   }
@@ -43,20 +64,6 @@ export function mountPreparedPolycssSnapshot({
   mountedScene.classList.toggle("cssmenger-css-opacity", lightingPresentation === "css-opacity");
   for (const existing of host.querySelectorAll(":scope > .polycss-camera")) existing.remove();
   host.append(mountedCamera);
-  if (!Array.isArray(renderAtlases) || !Array.isArray(renderAtlasAssets) ||
-      renderAtlases.length !== renderAtlasAssets.length || renderAtlases.length < 1 ||
-      renderAtlases.some((atlas, index) => renderAtlasAssets[index]?.sha256 !== atlas?.assetSha256 ||
-        typeof renderAtlasAssets[index].url !== "string" ||
-        renderAtlasAssets[index].decodedImageRetention !== "css-background-lifetime") ||
-      !["atlas", "css-opacity"].includes(lightingPresentation) ||
-      !["desktop", "mobile"].includes(planeAtlasProfile) || planeAtlas?.profile !== planeAtlasProfile ||
-      (lightingPresentation === "atlas" &&
-        (renderAtlases.length !== 1 || renderAtlases[0] !== planeAtlas) ||
-      lightingPresentation === "css-opacity" &&
-        (renderAtlases.length !== 2 || renderAtlases[0]?.paletteRole !== "css-opacity-base" ||
-          renderAtlases[1]?.presentation !== "css-black-alpha"))) {
-    throw new Error("Prepared cssMenger plane atlas asset is missing or unverified");
-  }
   const computedLeaf = getComputedStyle(leaves[0]);
   if ((lightingPresentation === "atlas" &&
         !computedLeaf.backgroundImage.includes(renderAtlasAssets[0].url)) ||
@@ -139,8 +146,8 @@ export function mountPreparedPolycssSnapshot({
           renderAtlasAssets.reduce((sum, asset) => sum + asset.byteLength, 0),
         preparedPlaneAtlasAssetSha256: renderAtlasAssets.map((asset) => asset.sha256).join(","),
         preparedPlaneAtlasDecodedImageRetention: renderAtlasAssets.every((asset) =>
-          asset.decodedImageRetention === "css-background-lifetime")
-          ? "css-background-lifetime"
+          asset.decodedImageRetention === "verified-decoded-object-url-lifetime")
+          ? "verified-decoded-object-url-lifetime"
           : "invalid",
         runtimeDomCreationCount,
         runtimeDomRemovalCount,
@@ -155,6 +162,12 @@ export function mountPreparedPolycssSnapshot({
       removePreparedSnapshotStyles();
     },
   });
+}
+
+function bindVerifiedAtlasUrls(cssText, renderAtlases, renderAtlasAssets) {
+  return renderAtlases.reduce((boundCss, atlas, index) => {
+    return boundCss.split(atlas.assetUrl).join(renderAtlasAssets[index].url);
+  }, cssText);
 }
 
 function removePreparedSnapshotStyles() {

--- a/src/adapters/menger/src/cssmenger/preparedPlaneAtlasAsset.mjs
+++ b/src/adapters/menger/src/cssmenger/preparedPlaneAtlasAsset.mjs
@@ -12,15 +12,35 @@ export async function loadPreparedMengerPlaneAtlasAsset(atlas) {
   if (bytes.byteLength !== atlas.byteLength || actualSha256 !== atlas.assetSha256) {
     throw new Error(`Prepared cssMenger plane atlas hash drifted (${actualSha256})`);
   }
+  const mimeType = validLightingAtlas(atlas) ? "image/avif" : "image/png";
+  const url = URL.createObjectURL(new Blob([bytes], { type: mimeType }));
+  const decodedImage = new Image();
+  decodedImage.decoding = "async";
+  decodedImage.src = url;
+  try {
+    await decodedImage.decode();
+    if (decodedImage.naturalWidth !== atlas.width || decodedImage.naturalHeight !== atlas.height) {
+      throw new Error(
+        `Prepared cssMenger plane atlas dimensions drifted (${decodedImage.naturalWidth}x${decodedImage.naturalHeight})`,
+      );
+    }
+  } catch (error) {
+    decodedImage.removeAttribute("src");
+    URL.revokeObjectURL(url);
+    throw error;
+  }
   let retained = true;
   return Object.freeze({
-    url: atlas.assetUrl,
+    url,
     byteLength: bytes.byteLength,
     sha256: actualSha256,
     contractSchema: atlas.schema,
     paletteRole: atlas.paletteRole ?? null,
-    decodedImageRetention: "css-background-lifetime",
+    decodedImageRetention: "verified-decoded-object-url-lifetime",
     destroy() {
+      if (!retained) return;
+      decodedImage.removeAttribute("src");
+      URL.revokeObjectURL(url);
       retained = false;
     },
     get retained() { return retained; },

--- a/src/adapters/menger/src/cssmenger/profileSelection.mjs
+++ b/src/adapters/menger/src/cssmenger/profileSelection.mjs
@@ -1,13 +1,10 @@
 const MOBILE_USER_AGENT = /Android|iPhone|iPad|iPod|Mobile/u;
 
 export function selectCssmengerPlaneAtlasProfile({
-  search = globalThis.location?.search ?? "",
   mediaMatches = (query) => globalThis.matchMedia(query).matches,
   userAgentDataMobile = globalThis.navigator?.userAgentData?.mobile === true,
   userAgent = globalThis.navigator?.userAgent ?? "",
 } = {}) {
-  const override = new URLSearchParams(search).get("profile");
-  if (override === "mobile" || override === "desktop") return override;
   return userAgentDataMobile || MOBILE_USER_AGENT.test(userAgent) ||
     mediaMatches("(hover: none) and (pointer: coarse)") || mediaMatches("(max-width: 430px)")
     ? "mobile"

--- a/src/adapters/menger/src/cssmenger/routeState.mjs
+++ b/src/adapters/menger/src/cssmenger/routeState.mjs
@@ -1,33 +1,20 @@
 export const DEFAULT_SCENE_ID = "depth-3";
 export const MOBILE_SCENE_ID = "depth-2";
-export const DEFAULT_LIGHTING_PRESENTATION = "atlas";
-export const PUBLIC_ROUTE_PARAMS = ["scene", "lighting"];
 
-export function createRouteState(search = globalThis.location?.search ?? "") {
-  const params = new URLSearchParams(search);
-  const scene = cleanSceneId(params.get("scene")) ?? DEFAULT_SCENE_ID;
-  const lighting = params.get("lighting") === "opacity" ? "opacity" : DEFAULT_LIGHTING_PRESENTATION;
+export function createRouteState() {
   return {
-    params,
-    scene,
-    lighting,
-    sceneExplicit: params.has("scene"),
-    lightingExplicit: params.has("lighting"),
+    scene: DEFAULT_SCENE_ID,
     manifestUrl: "/cssmenger/manifest.json",
-    publicRoute: publicRouteFor({ scene, lighting }),
-    routeContract: "?scene=<scene-id>&lighting=<atlas|opacity>",
   };
 }
 
-export function publicRouteFor({
-  scene = DEFAULT_SCENE_ID,
-  lighting = DEFAULT_LIGHTING_PRESENTATION,
+export function canonicalizeCssmengerRoute({
+  location = globalThis.location,
+  history = globalThis.history,
 } = {}) {
-  if (scene === DEFAULT_SCENE_ID && lighting === DEFAULT_LIGHTING_PRESENTATION) return "/";
-  const params = new URLSearchParams();
-  if (scene !== DEFAULT_SCENE_ID) params.set("scene", scene);
-  if (lighting === "opacity") params.set("lighting", lighting);
-  return "/?" + params.toString();
+  if (!location?.search || typeof history?.replaceState !== "function") return false;
+  history.replaceState(history.state, "", `${location.pathname}${location.hash ?? ""}`);
+  return true;
 }
 
 export function sceneEntryForRoute(manifest, routeState) {
@@ -40,10 +27,4 @@ export function sceneEntryForRoute(manifest, routeState) {
 
 export function routeSceneLabel(routeState) {
   return "scene=" + routeState.scene;
-}
-
-export function cleanSceneId(value) {
-  if (typeof value !== "string" || !value.trim()) return null;
-  const clean = value.trim().toLowerCase();
-  return /^[a-z0-9._-]+$/.test(clean) ? clean : null;
 }

--- a/src/adapters/menger/src/prepare/cssmenger/slicePlan.mjs
+++ b/src/adapters/menger/src/prepare/cssmenger/slicePlan.mjs
@@ -9,7 +9,7 @@ export const cssmengerSlicePlan = Object.freeze({
   firstSlice: Object.freeze({
     kind: "procedural-spatial-object",
     label: "One deterministic depth-3 source-ordered Menger sponge with a prepared XScreenSaver rotation/color segment",
-    routeContract: "?scene=depth-3",
+    routeContract: "/",
     expectedInputs: Object.freeze(["hacks/glx/menger.c", "colors.c/h", "hsv.c/h", "rotator.c/h", "yarandom.c/h"]),
     cameraIntent: "XScreenSaver 30 degree perspective at a fixed 960x600 viewport",
   }),

--- a/src/adapters/menger/src/prepare/cssmenger/writeManifest.mjs
+++ b/src/adapters/menger/src/prepare/cssmenger/writeManifest.mjs
@@ -47,7 +47,6 @@ export async function writeCssmengerPreparedOutput({
     warnings,
     runtime: {
       debugApi,
-      routeContract: "?scene=<scene-id>&lighting=<atlas|opacity>",
       geometryPayload: false,
       runtimeDomGrowth: false,
     },

--- a/src/adapters/menger/test/cssmenger-assets.test.mjs
+++ b/src/adapters/menger/test/cssmenger-assets.test.mjs
@@ -17,7 +17,11 @@ test("verified lighting atlas bytes stay bound to the CSS background lifetime", 
   const bytes = Uint8Array.from([17, 34, 51, 68]);
   const assetSha256 = createHash("sha256").update(bytes).digest("hex");
   class FakeImage {
-    constructor() { throw new Error("asset verification must not decode an off-DOM duplicate"); }
+    set src(value) { this.url = value; }
+    get naturalWidth() { return 27; }
+    get naturalHeight() { return 27; }
+    async decode() { this.decoded = true; }
+    removeAttribute(name) { if (name === "src") this.url = ""; }
   }
   globalThis.fetch = async () => ({
     ok: true,
@@ -38,7 +42,8 @@ test("verified lighting atlas bytes stay bound to the CSS background lifetime", 
       width: 27,
       height: 27,
     });
-    assert.equal(asset.decodedImageRetention, "css-background-lifetime");
+    assert.match(asset.url, /^blob:/u);
+    assert.equal(asset.decodedImageRetention, "verified-decoded-object-url-lifetime");
     assert.equal(asset.retained, true);
     asset.destroy();
     assert.equal(asset.retained, false);

--- a/src/adapters/menger/test/cssmenger-route-state.test.mjs
+++ b/src/adapters/menger/test/cssmenger-route-state.test.mjs
@@ -2,64 +2,42 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   DEFAULT_SCENE_ID,
+  canonicalizeCssmengerRoute,
   createRouteState,
-  publicRouteFor,
 } from "../src/cssmenger/routeState.mjs";
 import { selectCssmengerPlaneAtlasProfile } from "../src/cssmenger/profileSelection.mjs";
 
 test("cssmenger route defaults to the first slice", () => {
   const route = createRouteState("");
   assert.equal(route.scene, DEFAULT_SCENE_ID);
-  assert.equal(route.sceneExplicit, false);
   assert.equal(route.manifestUrl, "/cssmenger/manifest.json");
 });
 
-test("cssmenger route accepts safe scene ids", () => {
-  const route = createRouteState("?scene=demo-room_01");
-  assert.equal(route.scene, "demo-room_01");
-  assert.equal(route.sceneExplicit, true);
-  assert.equal(publicRouteFor({ scene: route.scene }), "/?scene=demo-room_01");
-});
-
-test("cssmenger route exposes the prepared CSS opacity A/B presentation", () => {
-  const route = createRouteState("?lighting=opacity");
-  assert.equal(route.lighting, "opacity");
-  assert.equal(route.lightingExplicit, true);
-  assert.equal(route.publicRoute, "/?lighting=opacity");
-  assert.equal(publicRouteFor({ scene: "depth-2", lighting: "opacity" }),
-    "/?scene=depth-2&lighting=opacity");
-  assert.equal(createRouteState("?lighting=filter").lighting, "atlas");
-});
-
-test("cssmenger route rejects unsafe scene ids", () => {
-  const route = createRouteState("?scene=../../retail");
+test("cssmenger route has no query-selectable product variants", () => {
+  const route = createRouteState();
   assert.equal(route.scene, DEFAULT_SCENE_ID);
+  assert.equal(Object.hasOwn(route, "params"), false);
+  assert.equal(Object.hasOwn(route, "lighting"), false);
 });
 
-test("cssmenger profile selection supports explicit preview overrides", () => {
-  assert.equal(selectCssmengerPlaneAtlasProfile({
-    search: "?profile=mobile",
-    mediaMatches: () => false,
-  }), "mobile");
-  assert.equal(selectCssmengerPlaneAtlasProfile({
-    search: "?profile=desktop",
-    mediaMatches: () => true,
-    userAgentDataMobile: true,
-  }), "desktop");
+test("cssmenger strips obsolete query selectors without reloading", () => {
+  const calls = [];
+  assert.equal(canonicalizeCssmengerRoute({
+    location: { search: "?obsolete=1", pathname: "/menger/", hash: "#x" },
+    history: { state: { stable: true }, replaceState: (...args) => calls.push(args) },
+  }), true);
+  assert.deepEqual(calls, [[{ stable: true }, "", "/menger/#x"]]);
 });
 
 test("cssmenger profile selection recognizes phones beyond the portrait breakpoint", () => {
   assert.equal(selectCssmengerPlaneAtlasProfile({
-    search: "",
     mediaMatches: (query) => query.includes("pointer: coarse"),
   }), "mobile");
   assert.equal(selectCssmengerPlaneAtlasProfile({
-    search: "",
     mediaMatches: () => false,
     userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)",
   }), "mobile");
   assert.equal(selectCssmengerPlaneAtlasProfile({
-    search: "",
     mediaMatches: () => false,
   }), "desktop");
 });

--- a/src/adapters/menger/tools/smoke-browser.mjs
+++ b/src/adapters/menger/tools/smoke-browser.mjs
@@ -8,7 +8,6 @@ import { adapterRoot, repositoryRoot } from "../src/prepare/cssmenger/paths.mjs"
 
 const smokeDir = join("bench", "results", "cssmenger", "smoke");
 const screenshotPath = join(smokeDir, "default-route.png");
-const cssOpacityScreenshotPath = join(smokeDir, "css-opacity-route.png");
 const narrowMobileScreenshotPath = join(smokeDir, "mobile-360-default-route.png");
 const mobileScreenshotPath = join(smokeDir, "mobile-390-default-route.png");
 const mobileDesktopAtlasScreenshotPath = join(smokeDir, "mobile-390-desktop-atlas-baseline.png");
@@ -34,7 +33,7 @@ try {
     const loadingPage = await browser.newPage({ viewport: { width: 960, height: 540 }, deviceScaleFactor: 1 });
     let releaseAtlasRequest;
     const atlasRequestGate = new Promise((resolve) => { releaseAtlasRequest = resolve; });
-    await loadingPage.route("**/cssmenger/assets/lighting-grid-*.avif", async (request) => {
+    await loadingPage.route("**/cssmenger/assets/lighting-shadow-grid-*.avif", async (request) => {
       await atlasRequestGate;
       await request.continue();
     });
@@ -46,9 +45,11 @@ try {
     });
     releaseAtlasRequest();
     await loadingPage.waitForFunction(() => document.body.classList.contains("ready"), null, { timeout: 30_000 });
+    const canonicalizedSearch = await loadingPage.evaluate(() => location.search);
     await loadingPage.close();
     if (loadingIndicator.content === "none" || loadingIndicator.width !== "18px" ||
-        loadingIndicator.height !== "18px" || loadingIndicator.borderRadius !== "50%") {
+        loadingIndicator.height !== "18px" || loadingIndicator.borderRadius !== "50%" ||
+        canonicalizedSearch !== "") {
       throw new Error(`cssMenger loading indicator failed: ${JSON.stringify(loadingIndicator)}`);
     }
     const page = await browser.newPage({ viewport: { width: 960, height: 540 }, deviceScaleFactor: 1 });
@@ -65,9 +66,8 @@ try {
       const debug = globalThis.__cssMengerDebug;
       const scene = document.querySelector(".polycss-camera > .polycss-scene");
       const leaves = [...scene.querySelectorAll(":scope > b")];
-      const selectedAtlas = debug.route.selectedPlaneAtlasProfile === "mobile"
-        ? debug.scene.mobilePlaneAtlas
-        : debug.scene.planeAtlas;
+      const shadowAtlas = debug.scene.cssOpacityShadowAtlas;
+      const baseAtlas = debug.scene.cssOpacityBaseAtlas;
       const importantRules = [];
       for (const sheet of [...document.styleSheets]) {
         for (const rule of [...(sheet.cssRules ?? [])]) {
@@ -97,6 +97,8 @@ try {
         errors: debug?.errors?.() ?? [],
         selectedDeviceProfile: debug.route.selectedDeviceProfile,
         selectedLightingMode: debug.route.selectedLightingMode,
+        selectedLightingPresentation: debug.route.selectedLightingPresentation,
+        locationSearch: location.search,
         maximumAdjacentTransformDegrees,
         internalTransformWrapCount,
         stats: debug?.stats?.() ?? null,
@@ -118,11 +120,14 @@ try {
           backfaceVisibility: firstStyle.backfaceVisibility,
           backgroundSize: firstStyle.backgroundSize,
           backgroundImage: firstStyle.backgroundImage,
+          filter: firstStyle.filter,
+          maskImage: firstStyle.maskImage,
+          backgroundBlendMode: firstStyle.backgroundBlendMode,
         },
-        expectedBackgroundSize: `${selectedAtlas.width}px ${selectedAtlas.height}px`,
-        atlasUrl: selectedAtlas.assetUrl,
-        atlasWidth: selectedAtlas.width,
-        atlasHeight: selectedAtlas.height,
+        expectedBackgroundSize:
+          `${shadowAtlas.width}px ${shadowAtlas.height}px, ${baseAtlas.width}px ${baseAtlas.height}px`,
+        atlasWidth: shadowAtlas.width,
+        atlasHeight: shadowAtlas.height,
         atlasPageCount: debug.scene.metrics.atlasPageCount,
         sceneVariableWidth: getComputedStyle(scene).getPropertyValue("--cssmenger-atlas-width"),
         sceneVariableHeight: getComputedStyle(scene).getPropertyValue("--cssmenger-atlas-height"),
@@ -155,6 +160,7 @@ try {
     const loopProgress = await page.evaluate(async () => {
       const debug = globalThis.__cssMengerDebug;
       debug.seek(1_535);
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
       debug.resume();
       await new Promise((resolve) => setTimeout(resolve, 90));
       const state = debug.state();
@@ -211,11 +217,16 @@ try {
       /^\/cssmenger\/assets\/lighting-grid-[a-f0-9]{64}\.avif$/u.test(path));
     const frozenAtlasRequests = requests.filter((path) =>
       /^\/cssmenger\/assets\/lighting-grid-mobile-[a-f0-9]{64}\.avif$/u.test(path));
+    const shadowAtlasRequests = requests.filter((path) =>
+      /^\/cssmenger\/assets\/lighting-shadow-grid-[a-f0-9]{64}\.avif$/u.test(path));
+    const baseAtlasRequests = requests.filter((path) =>
+      /^\/cssmenger\/assets\/planes-opacity-base-[a-f0-9]{64}\.png$/u.test(path));
     const pageRequests = requests.filter((path) => /(?:page|frame)-\d+/u.test(path));
 
     if (pageErrors.length || evidence.status !== "ready" || evidence.bodyDataAttributes.length !== 0 ||
         !evidence.ready || !evidence.stable || evidence.selectedDeviceProfile !== "desktop" ||
-        evidence.selectedLightingMode !== "dynamic" ||
+        evidence.selectedLightingMode !== "prepared-css-opacity" ||
+        evidence.selectedLightingPresentation !== "css-opacity" || evidence.locationSearch !== "" ||
         evidence.internalTransformWrapCount !== 0 || evidence.maximumAdjacentTransformDegrees >= 2 ||
         evidence.errors.length || evidence.bCount !== 84 || evidence.iCount !== 0 || evidence.sCount !== 0 ||
         evidence.forbiddenRendererCount !== 0 || evidence.leafImportantInlineCount !== 0 ||
@@ -227,11 +238,15 @@ try {
         evidence.importantRules.length !== 0 || evidence.computed.width !== "27px" ||
         evidence.computed.height !== "27px" || evidence.computed.imageRendering !== "pixelated" ||
         evidence.computed.backfaceVisibility !== "hidden" ||
-        !evidence.computed.backgroundImage.includes(evidence.atlasUrl) ||
+        (evidence.computed.backgroundImage.match(/url\("blob:/gu) ?? []).length !== 2 ||
+        evidence.computed.filter !== "none" || evidence.computed.maskImage !== "none" ||
+        !["normal", "normal, normal"].includes(evidence.computed.backgroundBlendMode) ||
         evidence.computed.backgroundSize !== evidence.expectedBackgroundSize ||
         evidence.sceneVariableWidth !== `${evidence.atlasWidth}px` ||
         evidence.sceneVariableHeight !== `${evidence.atlasHeight}px` || evidence.atlasPageCount !== 2 ||
-        new Set(desktopAtlasRequests).size !== 1 || frozenAtlasRequests.length !== 0 || pageRequests.length !== 0 ||
+        desktopAtlasRequests.length !== 0 || frozenAtlasRequests.length !== 0 ||
+        new Set(shadowAtlasRequests).size !== 1 || new Set(baseAtlasRequests).size !== 1 ||
+        pageRequests.length !== 0 ||
         sampledStates.some((sample, index) => sample.tick !== [0, 36, 420, 1_535][index] ||
           !sample.paused || sample.matrixMaxDelta > 5e-5) ||
         playbackProgress.tick < 25 || playbackProgress.tick > 45 || !playbackProgress.paused ||
@@ -242,10 +257,15 @@ try {
         seamEvidence.visibleLightingAddressMismatchCount !== 0 || seamEvidence.wrappedTick !== 0 ||
         evidence.stats.runtimeDomMutationCount !== 0 || evidence.stats.runtimeDomGrowth !== false ||
         evidence.stats.preparedPlaneAtlasProfile !== "desktop" ||
-        evidence.stats.preparedPlaneAtlasAssetBytes !== 6_542_470 ||
-        evidence.stats.preparedPlaneAtlasDecodedBytes !== 90_121_896 ||
-        evidence.stats.preparedPlaneAtlasDecodedImageRetention !== "css-background-lifetime" ||
-        evidence.stats.preparedColorPublicationMode !== "prepared-held-lighting-sample-plus-per-state-front-face-address" ||
+        evidence.stats.preparedPlaneAtlasAssetBytes !== 6_190_414 ||
+        evidence.stats.preparedPlaneAtlasDecodedBytes !== 198_866_224 ||
+        evidence.stats.preparedPlaneAtlasDecodedImageRetention !==
+          "verified-decoded-object-url-lifetime" ||
+        evidence.stats.preparedColorPublicationMode !==
+          "prepared-palette-base-plus-cadence-batched-black-alpha-shadow-atlas" ||
+        evidence.stats.preparedLightingAddressPublicationIntervalTicks !== 1 ||
+        evidence.stats.preparedLightingAtlasAssetCount !== 2 ||
+        evidence.stats.preparedCssOpacityWriteCountPerScheduledTick !== 0 ||
         evidence.stats.preparedSchedulerCatchUpMode !==
           "compositor-clock-adjacent-or-collapsed-prepared-resync" ||
         evidence.stats.preparedLoopPresentationMode !== "prepared-forward-cyclic-c2-no-turnaround-no-reset" ||
@@ -258,129 +278,12 @@ try {
         evidence.stats.runtimeLightingCalculationCount !== 0 || evidence.stats.runtimeGeometryConstructionCount !== 0) {
       throw new Error(`cssMenger browser smoke failed: ${JSON.stringify({
         evidence, sampledStates, playbackProgress, loopProgress, seamEvidence,
-        desktopAtlasRequests, frozenAtlasRequests, pageRequests, pageErrors,
+        desktopAtlasRequests, frozenAtlasRequests, shadowAtlasRequests, baseAtlasRequests,
+        pageRequests, pageErrors,
       })}`);
     }
     await page.evaluate(() => globalThis.__cssMengerDebug.seek(36));
     await page.screenshot({ path: screenshotPath });
-    const cssOpacityPage = await browser.newPage({ viewport: { width: 960, height: 540 }, deviceScaleFactor: 1 });
-    const cssOpacityRequests = [];
-    const cssOpacityErrors = [];
-    cssOpacityPage.on("request", (request) => cssOpacityRequests.push(new URL(request.url()).pathname));
-    cssOpacityPage.on("pageerror", (error) => cssOpacityErrors.push(error.stack || error.message));
-    cssOpacityPage.on("console", (message) => {
-      if (message.type() === "error") cssOpacityErrors.push(message.text());
-    });
-    await cssOpacityPage.goto(`${route}?scene=depth-3&profile=desktop&lighting=opacity`, {
-      waitUntil: "networkidle",
-    });
-    await cssOpacityPage.waitForFunction(() =>
-      document.body.classList.contains("ready") || document.body.classList.contains("error"), null,
-    { timeout: 30_000 });
-    const cssOpacityEvidence = await cssOpacityPage.evaluate(() => {
-      const debug = globalThis.__cssMengerDebug;
-      const scene = document.querySelector(".polycss-camera > .polycss-scene");
-      const leaves = [...scene.querySelectorAll(":scope > b")];
-      const first = leaves[0];
-      const baseStyle = getComputedStyle(first);
-      return {
-        status: document.body.classList.contains("ready") ? "ready" : "error",
-        route: debug.route,
-        errors: debug.errors(),
-        stable: debug.assertStableDomIdentity(),
-        stats: debug.stats(),
-        leafCount: leaves.length,
-        sceneClass: scene.className,
-        leafInlineProperties: [...new Set(leaves.flatMap((leaf) => [...leaf.style]))].sort(),
-        sceneInlineProperties: [...scene.style].sort(),
-        baseImage: baseStyle.backgroundImage,
-        baseSize: baseStyle.backgroundSize,
-        imageRendering: baseStyle.imageRendering,
-        filter: baseStyle.filter,
-        maskImage: baseStyle.maskImage,
-        maskPosition: baseStyle.maskPosition,
-        maskSize: baseStyle.maskSize,
-        backgroundBlendMode: baseStyle.backgroundBlendMode,
-      };
-    });
-    const cssOpacityBaseRequests = cssOpacityRequests.filter((path) =>
-      /^\/cssmenger\/assets\/planes-opacity-base-[a-f0-9]{64}\.png$/u.test(path));
-    const cssOpacityShadowRequests = cssOpacityRequests.filter((path) =>
-      /^\/cssmenger\/assets\/lighting-shadow-grid-[a-f0-9]{64}\.avif$/u.test(path));
-    const cssOpacityRgbRequests = cssOpacityRequests.filter((path) =>
-      /^\/cssmenger\/assets\/lighting-grid(?:-mobile)?-[a-f0-9]{64}\.avif$/u.test(path));
-    const cssOpacityLoopProgress = await cssOpacityPage.evaluate(async () => {
-      const debug = globalThis.__cssMengerDebug;
-      debug.seek(1_535);
-      debug.resume();
-      await new Promise((resolve) => setTimeout(resolve, 90));
-      const state = debug.state();
-      debug.pause();
-      return state;
-    });
-    const cssOpacitySeamEvidence = await cssOpacityPage.evaluate(() => {
-      const debug = globalThis.__cssMengerDebug;
-      const scene = document.querySelector(".polycss-camera > .polycss-scene");
-      const schedule = debug.scene.playback.frontFacingSchedule;
-      const visibleStateZeroLeaves = schedule.leafIndices.slice(schedule.offsets[0], schedule.offsets[3]);
-      debug.seek(0);
-      const expected = visibleStateZeroLeaves.map((leafIndex) =>
-        scene.children[leafIndex].style.backgroundPosition);
-      debug.seek(debug.scene.playback.stateCount - 1);
-      debug.step();
-      const actual = visibleStateZeroLeaves.map((leafIndex) =>
-        scene.children[leafIndex].style.backgroundPosition);
-      return {
-        mismatchCount: actual.reduce((count, value, index) => count + Number(value !== expected[index]), 0),
-        wrappedTick: debug.state().tick,
-      };
-    });
-    if (cssOpacityErrors.length || cssOpacityEvidence.status !== "ready" ||
-        cssOpacityEvidence.route.selectedLightingPresentation !== "css-opacity" ||
-        cssOpacityEvidence.route.selectedLightingMode !== "prepared-css-opacity" ||
-        cssOpacityEvidence.errors.length || !cssOpacityEvidence.stable || cssOpacityEvidence.leafCount !== 84 ||
-        !cssOpacityEvidence.sceneClass.includes("cssmenger-css-opacity") ||
-        cssOpacityEvidence.leafInlineProperties.some((property) =>
-          !["background-position", "background-position-x", "background-position-y", "transform"]
-            .includes(property)) ||
-        cssOpacityEvidence.sceneInlineProperties.some((property) => property !== "transform") ||
-        !cssOpacityEvidence.baseImage.includes("lighting-shadow-grid-") ||
-        !cssOpacityEvidence.baseImage.includes("planes-opacity-base-") ||
-        cssOpacityEvidence.maskImage !== "none" ||
-        cssOpacityEvidence.imageRendering !== "pixelated" ||
-        cssOpacityEvidence.filter !== "none" ||
-        !["normal", "normal, normal"].includes(cssOpacityEvidence.backgroundBlendMode) ||
-        cssOpacityEvidence.stats.preparedColorPublicationMode !==
-          "prepared-palette-base-plus-cadence-batched-black-alpha-shadow-atlas" ||
-        cssOpacityEvidence.stats.preparedSchedulerCatchUpMode !==
-          "compositor-clock-adjacent-or-collapsed-prepared-resync" ||
-        cssOpacityEvidence.stats.preparedCssOpacityWriteCountPerScheduledTick !== 0 ||
-        cssOpacityEvidence.stats.preparedLightingAddressPublicationIntervalTicks !== 1 ||
-        cssOpacityEvidence.stats.preparedLightingAtlasAssetCount !== 2 ||
-        cssOpacityEvidence.stats.preparedFlatSceneLeafLightingSeparation !== true ||
-        cssOpacityEvidence.stats.preparedLoopPresentationMode !==
-          "prepared-forward-cyclic-c2-no-turnaround-no-reset" ||
-        cssOpacityEvidence.stats.preparedCompositorRotationMode !==
-          "prepared-css-keyframes-on-existing-scene-node" ||
-        cssOpacityEvidence.stats.runtimeRotationStyleWriteCountPerScheduledTick !== 0 ||
-        cssOpacityLoopProgress.tick < 0 || cssOpacityLoopProgress.tick > 5 ||
-        cssOpacityLoopProgress.paused ||
-        cssOpacitySeamEvidence.mismatchCount !== 0 || cssOpacitySeamEvidence.wrappedTick !== 0 ||
-        cssOpacityEvidence.stats.runtimeDomMutationCount !== 0 ||
-        new Set(cssOpacityBaseRequests).size !== 1 || new Set(cssOpacityShadowRequests).size !== 1 ||
-        cssOpacityRgbRequests.length !== 0) {
-      throw new Error(`cssMenger CSS opacity smoke failed: ${JSON.stringify({
-        cssOpacityEvidence,
-        cssOpacityBaseRequests,
-        cssOpacityShadowRequests,
-        cssOpacityRgbRequests,
-        cssOpacityLoopProgress,
-        cssOpacitySeamEvidence,
-        cssOpacityErrors,
-      })}`);
-    }
-    await cssOpacityPage.screenshot({ path: cssOpacityScreenshotPath });
-    await cssOpacityPage.close();
     const mobileFraming = [];
     for (const viewport of [
       { width: 360, height: 780, expectedScale: "0.82", screenshotPath: narrowMobileScreenshotPath },
@@ -494,7 +397,7 @@ try {
         mobileEvidence.lightingSteps.some((step) => step.preparedLightingAddressWriteCount > 18) ||
         !mobileEvidence.lightingSteps.some((step) => step.preparedLightingAddressWriteCount > 0) ||
         mobileEvidence.tick !== 720 ||
-        !mobileEvidence.backgroundImage.includes(mobileEvidence.mobileUrl) ||
+        !mobileEvidence.backgroundImage.startsWith('url("blob:') ||
         mobileEvidence.backgroundSize !== mobileEvidence.expectedBackgroundSize ||
         mobileEvidence.transformAnimationName !== "cssmenger-prepared-rotation" ||
         mobileEvidence.transformAnimationDuration !== "46.08s" ||


### PR DESCRIPTION
Ships one automatic desktop experience and one automatic mobile experience at the canonical no-parameter route. Desktop selects depth-3 CSS-opacity lighting; mobile selects the depth-2 mobile atlas. Obsolete query selectors are not parsed and stale query strings are removed without reload.\n\nThe exact verified atlas bytes are decoded through retained object URLs and first presentation remains behind the loader. No prepared atlas pixels, geometry, cadence, or animation states change.\n\nValidated with typecheck, pinned v13 product-bank verification, Menger asset/unit tests, production build, full Chrome browser smoke, exact fixed-tick screenshot comparison, and a four-desktop-page sustained playback probe with zero gaps over 20 ms.