### PR TITLE
Stabilize cssMenger atomic playback cadence

### DIFF
--- a/src/adapters/menger/src/cssmenger/polycssScene.mjs
+++ b/src/adapters/menger/src/cssmenger/polycssScene.mjs
@@ -81,6 +81,7 @@ export function mountPreparedPolycssSnapshot({
   }
   const rotationAnimation = rotationAnimations[0];
   rotationAnimation.pause();
+  rotationAnimation.cancel();
   const stableNodes = Object.freeze([mountedCamera, mountedScene, ...leaves]);
   const axisLeafCounts = sceneData.meshDescriptors?.map((mesh) => mesh.polygonCount);
   if (!Array.isArray(axisLeafCounts) || axisLeafCounts.length !== 3 ||
@@ -120,7 +121,7 @@ export function mountPreparedPolycssSnapshot({
     camera: mountedCamera,
     scene: mountedScene,
     publicationRoot: mountedScene,
-    rotationAnimation,
+    rotationAnimation: null,
     axisLeaves,
     leaves: Object.freeze(leaves),
     assertStableDomIdentity,
@@ -140,7 +141,7 @@ export function mountPreparedPolycssSnapshot({
         preparedPlaneAtlasUniqueUrlCount: renderAtlases.length,
         preparedPlaneAtlasProfile: planeAtlasProfile,
         preparedLightingPresentation: lightingPresentation,
-        preparedCompositorRotationAnimationCount: 1,
+        preparedCompositorRotationAnimationCount: 0,
         preparedPlaneAtlasDecodedBytes:
           renderAtlases.reduce((sum, atlas) => sum + atlas.decodedBytes, 0),
         preparedPlaneAtlasAssetBytes:

--- a/src/adapters/menger/src/cssmenger/preparedPlayback.mjs
+++ b/src/adapters/menger/src/cssmenger/preparedPlayback.mjs
@@ -48,15 +48,13 @@ export function createCssmengerPreparedPlayer({
   const baseBackgroundPositions = cssOpacityMode ? Array(leaves.length).fill("0px 0px") : null;
   const currentSlotIndices = new Int32Array(leaves.length).fill(-1);
   const deferredAddressLeaves = new Uint8Array(leaves.length);
-  const schedulerLeadMilliseconds = compositorRotationMode
-    ? 1
-    : Math.min(4, frameMilliseconds / 4);
   let paused = true;
   let tick = playback.initial.stateIndex;
   let animationFrame = null;
   let delay = null;
-  let nextFrameAt = null;
-  let compositorClockReadCount = 0;
+  let preparedTimelineOrigin = null;
+  let nextCompositorBoundary = null;
+  let preparedTimelineCallbackCount = 0;
   let collapsedLightingResyncCount = 0;
   let maximumCollapsedStateCount = 0;
 
@@ -201,6 +199,7 @@ export function createCssmengerPreparedPlayer({
       stateIndex = (stateIndex + 1) % playback.stateCount;
       publishPreparedAddressState(stateIndex, deferredAddressLeaves);
     }
+    publishPreparedRotation(targetStateIndex);
     if (cssOpacityMode) {
       publishCssOpacityBasePositions(targetStateIndex);
     } else {
@@ -217,8 +216,9 @@ export function createCssmengerPreparedPlayer({
     return tick;
   }
 
-  function publishCompositorClockState(stateIndex) {
+  function publishPreparedTimelineState(stateIndex) {
     if (frozenLighting) {
+      publishPreparedRotation(stateIndex);
       tick = stateIndex;
       return tick;
     }
@@ -249,38 +249,33 @@ export function createCssmengerPreparedPlayer({
 
   function scheduleNextDraw() {
     if (paused || animationFrame !== null || delay !== null) return;
-    const animationTime = compositorRotationMode ? Number(rotationAnimation.currentTime) : null;
-    const nextAnimationBoundary = compositorRotationMode && Number.isFinite(animationTime)
-      ? (Math.floor(animationTime / frameMilliseconds) + 1) * frameMilliseconds
-      : null;
-    const wait = Math.max(0, (nextAnimationBoundary ?? nextFrameAt) -
-      (nextAnimationBoundary === null ? readNow() : animationTime) - schedulerLeadMilliseconds);
-    if (wait <= 1) {
-      animationFrame = requestFrame(loopFast);
+    if (compositorRotationMode) {
+      const animationTime = readNow() - preparedTimelineOrigin;
+      if (!Number.isFinite(nextCompositorBoundary)) {
+        nextCompositorBoundary = (Math.floor(animationTime / frameMilliseconds) + 1) * frameMilliseconds;
+      }
+      const wait = Math.max(0, nextCompositorBoundary - animationTime);
+      delay = requestDelay(() => {
+        delay = null;
+        if (!paused) loopFast(readNow());
+      }, Math.max(1, Math.ceil(wait)));
       return;
     }
-    delay = requestDelay(() => {
-      delay = null;
-      if (!paused) animationFrame = requestFrame(loopFast);
-    }, wait);
+    animationFrame = requestFrame(loopFast);
   }
 
   function loopFast(timestamp) {
     animationFrame = null;
     if (paused) return;
+    preparedTimelineCallbackCount += 1;
+    const animationTime = timestamp - preparedTimelineOrigin;
+    const stateCode = preparedStateCodeForAnimationTime(animationTime);
+    if (stateCode !== null) publishPreparedTimelineState(stateCode);
     if (compositorRotationMode) {
-      compositorClockReadCount += 1;
-      const stateCode = preparedStateCodeForAnimationTime(rotationAnimation.currentTime);
-      if (stateCode !== null) {
-        publishCompositorClockState(stateCode);
-      }
-    } else {
-      advanceOne();
+      nextCompositorBoundary =
+        (Math.floor(animationTime / frameMilliseconds) + 1) * frameMilliseconds;
     }
     if (paused) return;
-    if (!compositorRotationMode) {
-      nextFrameAt = Math.max(nextFrameAt + frameMilliseconds, timestamp);
-    }
     scheduleNextDraw();
   }
 
@@ -298,7 +293,8 @@ export function createCssmengerPreparedPlayer({
     pause() {
       paused = true;
       if (compositorRotationMode) rotationAnimation.pause();
-      nextFrameAt = null;
+      preparedTimelineOrigin = null;
+      nextCompositorBoundary = null;
       if (animationFrame !== null) cancelFrame(animationFrame);
       if (delay !== null) cancelDelay(delay);
       animationFrame = null;
@@ -308,8 +304,17 @@ export function createCssmengerPreparedPlayer({
     resume() {
       if (!paused || (!playback.loop && tick >= playback.segmentEndState)) return tick;
       paused = false;
-      nextFrameAt = compositorRotationMode ? null : readNow() + frameMilliseconds;
-      if (compositorRotationMode) rotationAnimation.play();
+      const now = readNow();
+      if (compositorRotationMode) {
+        const animationTime = Number(rotationAnimation.currentTime);
+        preparedTimelineOrigin = now -
+          (Number.isFinite(animationTime) ? animationTime : tick * frameMilliseconds);
+        nextCompositorBoundary =
+          (Math.floor((now - preparedTimelineOrigin) / frameMilliseconds) + 1) * frameMilliseconds;
+        rotationAnimation.play();
+      } else {
+        preparedTimelineOrigin = now - tick * frameMilliseconds;
+      }
       scheduleNextDraw();
       return tick;
     },
@@ -339,10 +344,11 @@ export function createCssmengerPreparedPlayer({
         sourceFrameDelayMilliseconds: frameMilliseconds,
         preparedTimelineStateCount: playback.stateCount,
         preparedPaletteColorCount: playback.palette.length,
-        preparedSchedulerCatchUpMode: compositorRotationMode
-          ? "compositor-clock-adjacent-or-collapsed-prepared-resync"
-          : "one-adjacent-prepared-state-no-skip",
-        runtimeCompositorClockReadCount: compositorClockReadCount,
+        preparedSchedulerCatchUpMode: "anchored-prepared-timeline-adjacent-or-collapsed-resync",
+        runtimeSchedulerTransport: compositorRotationMode
+          ? "anchored-deadline-setTimeout-prepared-timeline-publication"
+          : "continuous-requestAnimationFrame-prepared-timeline-publication",
+        runtimePreparedTimelineCallbackCount: preparedTimelineCallbackCount,
         preparedCollapsedLightingResyncCount: collapsedLightingResyncCount,
         preparedMaximumCollapsedLightingStateCount: maximumCollapsedStateCount,
         preparedLoopPresentationMode: playback.loop

--- a/src/adapters/menger/test/cssmenger-playback.test.mjs
+++ b/src/adapters/menger/test/cssmenger-playback.test.mjs
@@ -399,7 +399,7 @@ test("frozen mobile lighting initializes every leaf once and never publishes lig
   }
 });
 
-test("compositor time owns lighting state and collapses missed prepared states into one publication", () => {
+test("anchored prepared time publishes without rAF and collapses missed states once", () => {
   const originalHTMLElement = globalThis.HTMLElement;
   let requestedFrame = null;
   let requestedDelay = null;
@@ -464,20 +464,19 @@ test("compositor time owns lighting state and collapses missed prepared states i
     assert.equal(animationPlayCount, 1);
     animationCurrentTime = 29;
     requestedDelay();
-    requestedFrame(29);
     assert.equal(player.tick, 0);
     assert.equal(lightingAddressWrites, 42);
+    assert.equal(requestedFrame, null);
 
     animationCurrentTime = 30;
     now = 33;
-    requestedFrame(33);
+    requestedDelay();
     assert.equal(player.tick, 1);
     assert.equal(lightingAddressWrites, 84);
 
     animationCurrentTime = 270;
     now = 270;
     requestedDelay();
-    requestedFrame(270);
     assert.equal(player.tick, 9);
     assert.equal(lightingAddressWrites, 126);
     assert.equal(leaves[0].style.backgroundPosition, "0px -729px");
@@ -487,7 +486,6 @@ test("compositor time owns lighting state and collapses missed prepared states i
     animationCurrentTime = 330;
     now = 330;
     requestedDelay();
-    requestedFrame(330);
     assert.equal(player.tick, 11);
     assert.equal(lightingAddressWrites, 168);
     assert.equal(player.stats().preparedCollapsedLightingResyncCount, 2);
@@ -495,32 +493,34 @@ test("compositor time owns lighting state and collapses missed prepared states i
     animationCurrentTime = 360;
     now = 360;
     requestedDelay();
-    requestedFrame(360);
     assert.equal(player.tick, 0);
     assert.equal(lightingAddressWrites, 210);
 
     animationCurrentTime = 390;
     now = 390;
     requestedDelay();
-    requestedFrame(390);
     player.pause();
     assert.equal(player.tick, 1);
     assert.equal(lightingAddressWrites, 252);
     assert.equal(leaves[0].style.backgroundPosition, "0px -81px");
     assert.equal(animationCurrentTimeWrites, 1);
-    assert.equal(player.stats().runtimeCompositorClockReadCount, 6);
+    assert.equal(player.stats().runtimePreparedTimelineCallbackCount, 6);
     assert.equal(player.stats().preparedSchedulerCatchUpMode,
-      "compositor-clock-adjacent-or-collapsed-prepared-resync");
+      "anchored-prepared-timeline-adjacent-or-collapsed-resync");
+    assert.equal(player.stats().runtimeSchedulerTransport,
+      "anchored-deadline-setTimeout-prepared-timeline-publication");
   } finally {
     if (originalHTMLElement === undefined) delete globalThis.HTMLElement;
     else globalThis.HTMLElement = originalHTMLElement;
   }
 });
 
-test("late playback still advances one adjacent prepared state per scheduled draw", () => {
+test("continuous rAF publishes only changed prepared states and collapses missed states atomically", () => {
   const originalHTMLElement = globalThis.HTMLElement;
   let requestedFrame = null;
-  let requestedDelay = null;
+  let requestedFrameCount = 0;
+  let canceledFrameCount = 0;
+  let now = 0;
   let modelTransformWrites = 0;
   let lightingAddressWrites = 0;
   class FakeHTMLElement {
@@ -569,31 +569,58 @@ test("late playback still advances one adjacent prepared state per scheduled dra
       planeAtlas: fakeSparseAtlas(playback.frontFacingSchedule),
       publicationRoot: new FakeHTMLElement(),
       leaves,
-      readNow: () => 0,
-      requestFrame: (callback) => { requestedFrame = callback; return 1; },
-      cancelFrame: () => {},
-      requestDelay: (callback) => { requestedDelay = callback; return 2; },
-      cancelDelay: () => {},
+      readNow: () => now,
+      requestFrame: (callback) => {
+        requestedFrame = callback;
+        requestedFrameCount += 1;
+        return requestedFrameCount;
+      },
+      cancelFrame: () => { canceledFrameCount += 1; },
+      requestDelay: () => { throw new Error("atomic playback requested a timer"); },
+      cancelDelay: () => { throw new Error("atomic playback canceled a timer"); },
     });
+    const fireFrame = (timestamp) => {
+      const callback = requestedFrame;
+      requestedFrame = null;
+      callback(timestamp);
+    };
     player.resume();
-    requestedDelay();
-    requestedFrame(125);
+    assert.equal(requestedFrameCount, 1);
+    fireFrame(16);
+    assert.equal(player.tick, 0);
+    assert.equal(modelTransformWrites, 1);
+    assert.equal(lightingAddressWrites, 42);
+    fireFrame(31);
     assert.equal(player.tick, 1);
     assert.equal(modelTransformWrites, 2);
     assert.equal(lightingAddressWrites, 84);
     assert.equal(leaves[0].style.backgroundPosition, "0px -81px");
-    requestedDelay();
-    requestedFrame(245);
-    player.pause();
+    fireFrame(47);
+    assert.equal(player.tick, 1);
+    assert.equal(modelTransformWrites, 2);
+    assert.equal(lightingAddressWrites, 84);
+    fireFrame(61);
     assert.equal(player.tick, 2);
     assert.equal(modelTransformWrites, 3);
     assert.equal(lightingAddressWrites, 126);
-    assert.equal(leaves[0].style.backgroundPosition, "0px -162px");
-    assert.equal(player.stats().preparedSchedulerCatchUpMode, "one-adjacent-prepared-state-no-skip");
+    fireFrame(245);
+    assert.equal(player.tick, 8);
+    assert.equal(modelTransformWrites, 4);
+    assert.equal(lightingAddressWrites, 168);
+    assert.equal(leaves[0].style.backgroundPosition, "0px -648px");
+    assert.equal(player.stats().preparedCollapsedLightingResyncCount, 1);
+    assert.equal(player.stats().preparedMaximumCollapsedLightingStateCount, 6);
+    player.pause();
+    assert.equal(canceledFrameCount, 1);
+    assert.equal(player.stats().runtimePreparedTimelineCallbackCount, 5);
+    assert.equal(player.stats().preparedSchedulerCatchUpMode,
+      "anchored-prepared-timeline-adjacent-or-collapsed-resync");
+    assert.equal(player.stats().runtimeSchedulerTransport,
+      "continuous-requestAnimationFrame-prepared-timeline-publication");
     player.setTick(11);
+    now = 300;
     player.resume();
-    requestedDelay();
-    requestedFrame(400);
+    fireFrame(330);
     assert.equal(player.tick, 0);
     assert.equal(player.paused, false);
     player.pause();

--- a/src/adapters/menger/tools/oracle/capture-browser-frames.mjs
+++ b/src/adapters/menger/tools/oracle/capture-browser-frames.mjs
@@ -77,7 +77,10 @@ export async function captureBrowserMengerFrames(options = {}) {
           )];
           const planeAtlas = debug.scene.planeAtlas;
           const expectedTransformMatrix = new DOMMatrix(playback.transforms[tick]).toFloat64Array();
-          const publishedTransformMatrix = new DOMMatrix(rotationRoot?.style.transform).toFloat64Array();
+          const publishedTransform = rotationRoot instanceof HTMLElement
+            ? getComputedStyle(rotationRoot).transform
+            : "none";
+          const publishedTransformMatrix = new DOMMatrix(publishedTransform).toFloat64Array();
           const offsets = decodeU16(planeAtlas.addressStateOffsetsBase64);
           const leafIndices = decodeU8(planeAtlas.addressLeafIndicesBase64);
           const slotIndices = decodeU16(planeAtlas.addressSlotIndicesBase64);
@@ -91,11 +94,13 @@ export async function captureBrowserMengerFrames(options = {}) {
             actual: leaf.style.backgroundPosition,
           })).filter((address) => address.expected);
           const mismatchedAddresses = publishedAddresses.filter((address) => address.actual !== address.expected);
+          const deterministicStats = { ...debug.stats() };
+          delete deterministicStats.runtimePreparedTimelineCallbackCount;
           return {
             tick: debug.state().tick,
             paused: debug.state().paused,
             preparedTransform: playback.transforms[tick],
-            publishedTransform: rotationRoot?.style.transform ?? null,
+            publishedTransform,
             publishedTransformMatrixMaxDelta: Math.max(...publishedTransformMatrix.map((value, index) =>
               Math.abs(value - expectedTransformMatrix[index]))),
             paletteIndices: playback.colorRows[tick],
@@ -103,7 +108,7 @@ export async function captureBrowserMengerFrames(options = {}) {
             preparedLightingAddressCount: publishedAddresses.length,
             mismatchedLightingAddressCount: mismatchedAddresses.length,
             mismatchedLightingAddresses: mismatchedAddresses,
-            stats: debug.stats(),
+            stats: deterministicStats,
             errors: debug.errors(),
             stableDom: debug.assertStableDomIdentity(),
           };

--- a/src/adapters/menger/tools/smoke-browser.mjs
+++ b/src/adapters/menger/tools/smoke-browser.mjs
@@ -170,20 +170,16 @@ try {
     const seamEvidence = await page.evaluate(() => {
       const debug = globalThis.__cssMengerDebug;
       const scene = document.querySelector(".polycss-camera > .polycss-scene");
-      const animation = scene.getAnimations()
-        .find((candidate) => candidate.animationName === "cssmenger-prepared-rotation");
-      const frameMilliseconds = debug.scene.playback.sourceFrameDelayMilliseconds;
       const finalStateIndex = debug.scene.playback.stateCount - 1;
-      const cycleMilliseconds = debug.scene.playback.stateCount * frameMilliseconds;
       debug.pause();
-      const matrixAt = (currentTime) => {
-        animation.currentTime = currentTime;
+      const matrixAt = (stateIndex) => {
+        debug.seek(stateIndex);
         return [...new DOMMatrix(getComputedStyle(scene).transform).toFloat64Array()];
       };
       const zero = matrixAt(0);
-      const before = matrixAt(cycleMilliseconds - frameMilliseconds);
-      const boundary = matrixAt(cycleMilliseconds);
-      const after = matrixAt(cycleMilliseconds + frameMilliseconds);
+      const before = matrixAt(finalStateIndex);
+      const boundary = matrixAt(0);
+      const after = matrixAt(1);
       const incomingVelocity = boundary.map((value, index) => value - before[index]);
       const outgoingVelocity = after.map((value, index) => value - boundary[index]);
       const incomingMagnitude = Math.hypot(...incomingVelocity);
@@ -269,12 +265,14 @@ try {
         evidence.stats.preparedLightingAtlasAssetCount !== 1 ||
         evidence.stats.preparedCssOpacityWriteCountPerScheduledTick !== 0 ||
         evidence.stats.preparedSchedulerCatchUpMode !==
-          "compositor-clock-adjacent-or-collapsed-prepared-resync" ||
+          "anchored-prepared-timeline-adjacent-or-collapsed-resync" ||
+        evidence.stats.runtimeSchedulerTransport !==
+          "continuous-requestAnimationFrame-prepared-timeline-publication" ||
         evidence.stats.preparedLoopPresentationMode !== "prepared-forward-cyclic-c2-no-turnaround-no-reset" ||
         evidence.stats.preparedCompositorRotationMode !==
-          "prepared-css-keyframes-on-existing-scene-node" ||
-        evidence.stats.runtimeRotationStyleWriteCountPerScheduledTick !== 0 ||
-        evidence.stats.preparedCompositorRotationAnimationCount !== 1 ||
+          "prepared-inline-transform-publication" ||
+        evidence.stats.runtimeRotationStyleWriteCountPerScheduledTick !== 1 ||
+        evidence.stats.preparedCompositorRotationAnimationCount !== 0 ||
         evidence.stats.preparedFlatSceneLeafLightingSeparation !== true ||
         evidence.stats.retainedRotationRootCount !== 0 || evidence.stats.retainedLightingRootCount !== 0 ||
         evidence.stats.runtimeLightingCalculationCount !== 0 || evidence.stats.runtimeGeometryConstructionCount !== 0) {
@@ -412,8 +410,8 @@ try {
         mobileEvidence.transformAnimationDuration !== "46.08s" ||
         mobileEvidence.transformAnimationTimingFunction !== "linear" ||
         mobileEvidence.transformAnimationDirection !== "normal" ||
-        mobileEvidence.transformAnimationCount !== 1 ||
-        mobileEvidence.transformAnimationPlayState !== "paused" ||
+        mobileEvidence.transformAnimationCount !== 0 ||
+        mobileEvidence.transformAnimationPlayState !== undefined ||
         requestedDesktopAtlases.length !== 0 || requestedMobileAtlases.length !== 1) {
       throw new Error(`cssMenger responsive mobile atlas failed: ${JSON.stringify({
         mobileEvidence, requestedDesktopAtlases, requestedMobileAtlases, mobileErrors,

--- a/src/adapters/menger/tools/trace-cssmenger-performance.mjs
+++ b/src/adapters/menger/tools/trace-cssmenger-performance.mjs
@@ -179,6 +179,9 @@ try {
   const longTasks = sample.longTasks.filter((entry) => Number.isFinite(entry.duration));
   const calibrationFrameIntervals = calibrationSample.frameIntervals.filter((value) => Number.isFinite(value) && value >= 0);
   const calibrationLongTasks = calibrationSample.longTasks.filter((entry) => Number.isFinite(entry.duration));
+  const calibrationFrameSummary = summarizeDurations(calibrationFrameIntervals);
+  const missedDisplayFrameThresholdMilliseconds =
+    calibrationFrameSummary.p50Milliseconds * 1.5;
   const steadyImageDecodes = summarizeTraceWindowEvents(
     traceEvents,
     steadyTraceStartMark,
@@ -186,20 +189,24 @@ try {
     "ImageDecodeTask",
   );
   const summary = {
-    schema: "cssmenger-browser-performance-trace@2",
+    schema: "cssmenger-browser-performance-trace@4",
     capturedAt: new Date().toISOString(),
     route,
     build: "vite-production-preview",
     browser: { name: "Google Chrome", version: browserVersion, channel: "chrome", headless: true },
     viewport: { ...viewport, deviceScaleFactor },
     cpuThrottlingRate,
+    displayCadence: {
+      calibratedFrameIntervalMilliseconds: calibrationFrameSummary.p50Milliseconds,
+      missedFrameThresholdMilliseconds: missedDisplayFrameThresholdMilliseconds,
+    },
     startup: {
       ...startup,
       readyWallMilliseconds,
     },
     pausedCalibration: {
       durationMilliseconds: calibrationDurationMilliseconds,
-      requestAnimationFrame: summarizeDurations(calibrationFrameIntervals),
+      requestAnimationFrame: calibrationFrameSummary,
       overBudgetFrameCount: {
         above16_7Milliseconds: calibrationFrameIntervals.filter((value) => value > 16.7).length,
         above33_3Milliseconds: calibrationFrameIntervals.filter((value) => value > 33.3).length,
@@ -231,7 +238,10 @@ try {
       lightingAddressWriteExpectedFromPreparedAverage:
         (afterState.state.tick - beforeState.state.tick) *
         afterState.stats.preparedLightingAddressWritesPerScheduledTick.average,
-      schedulerCallbackCount: null,
+      schedulerCallbackCount:
+        afterState.stats.runtimePreparedTimelineCallbackCount -
+        beforeState.stats.runtimePreparedTimelineCallbackCount,
+      schedulerTransport: afterState.stats.runtimeSchedulerTransport,
       preparedLightingAddressUpdateCount: afterState.stats.preparedLightingAddressUpdateCount,
       preparedRedundantLightingAddressWriteCountRemoved:
         afterState.stats.preparedRedundantLightingAddressWriteCountRemoved,
@@ -239,6 +249,8 @@ try {
       runtimeLightingAddressComparisonCount: afterState.stats.runtimeLightingAddressComparisonCount,
       requestAnimationFrame: summarizeDurations(frameIntervals),
       overBudgetFrameCount: {
+        aboveCalibratedMissedFrameThreshold:
+          frameIntervals.filter((value) => value > missedDisplayFrameThresholdMilliseconds).length,
         above16_7Milliseconds: frameIntervals.filter((value) => value > 16.7).length,
         above33_3Milliseconds: frameIntervals.filter((value) => value > 33.3).length,
         atLeast50Milliseconds: frameIntervals.filter((value) => value >= 50).length,
@@ -271,6 +283,12 @@ try {
       path: tracePath,
       eventCount: traceEvents.length,
       rendererMainThread: summarizeRendererMainThread(traceEvents),
+      steadyFramePipeline: summarizeSteadyFramePipeline(
+        traceEvents,
+        steadyTraceStartMark,
+        steadyTraceEndMark,
+        missedDisplayFrameThresholdMilliseconds,
+      ),
       steadyImageDecodes,
     },
     errors: [...pageErrors, ...startup.errors, ...afterState.errors],
@@ -286,6 +304,23 @@ try {
       summary.steadyAnimation.runtimeLightingAddressComparisonCount === 0,
     noLongTasksDuringSteadyAnimation: summary.steadyAnimation.longTasks.count === 0,
     noFiftyMillisecondFrames: summary.steadyAnimation.overBudgetFrameCount.atLeast50Milliseconds === 0,
+    continuousSchedulerCallbacksCoverPreparedStates:
+      summary.steadyAnimation.schedulerTransport ===
+        "continuous-requestAnimationFrame-prepared-timeline-publication" &&
+      summary.steadyAnimation.schedulerCallbackCount >
+        summary.steadyAnimation.preparedStateAdvanceCount,
+    noDroppedOrSmoothnessAffectingCompositorFrames:
+      (summary.trace.steadyFramePipeline.pipeline.states.STATE_DROPPED ?? 0) === 0 &&
+      summary.trace.steadyFramePipeline.pipeline.affectsSmoothnessCount === 0,
+    noMissedDisplayCallbacks:
+      summary.steadyAnimation.overBudgetFrameCount
+        .aboveCalibratedMissedFrameThreshold === 0,
+    noFortyFiveMillisecondPublicationGaps:
+      summary.trace.steadyFramePipeline.compositorDrawFrame.overBudgetFrameCount
+        .above45Milliseconds === 0,
+    noFiftyMillisecondCompositorDrawGaps:
+      summary.trace.steadyFramePipeline.compositorDrawFrame.overBudgetFrameCount
+        .atLeast50Milliseconds === 0,
     noImageDecodesDuringSteadyAnimation: summary.trace.steadyImageDecodes.count === 0,
     noErrors: summary.errors.length === 0,
   };
@@ -341,11 +376,7 @@ function summarizeRendererMainThread(events) {
 }
 
 function summarizeTraceWindowEvents(events, startMark, endMark, eventName) {
-  const start = events.find((event) => event.name === startMark)?.ts;
-  const end = events.find((event) => event.name === endMark)?.ts;
-  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
-    throw new Error(`Trace is missing the ${startMark}..${endMark} measurement window`);
-  }
+  const { start, end } = traceWindowBounds(events, startMark, endMark);
   const durations = events
     .filter((event) => {
       if (event.name !== eventName || event.ph !== "X" || !Number.isFinite(event.ts) || !Number.isFinite(event.dur)) return false;
@@ -357,6 +388,74 @@ function summarizeTraceWindowEvents(events, startMark, endMark, eventName) {
     totalDurationMilliseconds: sum(durations),
     maximumDurationMilliseconds: maximum(durations),
   };
+}
+
+function summarizeSteadyFramePipeline(
+  events,
+  startMark,
+  endMark,
+  missedDisplayFrameThresholdMilliseconds,
+) {
+  const { start, end } = traceWindowBounds(events, startMark, endMark);
+  const threadNames = new Map(events
+    .filter((event) => event.ph === "M" && event.name === "thread_name")
+    .map((event) => [`${event.pid}:${event.tid}`, event.args?.name ?? "unnamed"]));
+  const reporters = [];
+  const reporterKeys = new Set();
+  for (const event of events) {
+    if (event.name !== "PipelineReporter" || event.ph !== "b" ||
+        !Number.isFinite(event.ts) || event.ts < start || event.ts > end) continue;
+    const report = event.args?.frame_reporter;
+    const key = `${event.ts}:${report?.frame_sequence}:${report?.state}`;
+    if (reporterKeys.has(key)) continue;
+    reporterKeys.add(key);
+    reporters.push(event);
+  }
+  reporters.sort((left, right) => left.ts - right.ts);
+  const states = {};
+  for (const event of reporters) {
+    const state = event.args?.frame_reporter?.state ?? "STATE_UNKNOWN";
+    states[state] = (states[state] ?? 0) + 1;
+  }
+  const drawTimes = events
+    .filter((event) => event.name === "DrawFrame" && Number.isFinite(event.ts) &&
+      event.ts >= start && event.ts <= end &&
+      threadNames.get(`${event.pid}:${event.tid}`) === "Compositor")
+    .map((event) => event.ts)
+    .sort((left, right) => left - right);
+  const drawIntervals = drawTimes.slice(1).map((value, index) => (value - drawTimes[index]) / 1000);
+  return {
+    pipeline: {
+      count: reporters.length,
+      states,
+      noUpdateDesiredRate: reporters.length
+        ? (states.STATE_NO_UPDATE_DESIRED ?? 0) / reporters.length
+        : null,
+      affectsSmoothnessCount: reporters.filter((event) =>
+        event.args?.frame_reporter?.affects_smoothness === true).length,
+    },
+    compositorDrawFrame: {
+      count: drawTimes.length,
+      intervals: summarizeDurations(drawIntervals),
+      overBudgetFrameCount: {
+        aboveCalibratedMissedFrameThreshold:
+          drawIntervals.filter((value) => value > missedDisplayFrameThresholdMilliseconds).length,
+        above16_7Milliseconds: drawIntervals.filter((value) => value > 16.7).length,
+        above33_3Milliseconds: drawIntervals.filter((value) => value > 33.3).length,
+        above45Milliseconds: drawIntervals.filter((value) => value > 45).length,
+        atLeast50Milliseconds: drawIntervals.filter((value) => value >= 50).length,
+      },
+    },
+  };
+}
+
+function traceWindowBounds(events, startMark, endMark) {
+  const start = events.find((event) => event.name === startMark)?.ts;
+  const end = events.find((event) => event.name === endMark)?.ts;
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    throw new Error(`Trace is missing the ${startMark}..${endMark} measurement window`);
+  }
+  return { start, end };
 }
 
 function percentile(sorted, fraction) {


### PR DESCRIPTION
## Summary
- replace the timer-to-rAF atomic scheduler handoff with continuous rAF sampling
- publish prepared transform and lighting only when the source state changes
- extend browser performance gates for display-cadence and 45 ms publication gaps

## Verification
- pnpm test:menger
- pnpm test:menger:assets
- pnpm build:menger
- pnpm test:menger:browser
- pnpm oracle:menger:browser:aa
- pnpm typecheck
- real-world trace: worst presented gap 39.69 ms, zero gaps above 40 ms