### PR TITLE
Optimize Gravity Well playback and add FrameSleuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,59 @@ XScreenSaver textures under the upstream copyright and permission notice.
 The source checkout, native helpers, captures, and traces remain local and
 ignored.
 
+## FrameSleuth
+
+FrameSleuth turns a Chrome DevTools `.json` or `.json.gz` performance trace
+into an evidence-backed frame report. It selects the active renderer, finds the
+slowest compositor DrawFrame intervals, attributes their renderer/compositor/raster/
+GPU work, correlates timer-to-rAF delay and pipeline drops, and distinguishes
+nested event totals from non-overlapping trace-slice occupancy. Missing trace
+categories are reported as unavailable rather than zero. Renderer-main garbage
+collection, V8 CPU-profile samples, and captured screenshots are included when
+present. CPU samples expose JavaScript self time hidden inside broad task and
+microtask envelopes.
+
+FrameSleuth Tracer creates comparable evidence without the old warm benchmark
+seam. By default it launches the installed Chrome headlessly without opening a
+window, begins tracing on `about:blank`, performs a cold navigation, and leaves
+the page untouched for eight seconds. It writes the raw gzip trace, full-run and
+post-startup FrameSleuth reports, and matching frame-time SVG line charts. No network-idle/readiness wait, seek, step, pause, or
+application-specific debug API participates in the capture.
+
+```sh
+pnpm framesleuth:trace -- http://127.0.0.1:5173/gravitywell/
+pnpm framesleuth:trace -- https://css.graphics/gravitywell/ --duration-ms 10000
+pnpm framesleuth:trace -- http://127.0.0.1:5173/gravitywell/ --screenshots
+pnpm framesleuth -- ~/Downloads/Trace.json.gz
+pnpm framesleuth -- before.json.gz --compare after.json.gz
+pnpm framesleuth -- Trace.json.gz --question "what work did we do on the worst frame?"
+pnpm framesleuth -- Trace.json.gz --format json --output analysis.json
+pnpm framesleuth -- Trace.json.gz --rank 2 --screenshots /tmp/frame-evidence
+```
+
+Use `--headed` only when visible Chrome and possible focus changes are explicitly
+wanted. It is closer to a manually recorded interactive trace, but still uses a
+fresh browser process rather than the user's existing tabs/profile. Screenshot
+events are opt-in because they add recording overhead. Headless captures are
+useful reproducible diagnostics, but they are not proof of physical-display
+presentation and can miss behavior that depends on the interactive compositor.
+
+Use `--frame <index>`, `--rank <slowest-rank>`, or `--around-ms <time>` to
+select one DrawFrame interval; use `--url <substring>` when a trace contains
+multiple active renderer pages. The JSON form uses the versioned
+`cssgraphics-frame-sleuth@1` schema so an agent can answer follow-up questions
+without reparsing the trace.
+
+Question routing covers worst-frame work, scheduler smoothness, lighting and
+rendering cost, dropped-frame/artifact markers, JavaScript functions, garbage
+collection, global GPU correlation, long tasks, missing evidence, screenshots,
+and before/after regressions.
+
+`DrawFrame` spacing is compositor evidence, not proof of physical display
+presentation. GPU/browser process activity is global to the trace and is never
+claimed as page-exclusive work. FrameSleuth lists missing evidence channels and
+keeps inclusive nested duration separate from interval-unioned occupancy.
+
 
 
 ## License

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "node": ">=22.12.0"
   },
   "scripts": {
+    "framesleuth": "node scripts/frame-sleuth.mjs",
+    "framesleuth:trace": "node scripts/frame-sleuth-trace.mjs",
     "dev": "vite --host 127.0.0.1",
     "dev:3dpipes": "vite --config src/adapters/3dpipes/vite.config.mjs --host 127.0.0.1",
     "dev:flowerbox": "vite --config src/adapters/flowerbox/vite.config.mjs --host 127.0.0.1",
@@ -139,6 +141,7 @@
     "compare:maze:frames": "node src/adapters/maze/tools/compare-frame-sequence.mjs",
     "perf:maze:trace": "node src/adapters/maze/tools/trace-performance.mjs",
     "test:site": "node --test site/test/*.test.mjs",
+    "test:framesleuth": "node --test scripts/frame-sleuth*.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/scripts/frame-sleuth-trace.mjs
+++ b/scripts/frame-sleuth-trace.mjs
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import { createReadStream, createWriteStream } from "node:fs";
+import { access, mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { chromium } from "playwright";
+import { analyzeTrace, extractFrameScreenshots, loadTrace, renderFrameChartSvg, renderMarkdown } from "./frame-sleuth.mjs";
+
+export const CAPTURE_SCHEMA = "cssgraphics-frame-sleuth-capture@1";
+export const DEFAULT_CAPTURE_DURATION_MS = 8_000;
+export const DEFAULT_STARTUP_TRIM_MS = 1_000;
+
+const DEVTOOLS_TRACE_CATEGORIES = Object.freeze([
+  "benchmark",
+  "blink",
+  "blink.user_timing",
+  "browser",
+  "cc",
+  "content",
+  "cppgc",
+  "devtools.timeline",
+  "disabled-by-default-blink.debug.layout",
+  "disabled-by-default-devtools.target-rundown",
+  "disabled-by-default-devtools.timeline",
+  "disabled-by-default-devtools.timeline.frame",
+  "disabled-by-default-devtools.v8-source-rundown",
+  "disabled-by-default-devtools.v8-source-rundown-sources",
+  "disabled-by-default-v8.compile",
+  "disabled-by-default-v8.cpu_profiler",
+  "disabled-by-default-v8.gc",
+  "disabled-by-default-v8.inspector",
+  "disabled-by-default-v8.stack_trace",
+  "interactions",
+  "loading",
+  "navigation",
+  "rail",
+  "renderer_host",
+  "v8",
+  "v8.execute",
+]);
+
+const HELP = `FrameSleuth Tracer — capture a DevTools-grade real-Chrome trace and analyze it
+
+Usage:
+  pnpm framesleuth:trace -- <url> [options]
+
+Options:
+  --output <path>       Raw trace path ending in .json.gz (default: unique ignored result path)
+  --duration-ms <ms>    Total untouched recording time including navigation (default: 8000)
+  --startup-ms <ms>     Trim this duration for the separate steady report (default: 1000)
+  --headed              Explicitly open installed Chrome (may take focus)
+  --screenshots         Capture DevTools screenshot events (adds recording overhead)
+  --width <pixels>      Set an explicit CSS viewport width; requires --height
+  --height <pixels>     Set an explicit CSS viewport height; requires --width
+  --help                Show this help
+
+The default is a fresh headless installed-Chrome process and never opens a
+window. Tracing begins on
+about:blank before cold navigation. The tracer never waits for network-idle or
+app readiness and never pauses, seeks, steps, or warms the measured page.
+`;
+
+export function traceCategories({ screenshots = false } = {}) {
+  return Object.freeze([
+    ...DEVTOOLS_TRACE_CATEGORIES,
+    ...(screenshots ? ["disabled-by-default-devtools.screenshot"] : []),
+  ]);
+}
+
+export function parseCaptureCli(argv) {
+  const options = {
+    durationMs: DEFAULT_CAPTURE_DURATION_MS,
+    startupMs: DEFAULT_STARTUP_TRIM_MS,
+    headless: true,
+    screenshots: false,
+    width: null,
+    height: null,
+  };
+  const urls = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--") continue;
+    if (argument === "--help" || argument === "-h") options.help = true;
+    else if (argument === "--output") options.output = requiredValue(argv, ++index, argument);
+    else if (argument === "--duration-ms") options.durationMs = positiveInteger(requiredValue(argv, ++index, argument), argument);
+    else if (argument === "--startup-ms") options.startupMs = nonNegativeInteger(requiredValue(argv, ++index, argument), argument);
+    else if (argument === "--headed") options.headless = false;
+    else if (argument === "--screenshots") options.screenshots = true;
+    else if (argument === "--width") options.width = positiveInteger(requiredValue(argv, ++index, argument), argument);
+    else if (argument === "--height") options.height = positiveInteger(requiredValue(argv, ++index, argument), argument);
+    else if (argument.startsWith("-")) throw new Error(`Unknown option ${argument}.`);
+    else urls.push(argument);
+  }
+  if (options.help) return options;
+  if (urls.length !== 1) throw new Error("Provide exactly one URL.");
+  let url;
+  try {
+    url = new URL(urls[0]);
+  } catch {
+    throw new Error("FrameSleuth Tracer requires an absolute http(s) URL.");
+  }
+  if (!new Set(["http:", "https:"]).has(url.protocol)) {
+    throw new Error("FrameSleuth Tracer requires an absolute http(s) URL.");
+  }
+  if ((options.width == null) !== (options.height == null)) {
+    throw new Error("Use --width and --height together.");
+  }
+  if (options.startupMs >= options.durationMs) {
+    throw new Error("--startup-ms must be smaller than --duration-ms.");
+  }
+  const output = resolve(options.output ?? defaultTracePath(url));
+  if (!output.endsWith(".json.gz")) throw new Error("--output must end in .json.gz.");
+  return Object.freeze({ ...options, url: url.href, output });
+}
+
+export function captureOutputPaths(tracePath) {
+  const absoluteTracePath = resolve(tracePath);
+  const stem = basename(absoluteTracePath).slice(0, -".json.gz".length);
+  const root = dirname(absoluteTracePath);
+  return Object.freeze({
+    trace: absoluteTracePath,
+    capture: resolve(root, `${stem}.capture.json`),
+    analysis: resolve(root, `${stem}.frame-sleuth.json`),
+    fullReport: resolve(root, `${stem}.frame-sleuth.md`),
+    steadyReport: resolve(root, `${stem}.frame-sleuth-steady.md`),
+    fullChart: resolve(root, `${stem}.frame-times.svg`),
+    steadyChart: resolve(root, `${stem}.frame-times-steady.svg`),
+    screenshots: resolve(root, `${stem}-screenshots`),
+  });
+}
+
+export async function captureFrameSleuthTrace(options, { browserType = chromium } = {}) {
+  const paths = captureOutputPaths(options.output);
+  await assertOutputsAbsent(paths, options.screenshots);
+  await mkdir(dirname(paths.trace), { recursive: true });
+  const categories = traceCategories(options);
+  const errors = [];
+  let browser;
+  let context;
+  let page;
+  let browserVersion = null;
+  const capturedAt = new Date().toISOString();
+  const wallStartedAt = Date.now();
+  try {
+    browser = await browserType.launch({ channel: "chrome", headless: options.headless });
+    browserVersion = browser.version();
+    context = await browser.newContext(options.width == null
+      ? { viewport: null }
+      : { viewport: { width: options.width, height: options.height } });
+    page = await context.newPage();
+    page.on("pageerror", (error) => errors.push(error.stack || error.message));
+    page.on("console", (message) => { if (message.type() === "error") errors.push(message.text()); });
+    const cdp = await context.newCDPSession(page);
+    await cdp.send("Network.enable");
+    await cdp.send("Network.setCacheDisabled", { cacheDisabled: true });
+    await startTrace(cdp, categories);
+    const recordingEndsAt = Date.now() + options.durationMs;
+    let navigationError = null;
+    try {
+      await page.goto(options.url, { waitUntil: "commit", timeout: 30_000 });
+      await page.waitForTimeout(Math.max(0, recordingEndsAt - Date.now()));
+    } catch (error) {
+      navigationError = error;
+    }
+    await stopTrace(cdp, paths.trace);
+    if (navigationError) throw navigationError;
+    const finalUrl = page.url();
+    await context.close();
+    context = null;
+    await browser.close();
+    browser = null;
+
+    const loaded = await loadTrace(paths.trace);
+    const urlFilter = new URL(options.url).pathname || new URL(options.url).hostname;
+    const full = analyzeTrace(loaded, {
+      top: 5,
+      url: urlFilter,
+      question: "what work happened on the worst captured frame?",
+    });
+    const steady = analyzeTrace(loaded, {
+      top: 5,
+      url: urlFilter,
+      startMs: options.startupMs,
+      question: "what work happened on the worst steady-playback frame?",
+    });
+    if (options.screenshots && steady.screenshots.available) {
+      steady.screenshots.extracted = await extractFrameScreenshots(loaded, steady, paths.screenshots);
+    }
+    await writeFile(paths.fullChart, renderFrameChartSvg(full), { flag: "wx" });
+    await writeFile(paths.steadyChart, renderFrameChartSvg(steady), { flag: "wx" });
+    await writeFile(paths.fullReport, renderMarkdown(full, null, { frameChart: basename(paths.fullChart) }), { flag: "wx" });
+    await writeFile(paths.steadyReport, renderMarkdown(steady, null, { frameChart: basename(paths.steadyChart) }), { flag: "wx" });
+    await writeFile(paths.analysis, `${JSON.stringify({ full, steady }, null, 2)}\n`, { flag: "wx" });
+    const traceIdentity = await fileIdentity(paths.trace);
+    const capture = Object.freeze({
+      schema: CAPTURE_SCHEMA,
+      capturedAt,
+      requestedUrl: options.url,
+      finalUrl,
+      durationMs: options.durationMs,
+      startupTrimMs: options.startupMs,
+      wallDurationMs: Date.now() - wallStartedAt,
+      browser: {
+        name: "Google Chrome",
+        channel: "chrome",
+        version: browserVersion,
+        headless: options.headless,
+      },
+      viewport: options.width == null ? "browser-default" : { width: options.width, height: options.height },
+      cache: "disabled-fresh-context",
+      untouchedPage: true,
+      categories,
+      screenshotsRequested: options.screenshots,
+      errors,
+      trace: { path: paths.trace, ...traceIdentity },
+      reports: {
+        full: paths.fullReport,
+        steady: paths.steadyReport,
+        analysis: paths.analysis,
+        charts: { full: paths.fullChart, steady: paths.steadyChart },
+        screenshots: steady.screenshots.extracted,
+      },
+      selection: steady.selection,
+      cadence: steady.cadence,
+      worstSteadyFrame: steady.worstFrames[0] ?? null,
+    });
+    await writeFile(paths.capture, `${JSON.stringify(capture, null, 2)}\n`, { flag: "wx" });
+    return capture;
+  } finally {
+    await context?.close().catch(() => undefined);
+    await browser?.close().catch(() => undefined);
+  }
+}
+
+async function startTrace(cdp, categories) {
+  await cdp.send("Tracing.start", {
+    categories: categories.join(","),
+    options: "sampling-frequency=10000",
+    transferMode: "ReturnAsStream",
+    streamFormat: "json",
+    streamCompression: "gzip",
+  });
+}
+
+async function stopTrace(cdp, path) {
+  const completed = new Promise((resolveComplete) => cdp.once("Tracing.tracingComplete", resolveComplete));
+  await cdp.send("Tracing.end");
+  const { stream } = await completed;
+  if (!stream) throw new Error("Chrome trace did not return a stream.");
+  const output = createWriteStream(path, { flags: "wx" });
+  let succeeded = false;
+  try {
+    while (true) {
+      const result = await cdp.send("IO.read", { handle: stream });
+      const bytes = result.base64Encoded ? Buffer.from(result.data, "base64") : Buffer.from(result.data, "utf8");
+      if (!output.write(bytes)) await once(output, "drain");
+      if (result.eof) break;
+    }
+    output.end();
+    await once(output, "close");
+    succeeded = true;
+  } finally {
+    await cdp.send("IO.close", { handle: stream }).catch(() => undefined);
+    if (!succeeded) {
+      output.destroy();
+      await rm(path, { force: true });
+    }
+  }
+}
+
+async function assertOutputsAbsent(paths, screenshots) {
+  const candidates = [paths.trace, paths.capture, paths.analysis, paths.fullReport, paths.steadyReport, paths.fullChart, paths.steadyChart];
+  if (screenshots) candidates.push(paths.screenshots);
+  for (const path of candidates) {
+    try {
+      await access(path);
+      throw new Error(`Refusing to overwrite existing FrameSleuth output ${path}`);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+}
+
+async function fileIdentity(path) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return Object.freeze({
+    byteLength: (await stat(path)).size,
+    sha256: hash.digest("hex"),
+  });
+}
+
+function defaultTracePath(url) {
+  const timestamp = new Date().toISOString().replaceAll(":", "-");
+  const slug = `${url.hostname}${url.pathname}`.replace(/[^a-z0-9]+/giu, "-").replace(/^-|-$/gu, "") || "page";
+  return resolve("bench/results/frame-sleuth", `${timestamp}-${slug}`, "Trace.json.gz");
+}
+
+function requiredValue(argv, index, option) {
+  const value = argv[index];
+  if (value == null || value.startsWith("--")) throw new Error(`${option} requires a value.`);
+  return value;
+}
+
+function positiveInteger(value, option) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number <= 0) throw new Error(`${option} requires a positive integer.`);
+  return number;
+}
+
+function nonNegativeInteger(value, option) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 0) throw new Error(`${option} requires a non-negative integer.`);
+  return number;
+}
+
+async function main(argv) {
+  const options = parseCaptureCli(argv);
+  if (options.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  const capture = await captureFrameSleuthTrace(options);
+  process.stdout.write(`${JSON.stringify(capture, null, 2)}\n`);
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (invokedDirectly) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`FrameSleuth Tracer: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/frame-sleuth-trace.test.mjs
+++ b/scripts/frame-sleuth-trace.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+import {
+  CAPTURE_SCHEMA,
+  captureOutputPaths,
+  parseCaptureCli,
+  traceCategories,
+} from "./frame-sleuth-trace.mjs";
+
+test("defaults to a long untouched no-focus installed-Chrome capture", () => {
+  const output = resolve("output/frame-sleuth-test/default/Trace.json.gz");
+  const options = parseCaptureCli([
+    "http://127.0.0.1:5173/gravitywell/?bank=15",
+    "--output", output,
+  ]);
+  assert.equal(CAPTURE_SCHEMA, "cssgraphics-frame-sleuth-capture@1");
+  assert.equal(options.durationMs, 8_000);
+  assert.equal(options.startupMs, 1_000);
+  assert.equal(options.headless, true);
+  assert.equal(options.screenshots, false);
+  assert.equal(options.width, null);
+  assert.equal(options.height, null);
+  assert.equal(options.url, "http://127.0.0.1:5173/gravitywell/?bank=15");
+});
+
+test("requires paired viewport dimensions and safe gzip output", () => {
+  assert.throws(() => parseCaptureCli(["https://example.test/", "--width", "390"]), /together/);
+  assert.throws(() => parseCaptureCli(["https://example.test/", "--startup-ms", "8000"]), /smaller/);
+  assert.throws(() => parseCaptureCli([new URL("demo.html", `file:${"///"}`).href]), /http\(s\)/);
+  assert.throws(() => parseCaptureCli([
+    "https://example.test/",
+    "--output", resolve("output/frame-sleuth-test/Trace.json"),
+  ]), /.json.gz/);
+});
+
+test("requires explicit headed opt-in before opening a Chrome window", () => {
+  const options = parseCaptureCli([
+    "https://example.test/",
+    "--headed",
+    "--output", resolve("output/frame-sleuth-test/headed/Trace.json.gz"),
+  ]);
+  assert.equal(options.headless, false);
+});
+
+test("captures DevTools frame, JavaScript, GC, navigation, and optional screenshot evidence", () => {
+  const categories = traceCategories();
+  assert.ok(categories.includes("disabled-by-default-devtools.timeline.frame"));
+  assert.ok(categories.includes("disabled-by-default-v8.cpu_profiler"));
+  assert.ok(categories.includes("v8.execute"));
+  assert.ok(categories.includes("navigation"));
+  assert.ok(!categories.includes("disabled-by-default-devtools.screenshot"));
+  assert.ok(traceCategories({ screenshots: true }).includes("disabled-by-default-devtools.screenshot"));
+});
+
+test("derives reports beside the raw trace", () => {
+  const fixture = resolve("output/frame-sleuth-test/run/Trace.json.gz");
+  const root = resolve("output/frame-sleuth-test/run");
+  const paths = captureOutputPaths(fixture);
+  assert.equal(paths.trace, fixture);
+  assert.equal(paths.capture, resolve(root, "Trace.capture.json"));
+  assert.equal(paths.fullReport, resolve(root, "Trace.frame-sleuth.md"));
+  assert.equal(paths.steadyReport, resolve(root, "Trace.frame-sleuth-steady.md"));
+  assert.equal(paths.fullChart, resolve(root, "Trace.frame-times.svg"));
+  assert.equal(paths.steadyChart, resolve(root, "Trace.frame-times-steady.svg"));
+});
+
+test("starts tracing before cold navigation and contains no app warmup seam", async () => {
+  const source = await readFile(resolve(import.meta.dirname, "frame-sleuth-trace.mjs"), "utf8");
+  assert.ok(source.indexOf("await startTrace(cdp, categories)") < source.indexOf("await page.goto(options.url"));
+  assert.doesNotMatch(source, /networkidle|waitForFunction|\.evaluate\(|\.pause\(|\.seek|\.step\(/u);
+  assert.match(source, /headless: options\.headless/u);
+  assert.match(source, /Network\.setCacheDisabled/u);
+});

--- a/scripts/frame-sleuth.mjs
+++ b/scripts/frame-sleuth.mjs
@@ -1,0 +1,1733 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { gunzipSync } from "node:zlib";
+
+export const SCHEMA = "cssgraphics-frame-sleuth@1";
+
+const FOCUS_EVENTS = new Set([
+  "RunTask",
+  "ThreadControllerImpl::RunTask",
+  "FireAnimationFrame",
+  "TimerFire",
+  "FunctionCall",
+  "RunMicrotasks",
+  "UpdateLayoutTree",
+  "RecalculateStyles",
+  "Layout",
+  "PrePaint",
+  "Paint",
+  "PaintImage",
+  "UpdateLayer",
+  "Layerize",
+  "Commit",
+  "RasterTask",
+  "GPUTask",
+]);
+
+const HELP = `FrameSleuth — explain the work performed around slow browser frames
+
+Usage:
+  pnpm framesleuth -- <trace.json|trace.json.gz> [options]
+
+Options:
+  --compare <trace>      Compare the first trace with a second trace
+  --format <type>        markdown (default) or json
+  --output <path>        Write the report to a file
+  --top <count>          Number of slowest compositor DrawFrame intervals (default: 5)
+  --frame <index>        Inspect one 1-based DrawFrame interval
+  --rank <index>         Inspect the Nth-slowest DrawFrame interval
+  --around-ms <number>   Inspect the interval containing this time after window start
+  --screenshots <dir>    Extract the screenshot nearest each reported slow interval
+  --url <substring>      Prefer a renderer whose traced page URL contains this text
+  --start-ms <number>    Trim the inferred active window from its start
+  --end-ms <number>      End analysis this many milliseconds after the inferred start
+  --question <text>      Put the most relevant evidence first
+  --help                 Show this help
+
+Examples:
+  pnpm framesleuth -- ~/Downloads/Trace.json.gz
+  pnpm framesleuth -- before.json.gz --compare after.json.gz
+  pnpm framesleuth -- Trace.json.gz --question "what work did we do on the worst frame?"
+  pnpm framesleuth -- Trace.json.gz --format json --output analysis.json
+  pnpm framesleuth -- Trace.json.gz --rank 2 --screenshots /tmp/frame-evidence
+
+Question topics:
+  worst-frame work; smoothness/scheduler; lighting/paint/raster; drops/artifacts;
+  JavaScript; garbage collection; GPU; long tasks; evidence coverage;
+  screenshots; and before/after regression (with --compare).
+`;
+
+export async function loadTrace(path) {
+  const absolutePath = resolve(path);
+  const source = await readFile(absolutePath);
+  const compressed = source[0] === 0x1f && source[1] === 0x8b;
+  const decoded = compressed ? gunzipSync(source) : source;
+  let parsed;
+  try {
+    parsed = JSON.parse(decoded.toString("utf8"));
+  } catch (error) {
+    throw new Error(`Trace ${absolutePath} is not valid JSON: ${error.message}`);
+  }
+  const events = Array.isArray(parsed) ? parsed : parsed.traceEvents;
+
+  if (!Array.isArray(events)) {
+    throw new Error(`Trace ${absolutePath} does not contain a traceEvents array.`);
+  }
+
+  return {
+    path: absolutePath,
+    bytes: source.byteLength,
+    decodedBytes: decoded.byteLength,
+    compressed,
+    events,
+  };
+}
+
+export function analyzeTrace(loaded, options = {}) {
+  const metadata = collectMetadata(loaded.events);
+  const selection = selectRenderer(loaded.events, metadata, options.url);
+  const cpuProfile = collectCpuProfile(loaded.events, selection);
+  const baseWindow = inferActiveWindow(loaded.events, selection);
+  const window = trimWindow(baseWindow, options.startMs, options.endMs);
+  const events = loaded.events.filter((event) => overlapsWindow(event, window));
+  const rendererEvents = events.filter((event) => event.pid === selection.pid);
+  const mainEvents = rendererEvents.filter((event) => event.tid === selection.mainTid);
+  const compositorEvents = rendererEvents.filter((event) => event.tid === selection.compositorTid);
+  const rasterTids = new Set(
+    rendererEvents.filter((event) => event.name === "RasterTask").map((event) => event.tid),
+  );
+
+  const rafEvents = sortedEvents(mainEvents, "FireAnimationFrame");
+  const updateEvents = sortedEvents(mainEvents, "UpdateLayoutTree");
+  const timerEvents = sortedEvents(mainEvents, "TimerFire");
+  const drawEvents = uniqueTimestampEvents(sortedEvents(compositorEvents, "DrawFrame"));
+  const presentationEvents = uniqueTimestampEvents(sortedEvents(mainEvents, "AnimationFrame::Presentation"));
+  const layerTreeId = dominantValue(drawEvents.map((event) => event.args?.layerTreeId).filter((value) => value != null));
+  const pipelineRecords = collectPipelineRecords(compositorEvents, layerTreeId);
+  const capabilities = summarizeCapabilities({
+    loadedEvents: events,
+    mainEvents,
+    compositorEvents,
+    rendererEvents,
+    drawEvents,
+    pipelineRecords,
+    selection,
+    cpuProfile,
+  });
+  if (layerTreeId == null && pipelineRecords.length > 0) {
+    capabilities.warnings.push("DrawFrame events did not identify a dominant layer tree; PipelineReporter records are renderer-process scoped.");
+  }
+  const cadence = estimateDisplayCadence(compositorEvents, rafEvents, pipelineRecords);
+  const rafStats = summarizeTimestamps(rafEvents.map((event) => event.ts));
+  const timerStats = summarizeTimestamps(timerEvents.map((event) => event.ts));
+  const schedulerCoupling = summarizeSchedulerCoupling(timerStats, rafStats, cadence.ms);
+  const timerToRaf = pairTimersWithRaf(timerEvents, rafEvents, cadence.ms);
+  const frameIntervals = buildFrameIntervals(drawEvents);
+  const drawStats = summarizeTimestamps(drawEvents.map((event) => event.ts));
+  const drawBaselineMs = drawStats.p50Ms ?? cadence.ms;
+  const indexedFrameEvents = indexCompleteEventsByFrame(events, frameIntervals);
+  const frameDetails = frameIntervals.map((frame) =>
+    analyzeFrame({
+      frame,
+      frameEvents: indexedFrameEvents.get(frame.index) ?? [],
+      metadata,
+      selection,
+      rasterTids,
+      cadence,
+      rafEvents,
+      updateEvents,
+      timerToRaf,
+      pipelineRecords,
+      schedulerCoupling,
+      drawBaselineMs,
+      traceStartTs: window.startTs,
+      capabilities,
+      cpuProfile,
+    }),
+  );
+  const slowest = [...frameDetails].sort((a, b) => b.intervalMs - a.intervalMs);
+  const requestedFrame = selectRequestedFrame(frameDetails, slowest, window, options);
+  const longTasks = summarizeLongTasks(mainEvents, window, 50);
+  const pipeline = summarizePipeline(pipelineRecords, drawEvents, cadence.ms, drawStats.p50Ms, window.startTs);
+  pipeline.available = capabilities.signals.pipelineReporter.available;
+  if (!pipeline.available) {
+    pipeline.droppedCount = null;
+    pipeline.affectsSmoothnessCount = null;
+    pipeline.severeDrawStallAlignedCount = null;
+  }
+  const focus = inferQuestionFocus(options.question);
+  const topCount = options.top ?? 5;
+  const gc = summarizeGarbageCollection(mainEvents, window);
+  const updateStats = summarizeTimestamps(updateEvents.map((event) => event.ts));
+  const presentationIntervals = buildFrameIntervals(presentationEvents);
+  const timelineIntervals = presentationIntervals.length > 0 ? presentationIntervals : frameIntervals;
+  const indexedTimelineEvents = presentationIntervals.length > 0
+    ? indexCompleteEventsByFrame(events, timelineIntervals)
+    : indexedFrameEvents;
+  const timelineFrames = buildTimelineFrames(timelineIntervals, indexedTimelineEvents, selection, window.startTs);
+  const timelineStats = {
+    eventCount: timelineIntervals.length + Number(timelineIntervals.length > 0),
+    ...summarizeNumbers(timelineIntervals.map((frame) => frame.intervalMs)),
+  };
+  const timelineBaselineMs = timelineStats.p50Ms ?? drawBaselineMs;
+  const worstTimelineInterval = [...timelineIntervals].sort((a, b) => b.intervalMs - a.intervalMs)[0] ?? null;
+  const worstTimelineFrame = presentationIntervals.length > 0 && worstTimelineInterval
+    ? analyzeFrame({
+      frame: worstTimelineInterval,
+      frameEvents: indexedTimelineEvents.get(worstTimelineInterval.index) ?? [],
+      metadata,
+      selection,
+      rasterTids,
+      cadence,
+      rafEvents,
+      updateEvents,
+      timerToRaf,
+      pipelineRecords,
+      schedulerCoupling,
+      drawBaselineMs: timelineBaselineMs,
+      traceStartTs: window.startTs,
+      capabilities,
+      cpuProfile,
+      intervalKind: "presented animation frame",
+    })
+    : slowest[0] ?? null;
+  const screenshotEvents = collectScreenshotEvents(events);
+  const screenshotTarget = requestedFrame ?? worstTimelineFrame;
+  const nearestScreenshot = screenshotTarget ? nearestScreenshotMetadata(screenshotEvents, screenshotTarget, window.startTs) : null;
+  if (screenshotEvents.length > 0 && screenshotTarget && !nearestScreenshot) {
+    capabilities.warnings.push("Screenshot events were captured, but none matched the selected frame sequence; no temporally-near image from another page was substituted.");
+  }
+
+  return {
+    schema: SCHEMA,
+    generatedAt: new Date().toISOString(),
+    input: {
+      path: loaded.path,
+      name: basename(loaded.path),
+      bytes: loaded.bytes,
+      decodedBytes: loaded.decodedBytes,
+      compressed: loaded.compressed,
+      eventCount: loaded.events.length,
+    },
+    selection: {
+      rendererPid: selection.pid,
+      rendererMainTid: selection.mainTid,
+      compositorTid: selection.compositorTid,
+      layerTreeId,
+      urls: selection.urls,
+      candidates: selection.candidates,
+    },
+    window: {
+      source: baseWindow.source,
+      startTs: window.startTs,
+      endTs: window.endTs,
+      durationMs: round((window.endTs - window.startTs) / 1000),
+    },
+    question: options.question || null,
+    focus,
+    capabilities,
+    cadence: {
+      display: cadence,
+      requestAnimationFrame: rafStats,
+      styleAndLayout: updateStats,
+      drawFrame: drawStats,
+      timer: timerStats,
+      timerToNextRafDelay: summarizeNumbers(timerToRaf.map((pair) => pair.delayMs)),
+      timerToRafDelay: schedulerCoupling.coupled ? summarizeNumbers(timerToRaf.map((pair) => pair.delayMs)) : summarizeNumbers([]),
+      schedulerCoupling,
+      drawGapsAboveMs: Object.fromEntries(
+        [33.3, 40, 45, 50].map((threshold) => [String(threshold), frameIntervals.filter((frame) => frame.intervalMs > threshold).length]),
+      ),
+      drawGapsAboveDisplayMultiples: Object.fromEntries(
+        [1.5, 2, 3].map((multiple) => [String(multiple), frameIntervals.filter((frame) => frame.intervalMs > cadence.ms * multiple).length]),
+      ),
+      drawGapsAboveBaselineMultiples: Object.fromEntries(
+        [1.25, 1.5, 2].map((multiple) => [String(multiple), frameIntervals.filter((frame) => frame.intervalMs > drawBaselineMs * multiple).length]),
+      ),
+    },
+    workload: summarizeWorkload({ events, mainEvents, selection, metadata, rasterTids, window }),
+    cpuProfile: {
+      chunkCount: cpuProfile.chunkCount,
+      unresolvedSampleCount: cpuProfile.unresolvedSampleCount,
+      ...summarizeCpuSamples(cpuProfile.samples, window, cpuProfile.available),
+    },
+    garbageCollection: gc,
+    screenshots: {
+      available: screenshotEvents.length > 0,
+      count: screenshotEvents.length,
+      nearestToSelectedFrame: nearestScreenshot,
+      extracted: [],
+    },
+    pipeline,
+    longTasks: {
+      available: capabilities.signals.runTask.available,
+      thresholdMs: 50,
+      count: capabilities.signals.runTask.available ? longTasks.length : null,
+      maxMs: nullableMax(longTasks.map((task) => task.durationMs)),
+      tasks: longTasks,
+    },
+    requestedFrame,
+    worstFrames: slowest.slice(0, topCount),
+    timeline: {
+      displayMs: cadence.ms,
+      drawBaselineMs,
+      baselineMs: timelineBaselineMs,
+      source: presentationIntervals.length > 0 ? "AnimationFrame::Presentation" : "DrawFrame fallback",
+      stats: timelineStats,
+      worstFrame: worstTimelineFrame,
+      frames: timelineFrames,
+    },
+    verdict: buildVerdict({
+      slowest,
+      timelineWorst: worstTimelineFrame,
+      timelineBaselineMs,
+      cadence,
+      drawStats,
+      pipeline,
+      longTasks,
+      capabilities,
+    }),
+  };
+}
+
+export function compareAnalyses(before, after) {
+  const metrics = {
+    worstDrawGapMs: [before.cadence.drawFrame.maxMs, after.cadence.drawFrame.maxMs],
+    drawGapsAbove45Ms: [before.cadence.drawGapsAboveMs["45"], after.cadence.drawGapsAboveMs["45"]],
+    drawGapsAbove1_5xBaseline: [before.cadence.drawGapsAboveBaselineMultiples["1.5"], after.cadence.drawGapsAboveBaselineMultiples["1.5"]],
+    drawGapP95Ms: [before.cadence.drawFrame.p95Ms, after.cadence.drawFrame.p95Ms],
+    maxRafGapMs: [before.cadence.requestAnimationFrame.maxMs, after.cadence.requestAnimationFrame.maxMs],
+    maxTimerToRafDelayMs: [before.cadence.timerToRafDelay.maxMs, after.cadence.timerToRafDelay.maxMs],
+    longTaskCount: [before.longTasks.count, after.longTasks.count],
+    droppedPipelineRecords: [before.pipeline.droppedCount, after.pipeline.droppedCount],
+    maxPaintMs: [before.workload.named.Paint?.maxMs ?? null, after.workload.named.Paint?.maxMs ?? null],
+    maxRasterMs: [before.workload.named.RasterTask?.maxMs ?? null, after.workload.named.RasterTask?.maxMs ?? null],
+    maxGcMs: [before.garbageCollection.maxMs, after.garbageCollection.maxMs],
+  };
+
+  return {
+    before: before.input.name,
+    after: after.input.name,
+    metrics: Object.fromEntries(
+      Object.entries(metrics).map(([key, [beforeValue, afterValue]]) => [
+        key,
+        {
+          before: beforeValue,
+          after: afterValue,
+          delta: beforeValue == null || afterValue == null ? null : round(afterValue - beforeValue),
+        },
+      ]),
+    ),
+  };
+}
+
+export function renderMarkdown(analysis, comparison = null, artifacts = {}) {
+  const targetFrame = analysis.requestedFrame ?? analysis.timeline.worstFrame ?? analysis.worstFrames[0];
+  const lines = [
+    `# FrameSleuth: ${analysis.input.name}`,
+    "",
+    analysis.question ? `Question: **${analysis.question}**` : "",
+    analysis.question ? "" : "",
+    `**Answer:** ${answerQuestion(analysis, targetFrame, comparison)}`,
+    "",
+    `Renderer PID ${analysis.selection.rendererPid}; analyzed ${formatMs(analysis.window.durationMs)} from ${analysis.window.source}.`,
+    analysis.selection.urls.length ? `Traced target URL: ${analysis.selection.urls.join(", ")}.` : "Traced target URL: unavailable.",
+    `Estimated display cadence: ${formatMs(analysis.cadence.display.ms)} (${analysis.cadence.display.basis}).`,
+    "",
+    "## Cadence",
+    "",
+    "| Signal | Count | p50 | p95 | Max |",
+    "| --- | ---: | ---: | ---: | ---: |",
+    cadenceRow("requestAnimationFrame", analysis.cadence.requestAnimationFrame),
+    cadenceRow("Style/layout publication", analysis.cadence.styleAndLayout),
+    ...(analysis.timeline.source === "AnimationFrame::Presentation"
+      ? [cadenceRow("Presented animation frame", analysis.timeline.stats)]
+      : []),
+    cadenceRow("DrawFrame", analysis.cadence.drawFrame),
+    cadenceRow("Timer", analysis.cadence.timer),
+    cadenceRow("Timer → next rAF (handoff-compatible only)", analysis.cadence.timerToRafDelay),
+    `| Timer/rAF handoff pattern | ${analysis.cadence.schedulerCoupling.coupled ? "yes" : "no"} | ${formatMs(analysis.cadence.schedulerCoupling.cadenceDeltaMs)} cadence delta | ${formatMetric(analysis.cadence.schedulerCoupling.timerToRafCountRatio)} count ratio | ${analysis.cadence.schedulerCoupling.confidence} |`,
+    "",
+    `Draw gaps: ${analysis.cadence.drawGapsAboveMs["33.3"]} >33.3 ms; ${analysis.cadence.drawGapsAboveMs["40"]} >40 ms; ${analysis.cadence.drawGapsAboveMs["45"]} >45 ms; ${analysis.cadence.drawGapsAboveMs["50"]} >50 ms.`,
+    `Display-relative gaps: ${analysis.cadence.drawGapsAboveDisplayMultiples["1.5"]} >1.5×; ${analysis.cadence.drawGapsAboveDisplayMultiples["2"]} >2×; ${analysis.cadence.drawGapsAboveDisplayMultiples["3"]} >3× the inferred display interval.`,
+    `DrawFrame-baseline outliers: ${analysis.cadence.drawGapsAboveBaselineMultiples["1.25"]} >1.25×; ${analysis.cadence.drawGapsAboveBaselineMultiples["1.5"]} >1.5×; ${analysis.cadence.drawGapsAboveBaselineMultiples["2"]} >2× the trace's DrawFrame p50.`,
+    `Long main-thread tasks: ${formatAvailabilityCount(analysis.longTasks.available, analysis.longTasks.count)}. Pipeline drops: ${formatAvailabilityCount(analysis.pipeline.available, analysis.pipeline.droppedCount)}${analysis.pipeline.available ? ` (${analysis.pipeline.severeDrawStallAlignedCount} aligned with a severe DrawFrame stall)` : ""}.`,
+    `Renderer-main GC: ${analysis.garbageCollection.eventCount} slices, ${formatMs(analysis.garbageCollection.occupancyMs)} occupancy, ${formatMs(analysis.garbageCollection.totalMs)} inclusive nested time, ${formatMs(analysis.garbageCollection.maxMs)} max slice.`,
+  ];
+
+  if (artifacts.frameChart) {
+    lines.push(
+      "",
+      "## Frame-time timeline",
+      "",
+      `![Presented frame time over time](${artifacts.frameChart})`,
+      "",
+      `The chart plots each ${analysis.timeline.source === "AnimationFrame::Presentation" ? "presented animation-frame interval from Chromium's presentation-feedback timestamp" : "DrawFrame fallback interval"} directly in milliseconds; slower frames rise upward. Re-presenting unchanged compositor content is deliberately not counted as a new animation frame. The dashed line is the trace's p50 cadence and the dotted line is the inferred display interval. Highlighted points exceed 1.5× the p50 frame interval. FPS is reported only as a cadence summary, not as an instantaneous per-event claim. The work table below analyzes the same highlighted interval.`,
+    );
+  }
+
+  if (targetFrame) {
+    const intervalHeading = analysis.requestedFrame
+      ? `Frame interval ${targetFrame.index}`
+      : targetFrame.intervalKind === "presented animation frame"
+        ? "Worst presented animation-frame interval"
+        : "Worst compositor DrawFrame interval";
+    lines.push("", `## ${intervalHeading}`, "");
+    lines.push(
+      `Interval ${targetFrame.index} lasted **${formatMs(targetFrame.intervalMs)}** at +${formatMs(targetFrame.startMs)} to +${formatMs(targetFrame.endMs)}.`,
+      "",
+      "### Work overlapping the interval",
+      "",
+      "| Execution role | Trace-slice occupancy |",
+      "| --- | ---: |",
+      ...Object.entries(targetFrame.roleBusyMs).map(([role, value]) => `| ${role} | ${formatMs(value)} |`),
+      "",
+      "| Execution role | Trace event | Count | Inclusive time | Max event |",
+      "| --- | --- | ---: | ---: | ---: |",
+      ...targetFrame.namedWork.slice(0, 12).map(
+        (event) => `| ${event.role} | ${event.name} | ${event.count} | ${formatMs(event.totalMs)} | ${formatMs(event.maxMs)} |`,
+      ),
+    );
+
+    if (targetFrame.topMainFunctions.length > 0) {
+      lines.push(
+        "",
+        "### Top main-thread functions",
+        "",
+        "| Function | Inclusive time | Calls |",
+        "| --- | ---: | ---: |",
+        ...targetFrame.topMainFunctions.slice(0, 8).map(
+          (entry) => `| ${escapeTable(entry.label)} | ${formatMs(entry.totalMs)} | ${entry.count} |`,
+        ),
+      );
+    }
+
+    const actionableCpuSamples = targetFrame.cpuProfile.topSelf.filter(
+      (entry) => entry.codeType === "JS" || entry.functionName === "(garbage collector)",
+    );
+    if (targetFrame.cpuProfile.available && actionableCpuSamples.length > 0) {
+      lines.push(
+        "",
+        "### Sampled main-thread self time",
+        "",
+        "| Function | Estimated self time | Samples | Hottest source line |",
+        "| --- | ---: | ---: | ---: |",
+        ...actionableCpuSamples.slice(0, 8).map(
+          (entry) => `| ${escapeTable(entry.label)} | ${formatMs(entry.sampledMs)} | ${entry.sampleCount} | ${entry.hotLine?.line ?? "n/a"} |`,
+        ),
+        "",
+        "CPU-profile values are sampling estimates, not exact wall-clock durations. Idle and unsymbolized program samples are excluded from this source-function table.",
+      );
+    }
+
+    lines.push("", "### Attribution", "");
+    for (const diagnosis of targetFrame.diagnoses) {
+      lines.push(`- **${diagnosis.label}** (${diagnosis.confidence}): ${diagnosis.evidence}`);
+    }
+  }
+
+  lines.push("", "## Slowest intervals", "", "| Rank | Interval | Gap | Main busy | Paint max | Raster max |", "| ---: | ---: | ---: | ---: | ---: | ---: |");
+  analysis.worstFrames.forEach((frame, index) => {
+    lines.push(
+      `| ${index + 1} | ${frame.index} | ${formatMs(frame.intervalMs)} | ${formatMs(frame.roleBusyMs["renderer-main"] ?? 0)} | ${formatMs(frame.metrics.paintMaxMs)} | ${formatMs(frame.metrics.rasterMaxMs)} |`,
+    );
+  });
+
+  if (analysis.pipeline.dropped.length > 0) {
+    lines.push("", "## Pipeline drop records", "");
+    for (const drop of analysis.pipeline.dropped.slice(0, 12)) {
+      lines.push(
+        `- +${formatMs(drop.atMs)}: ${drop.state}${drop.frameType ? ` (${drop.frameType})` : ""}; surrounding DrawFrame gap ${formatMs(drop.surroundingDrawGapMs)}; ${drop.classification}.`,
+      );
+    }
+    if (analysis.pipeline.dropped.length > 12) lines.push(`- … ${analysis.pipeline.dropped.length - 12} additional records are available in JSON output.`);
+  }
+
+  if (analysis.screenshots.nearestToSelectedFrame) {
+    const screenshot = analysis.screenshots.nearestToSelectedFrame;
+    lines.push(
+      "",
+      "## Screenshot evidence",
+      "",
+      `Nearest captured screenshot: +${formatMs(screenshot.atMs)}, ${formatMs(screenshot.deltaFromFrameEndMs)} from the selected interval end${screenshot.exactFrameSequence ? ", exact frame-sequence match" : ""}.`,
+    );
+    for (const extracted of analysis.screenshots.extracted) lines.push(`- ${extracted.path}`);
+  }
+
+  if (comparison) {
+    lines.push("", `## Comparison: ${comparison.before} → ${comparison.after}`, "", "| Metric | Before | After | Delta |", "| --- | ---: | ---: | ---: |");
+    for (const [name, metric] of Object.entries(comparison.metrics)) {
+      lines.push(`| ${name} | ${formatMetric(metric.before)} | ${formatMetric(metric.after)} | ${formatSigned(metric.delta)} |`);
+    }
+  }
+
+  if (analysis.capabilities.warnings.length > 0) {
+    lines.push("", "## Evidence limits", "", ...analysis.capabilities.warnings.map((warning) => `- ${warning}`));
+  }
+  lines.push("", "Inclusive event totals may contain nested work. Execution-role occupancy is interval-unioned and does not double-count nesting; it is traced slice occupancy, not CPU utilization.", "");
+  return lines.filter((line, index, all) => line !== "" || all[index - 1] !== "").join("\n");
+}
+
+export function renderFrameChartSvg(analysis) {
+  const frames = analysis.timeline?.frames ?? [];
+  if (frames.length === 0) throw new Error("A frame-time chart requires at least one frame interval.");
+  const width = 1200;
+  const height = 370;
+  const margin = { right: 30, left: 72 };
+  const plotWidth = width - margin.left - margin.right;
+  const framePlot = { top: 66, height: 240 };
+  const xMin = Math.min(...frames.map((frame) => frame.startMs));
+  const xMax = Math.max(...frames.map((frame) => frame.endMs));
+  const baseline = analysis.timeline.baselineMs ?? analysis.timeline.drawBaselineMs;
+  const displayMs = analysis.timeline.displayMs;
+  const outlierThreshold = baseline * 1.5;
+  const rawFrameMax = Math.max(...frames.map((frame) => frame.intervalMs));
+  const frameStep = rawFrameMax <= 20 ? 5 : rawFrameMax <= 60 ? 10 : 20;
+  const frameMax = Math.max(frameStep, Math.ceil(rawFrameMax / frameStep) * frameStep);
+  const x = (value) => margin.left + ((value - xMin) / Math.max(1, xMax - xMin)) * plotWidth;
+  const frameY = (value) => framePlot.top + framePlot.height - (value / frameMax) * framePlot.height;
+  const oneDecimal = (value) => Number(value).toFixed(1);
+  const secondsPrecision = (xMax - xMin) / 1000 < 1 ? 2 : (xMax - xMin) / 1000 < 10 ? 1 : 0;
+  const secondsLabel = (value) => `${Number(value).toFixed(secondsPrecision)}s`;
+  const framePoints = frames.map((frame) => `${round(x(frame.endMs))},${round(frameY(frame.intervalMs))}`).join(" ");
+  const worst = frames.reduce((current, frame) => frame.intervalMs > current.intervalMs ? frame : current, frames[0]);
+  const frameTicks = Array.from({ length: frameMax / frameStep + 1 }, (_, index) => index * frameStep);
+  const xTickCount = 6;
+  const xTicks = Array.from({ length: xTickCount + 1 }, (_, index) => xMin + ((xMax - xMin) * index) / xTickCount);
+  const outliers = frames.filter((frame) => frame.intervalMs > outlierThreshold);
+  const sourceLabel = analysis.timeline.source === "AnimationFrame::Presentation"
+    ? "Presented animation-frame interval (ms)"
+    : "DrawFrame interval (ms, presentation fallback)";
+  const p50Text = `p50 ${oneDecimal(baseline)} ms (~${oneDecimal(1000 / baseline)} FPS)`;
+  const displayText = `display interval ${oneDecimal(displayMs)} ms`;
+  const worstText = `worst ${oneDecimal(worst.intervalMs)} ms gap`;
+  const worstTextAnchor = x(worst.endMs) > margin.left + plotWidth * 0.8 ? "end" : "start";
+  const worstTextX = worstTextAnchor === "end" ? margin.left + plotWidth - 6 : round(x(worst.endMs) + 8);
+  const worstPointY = frameY(worst.intervalMs);
+  const worstTextY = Math.max(framePlot.top + 18, Math.min(framePlot.top + framePlot.height - 6, worstPointY + 20));
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" role="img" aria-labelledby="title description">
+  <title id="title">FrameSleuth presented animation-frame times</title>
+  <desc id="description">The blue line shows ${sourceLabel.toLowerCase()}, with slower frames rising upward. The p50 frame interval is ${oneDecimal(baseline)} milliseconds and the worst interval is ${oneDecimal(worst.intervalMs)} milliseconds.</desc>
+  <style>
+    :root { color-scheme: dark; --bg: #0b1020; --fg: #f1f5f9; --muted: #a6b2c5; --grid: #29364d; --draw: #60a5fa; --main: #fbbf24; --outlier: #fb7185; }
+    text { fill: var(--fg); font: 12px ui-sans-serif, system-ui, sans-serif; }
+    .muted { fill: var(--muted); }
+    .grid { stroke: var(--grid); stroke-width: 1; }
+    .frame { fill: var(--bg); stroke: var(--grid); }
+    .annotation { font-weight: 500; }
+  </style>
+  <rect width="${width}" height="${height}" fill="var(--bg)"/>
+  <text x="${margin.left}" y="25" font-size="17" font-weight="500">Presented animation-frame times</text>
+  <line x1="${margin.left}" y1="42" x2="${margin.left + 24}" y2="42" stroke="var(--draw)" stroke-width="2.5"/><text x="${margin.left + 32}" y="46">${sourceLabel}</text>
+  <circle cx="${margin.left + 300}" cy="42" r="4" fill="var(--outlier)"/><text x="${margin.left + 311}" y="46">Frame pacing outlier</text>
+  <rect class="frame" x="${margin.left}" y="${framePlot.top}" width="${plotWidth}" height="${framePlot.height}" fill="none"/>
+  ${frameTicks.map((tick) => `<line class="grid" x1="${margin.left}" y1="${round(frameY(tick))}" x2="${margin.left + plotWidth}" y2="${round(frameY(tick))}"/><text class="muted" x="${margin.left - 10}" y="${round(frameY(tick) + 4)}" text-anchor="end">${tick}</text>`).join("\n  ")}
+  ${xTicks.map((tick) => `<line class="grid" x1="${round(x(tick))}" y1="${framePlot.top}" x2="${round(x(tick))}" y2="${framePlot.top + framePlot.height}"/><text class="muted" x="${round(x(tick))}" y="${framePlot.top + framePlot.height + 22}" text-anchor="middle">${secondsLabel((tick - xMin) / 1000)}</text>`).join("\n  ")}
+  <line x1="${margin.left}" y1="${round(frameY(baseline))}" x2="${margin.left + plotWidth}" y2="${round(frameY(baseline))}" stroke="var(--muted)" stroke-dasharray="7 5"/>
+  <line x1="${margin.left}" y1="${round(frameY(displayMs))}" x2="${margin.left + plotWidth}" y2="${round(frameY(displayMs))}" stroke="var(--grid)" stroke-dasharray="2 4"/>
+  <polyline fill="none" stroke="var(--draw)" stroke-width="2.3" stroke-linejoin="round" points="${framePoints}"/>
+  ${outliers.map((frame) => `<circle cx="${round(x(frame.endMs))}" cy="${round(frameY(frame.intervalMs))}" r="4" fill="var(--outlier)"><title>+${round(frame.endMs)} ms: ${round(frame.intervalMs)} ms presented-frame interval</title></circle>`).join("\n  ")}
+  <rect x="${margin.left + plotWidth - 252}" y="${round(frameY(baseline) - 21)}" width="246" height="18" fill="var(--bg)" fill-opacity="0.92"/><text class="muted annotation" x="${margin.left + plotWidth - 8}" y="${round(frameY(baseline) - 7)}" text-anchor="end">${p50Text}</text>
+  <rect x="${margin.left + 6}" y="${round(frameY(displayMs) - 18)}" width="156" height="18" fill="var(--bg)" fill-opacity="0.92"/><text class="muted annotation" x="${margin.left + 10}" y="${round(frameY(displayMs) - 4)}">${displayText}</text>
+  <line x1="${round(x(worst.endMs))}" y1="${framePlot.top}" x2="${round(x(worst.endMs))}" y2="${framePlot.top + framePlot.height}" stroke="var(--outlier)" stroke-dasharray="3 4"/>
+  <rect x="${worstTextAnchor === "end" ? worstTextX - 266 : worstTextX - 4}" y="${round(worstTextY - 15)}" width="270" height="20" fill="var(--bg)" fill-opacity="0.92"/><text class="annotation" x="${worstTextX}" y="${round(worstTextY)}" text-anchor="${worstTextAnchor}">${worstText}</text>
+  <text class="axis-title" data-axis="y" x="18" y="${framePlot.top + framePlot.height / 2}" text-anchor="middle" transform="rotate(-90 18 ${framePlot.top + framePlot.height / 2})">Presented animation-frame interval (ms)</text>
+  <text class="axis-title" data-axis="x" x="${margin.left + plotWidth / 2}" y="${height - 10}" text-anchor="middle">Time after analysis-window start (seconds)</text>
+</svg>
+`;
+}
+
+function collectMetadata(events) {
+  const processNames = new Map();
+  const threadNames = new Map();
+  const urlsByPid = new Map();
+
+  function addUrl(pidValue, url) {
+    const pid = Number(pidValue);
+    if (!Number.isFinite(pid) || typeof url !== "string" || url.length === 0) return;
+    const urls = urlsByPid.get(pid) ?? new Set();
+    urls.add(url);
+    urlsByPid.set(pid, urls);
+  }
+
+  for (const event of events) {
+    if (event.ph === "M" && event.name === "process_name") processNames.set(event.pid, event.args?.name ?? "");
+    if (event.ph === "M" && event.name === "thread_name") threadNames.set(threadKey(event.pid, event.tid), event.args?.name ?? "");
+    const frames = event.name === "TracingStartedInBrowser" ? event.args?.data?.frames : null;
+    if (Array.isArray(frames)) {
+      for (const frame of frames) {
+        addUrl(frame.processId, frame.url);
+      }
+    }
+    if (event.name === "FrameCommittedInBrowser") {
+      addUrl(event.args?.data?.processId ?? event.pid, event.args?.data?.url);
+    }
+    if (event.name === "CommitLoad" && event.args?.data?.isMainFrame !== false) {
+      addUrl(event.pid, event.args?.data?.url);
+    }
+    if (event.name === "FrameLoader:state_snapshot" && event.args?.snapshot?.isOutermostMainFrame !== false) {
+      addUrl(event.pid, event.args?.snapshot?.documentLoaderURL);
+    }
+  }
+
+  return { processNames, threadNames, urlsByPid };
+}
+
+function selectRenderer(events, metadata, urlFilter) {
+  const mains = [];
+  for (const [key, name] of metadata.threadNames) {
+    if (name !== "CrRendererMain") continue;
+    const [pidText, tidText] = key.split(":");
+    const pid = Number(pidText);
+    const tid = Number(tidText);
+    const capturedUrls = [...(metadata.urlsByPid.get(pid) ?? [])];
+    const urls = capturedUrls.some((url) => url !== "about:blank")
+      ? capturedUrls.filter((url) => url !== "about:blank")
+      : capturedUrls;
+    const mainEvents = events.filter((event) => event.pid === pid && event.tid === tid);
+    const compositorTids = [...metadata.threadNames]
+      .filter(([thread, threadName]) => thread.startsWith(`${pid}:`) && threadName === "Compositor")
+      .map(([thread]) => Number(thread.split(":")[1]));
+    const rafCount = countNamed(mainEvents, "FireAnimationFrame");
+    const updateCount = countNamed(mainEvents, "UpdateLayoutTree");
+    const drawCount = events.filter(
+      (event) => event.pid === pid && compositorTids.includes(event.tid) && event.name === "DrawFrame",
+    ).length;
+    const urlMatch = Boolean(urlFilter && urls.some((url) => url.includes(urlFilter)));
+    const score = rafCount * 10 + updateCount * 4 + drawCount * 2 + (urlMatch ? 1_000_000 : 0);
+    mains.push({ pid, tid, compositorTids, urls, rafCount, updateCount, drawCount, urlMatch, score });
+  }
+
+  mains.sort((a, b) => b.score - a.score);
+  const selected = mains[0];
+  if (!selected || selected.score === 0) throw new Error("FrameSleuth could not find an active CrRendererMain thread.");
+  if (urlFilter && !selected.urlMatch) throw new Error(`No active renderer URL contains ${JSON.stringify(urlFilter)}.`);
+
+  const compositorTid = selected.compositorTids
+    .map((tid) => ({ tid, draws: events.filter((event) => event.pid === selected.pid && event.tid === tid && event.name === "DrawFrame").length }))
+    .sort((a, b) => b.draws - a.draws)[0]?.tid;
+  if (compositorTid == null) throw new Error(`Renderer PID ${selected.pid} has no Compositor thread.`);
+
+  return {
+    pid: selected.pid,
+    mainTid: selected.tid,
+    compositorTid,
+    urls: selected.urls,
+    candidates: mains.map(({ pid, tid, urls, rafCount, updateCount, drawCount, urlMatch, score }) => ({
+      pid,
+      tid,
+      urls,
+      rafCount,
+      updateCount,
+      drawCount,
+      urlMatch,
+      score,
+    })),
+  };
+}
+
+function inferActiveWindow(events, selection) {
+  const selectedEvents = events.filter((event) => event.pid === selection.pid);
+  const startMarks = selectedEvents.filter((event) => /steady.*(?:animation|playback).*start|(?:animation|playback).*steady.*start/iu.test(event.name));
+  const endMarks = selectedEvents.filter((event) => /steady.*(?:animation|playback).*end|(?:animation|playback).*steady.*end/iu.test(event.name));
+  if (startMarks.length > 0 && endMarks.length > 0) {
+    const startTs = Math.min(...startMarks.map((event) => event.ts));
+    const endTs = Math.max(...endMarks.map((event) => event.ts));
+    if (endTs > startTs) return { startTs, endTs, source: "steady-playback user timing marks" };
+  }
+
+  const active = selectedEvents.filter(
+    (event) =>
+      (event.tid === selection.mainTid && (event.name === "FireAnimationFrame" || event.name === "UpdateLayoutTree")) ||
+      (event.tid === selection.compositorTid && event.name === "DrawFrame"),
+  );
+  if (active.length < 2) throw new Error("Selected renderer has too few animation events to infer an active window.");
+  return {
+    startTs: Math.min(...active.map((event) => event.ts)),
+    endTs: Math.max(...active.map(eventEnd)),
+    source: "active renderer animation events",
+  };
+}
+
+function trimWindow(window, startMs, endMs) {
+  const requestedStart = window.startTs + (startMs ?? 0) * 1000;
+  const requestedEnd = endMs == null ? window.endTs : window.startTs + endMs * 1000;
+  if (requestedEnd <= requestedStart) throw new Error("The requested analysis window is empty.");
+  return { startTs: requestedStart, endTs: Math.min(requestedEnd, window.endTs) };
+}
+
+function estimateDisplayCadence(compositorEvents, rafEvents, pipelineRecords) {
+  const candidates = [];
+  const beginFrames = uniqueTimestampEvents(sortedEvents(compositorEvents, "BeginFrame"));
+  const presented = pipelineRecords.filter((record) => record.state === "STATE_PRESENTED_ALL");
+  addCadenceCandidate(candidates, "Compositor BeginFrame", beginFrames.map((event) => event.ts));
+  addCadenceCandidate(candidates, "presented PipelineReporter", presented.map((record) => record.ts));
+  addCadenceCandidate(candidates, "requestAnimationFrame", rafEvents.map((event) => event.ts));
+  const plausible = candidates.filter((candidate) => candidate.count >= 5 && candidate.p50Ms >= 4 && candidate.p50Ms <= 40);
+  // Prefer the compositor clock. Matching only common 60/120 Hz periods gives
+  // wrong answers on 75/90/144 Hz and variable-refresh displays.
+  const best = plausible[0] ?? candidates[0];
+  return best
+    ? { ms: round(best.p50Ms), basis: best.basis, sampleCount: best.count, inferred: true }
+    : { ms: 16.667, basis: "60 Hz fallback", sampleCount: 0, inferred: false };
+}
+
+function addCadenceCandidate(candidates, basis, timestamps) {
+  const stats = summarizeTimestamps(timestamps);
+  if (stats.count > 0 && stats.p50Ms != null) candidates.push({ basis, count: stats.count, p50Ms: stats.p50Ms });
+}
+
+function collectPipelineRecords(events, layerTreeId) {
+  const records = [];
+  const seen = new Set();
+  for (const event of events) {
+    const reporter = event.name === "PipelineReporter" ? event.args?.frame_reporter : null;
+    if (!reporter?.state) continue;
+    if (layerTreeId != null && reporter.layer_tree_host_id != null && reporter.layer_tree_host_id !== layerTreeId) continue;
+    const identity = reporter.frame_sequence == null
+      ? `${event.ts}`
+      : `${reporter.frame_source ?? "?"}:${reporter.frame_sequence}`;
+    const key = `${identity}:${reporter.state}:${reporter.frame_type ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    records.push({
+      ts: event.ts,
+      state: reporter.state,
+      affectsSmoothness: reporter.affects_smoothness === true,
+      frameType: reporter.frame_type ?? null,
+      frameSequence: reporter.frame_sequence ?? null,
+      frameSource: reporter.frame_source ?? null,
+      layerTreeHostId: reporter.layer_tree_host_id ?? null,
+    });
+  }
+  return records.sort((a, b) => a.ts - b.ts);
+}
+
+function summarizePipeline(records, drawEvents, displayMs, drawBaselineMs, startTs) {
+  const states = {};
+  for (const record of records) states[record.state] = (states[record.state] ?? 0) + 1;
+  const drops = records.filter((record) => record.state.includes("DROPPED") || record.affectsSmoothness);
+  const severeThresholdMs = Math.max(displayMs * 2.4, (drawBaselineMs ?? displayMs) * 1.5);
+  const dropped = drops.map((record) => {
+    const surroundingDrawGapMs = surroundingGap(drawEvents, record.ts);
+    const severe = surroundingDrawGapMs != null && surroundingDrawGapMs > severeThresholdMs;
+    return {
+      atMs: offsetMs(record.ts, startTs),
+      state: record.state,
+      frameType: record.frameType,
+      affectsSmoothness: record.affectsSmoothness,
+      surroundingDrawGapMs,
+      classification: severe ? "aligned with a severe DrawFrame stall" : "not aligned with a severe DrawFrame stall",
+      severeDrawStallAligned: severe,
+    };
+  });
+  return {
+    recordCount: records.length,
+    states,
+    droppedCount: dropped.length,
+    affectsSmoothnessCount: records.filter((record) => record.affectsSmoothness).length,
+    severeDrawStallAlignedCount: dropped.filter((record) => record.severeDrawStallAligned).length,
+    severeDrawStallThresholdMs: round(severeThresholdMs),
+    dropped,
+  };
+}
+
+function pairTimersWithRaf(timers, rafEvents, displayMs) {
+  return timers.flatMap((timer) => {
+    const raf = rafEvents.find((event) => event.ts >= timer.ts);
+    if (!raf || (raf.ts - timer.ts) / 1000 > Math.max(50, displayMs * 3)) return [];
+    return [{
+      timerTs: timer.ts,
+      rafTs: raf.ts,
+      delayMs: round((raf.ts - timer.ts) / 1000),
+      correlation: "temporal-next-callback",
+    }];
+  });
+}
+
+function summarizeSchedulerCoupling(timerStats, rafStats, displayMs) {
+  if (timerStats.eventCount < 5 || rafStats.eventCount < 5 || timerStats.p50Ms == null || rafStats.p50Ms == null) {
+    return { coupled: false, confidence: "insufficient-samples", timerToRafCountRatio: null, cadenceDeltaMs: null };
+  }
+  const countRatio = timerStats.eventCount / rafStats.eventCount;
+  const cadenceDeltaMs = Math.abs(timerStats.p50Ms - rafStats.p50Ms);
+  const coupled = countRatio >= 0.75 && countRatio <= 1.25 && cadenceDeltaMs <= displayMs;
+  return {
+    coupled,
+    confidence: coupled ? "medium" : "high",
+    timerToRafCountRatio: round(countRatio),
+    cadenceDeltaMs: round(cadenceDeltaMs),
+    evidence: coupled
+      ? "timer and rAF event counts/cadences are compatible with a handoff pattern"
+      : "timer and rAF counts/cadences do not support a one-to-one handoff pattern",
+  };
+}
+
+function buildFrameIntervals(drawEvents) {
+  const intervals = [];
+  for (let index = 1; index < drawEvents.length; index += 1) {
+    const previous = drawEvents[index - 1];
+    const current = drawEvents[index];
+    intervals.push({
+      index,
+      startTs: previous.ts,
+      endTs: current.ts,
+      intervalMs: round((current.ts - previous.ts) / 1000),
+      previousFrameSeqId: previous.args?.frameSeqId ?? null,
+      frameSeqId: current.args?.frameSeqId ?? null,
+    });
+  }
+  return intervals;
+}
+
+function buildTimelineFrames(intervals, indexedEvents, selection, traceStartTs) {
+  return intervals.map((frame) => {
+    const mainThreadIntervals = (indexedEvents.get(frame.index) ?? [])
+      .filter((event) => event.pid === selection.pid && event.tid === selection.mainTid)
+      .map((event) => clipInterval(event, frame.startTs, frame.endTs));
+    return {
+      index: frame.index,
+      startMs: offsetMs(frame.startTs, traceStartTs),
+      endMs: offsetMs(frame.endTs, traceStartTs),
+      intervalMs: frame.intervalMs,
+      mainBusyMs: round(unionDuration(mainThreadIntervals) / 1000),
+    };
+  });
+}
+
+function indexCompleteEventsByFrame(events, frames) {
+  const indexed = new Map(frames.map((frame) => [frame.index, []]));
+  if (frames.length === 0) return indexed;
+  for (const event of events) {
+    if (!isComplete(event)) continue;
+    let index = firstFrameEndingAfter(frames, event.ts);
+    const endTs = eventEnd(event);
+    while (index < frames.length && frames[index].startTs < endTs) {
+      indexed.get(frames[index].index).push(event);
+      index += 1;
+    }
+  }
+  return indexed;
+}
+
+function firstFrameEndingAfter(frames, timestamp) {
+  let low = 0;
+  let high = frames.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (frames[middle].endTs <= timestamp) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+function selectRequestedFrame(frameDetails, slowest, window, options) {
+  const selectors = [options.frame != null, options.rank != null, options.aroundMs != null].filter(Boolean).length;
+  if (selectors > 1) throw new Error("Use only one of --frame, --rank, or --around-ms.");
+  if (options.frame != null) {
+    const selected = frameDetails.find((frame) => frame.index === options.frame);
+    if (!selected) throw new Error(`DrawFrame interval ${options.frame} does not exist; valid range is 1-${frameDetails.at(-1)?.index ?? 0}.`);
+    return selected;
+  }
+  if (options.rank != null) {
+    const selected = slowest[options.rank - 1];
+    if (!selected) throw new Error(`Slow-frame rank ${options.rank} does not exist; only ${slowest.length} intervals were captured.`);
+    return selected;
+  }
+  if (options.aroundMs != null) {
+    const timestamp = window.startTs + options.aroundMs * 1000;
+    const selected = frameDetails.find((frame, index) =>
+      frame.startTs <= timestamp && (timestamp < frame.endTs || (index === frameDetails.length - 1 && timestamp === frame.endTs)),
+    );
+    if (!selected) throw new Error(`No DrawFrame interval contains +${options.aroundMs} ms.`);
+    return selected;
+  }
+  return null;
+}
+
+function summarizeCapabilities({ loadedEvents, mainEvents, compositorEvents, rendererEvents, drawEvents, pipelineRecords, selection, cpuProfile }) {
+  const screenshotCount = loadedEvents.filter((event) => event.name === "Screenshot" && screenshotPayload(event)).length;
+  const capabilities = {
+    drawFrame: capability(drawEvents.length, "compositor frame-spacing analysis", 2),
+    beginFrame: capability(countNamed(compositorEvents, "BeginFrame"), "display-cadence estimation"),
+    requestAnimationFrame: capability(countNamed(mainEvents, "FireAnimationFrame"), "callback-cadence analysis"),
+    runTask: capability(mainEvents.filter((event) => isComplete(event) && isTask(event)).length, "main-thread long-task exclusion"),
+    pipelineReporter: capability(pipelineRecords.length, "dropped-frame marker analysis"),
+    paint: capability(countNamed(rendererEvents, "Paint"), "paint-cost analysis"),
+    raster: capability(countNamed(rendererEvents, "RasterTask"), "raster-cost analysis"),
+    functionCall: capability(countNamed(mainEvents, "FunctionCall"), "JavaScript function attribution"),
+    cpuProfile: capability(cpuProfile.samples.length, "sampled JavaScript self-time attribution"),
+    screenshots: capability(screenshotCount, "visual evidence extraction"),
+  };
+  const warnings = [];
+  if (!capabilities.drawFrame.available) warnings.push("At least two DrawFrame events are required for frame-spacing analysis.");
+  if (!capabilities.runTask.available) warnings.push("RunTask slices were not captured; absence of long tasks cannot be established.");
+  if (!capabilities.pipelineReporter.available) warnings.push("PipelineReporter was not captured; dropped-frame marker conclusions are unavailable.");
+  if (!capabilities.paint.available) warnings.push("Paint events were not captured; paint cost is unknown, not zero.");
+  if (!capabilities.raster.available) warnings.push("RasterTask events were not captured; raster cost is unknown, not zero.");
+  if (!capabilities.cpuProfile.available) warnings.push("V8 CPU profile samples were not captured; JavaScript inside task and microtask envelopes may be opaque.");
+  if (!capabilities.beginFrame.available) warnings.push("BeginFrame was not captured; display cadence uses a weaker fallback signal.");
+  if (!capabilities.screenshots.available) warnings.push("Screenshot events were not captured; FrameSleuth cannot provide visual evidence for this trace.");
+  const activeCandidates = selection.candidates.filter((candidate) => candidate.score > 0);
+  if (selection.urls.length === 0) warnings.push("The selected renderer has no traced URL metadata; PID selection is activity-based only.");
+  if (activeCandidates.length > 1 && !activeCandidates[0].urlMatch) {
+    warnings.push(`${activeCandidates.length} active renderer candidates were found; use --url when the automatically selected page is not the target.`);
+  }
+  warnings.push("GPU and browser-process slices are global to the trace and cannot be attributed exclusively to the selected page.");
+  return { signals: capabilities, warnings };
+}
+
+function collectCpuProfile(events, selection) {
+  const profiles = events.filter((event) =>
+    event.name === "Profile" && event.ph === "P" && event.pid === selection.pid &&
+    event.tid === selection.mainTid && Number.isFinite(event.args?.data?.startTime),
+  );
+  if (profiles.length === 0) {
+    return { available: false, chunkCount: 0, unresolvedSampleCount: 0, samples: [] };
+  }
+  const profile = profiles[0];
+  const chunks = events
+    .filter((event) => event.name === "ProfileChunk" && event.ph === "P" && event.pid === selection.pid &&
+      (profile.id == null || event.id == null || event.id === profile.id))
+    .sort((a, b) => a.ts - b.ts);
+  const nodes = new Map();
+  const rawSamples = [];
+  let timestamp = profile.args.data.startTime;
+  for (const chunk of chunks) {
+    const data = chunk.args?.data ?? {};
+    for (const node of data.cpuProfile?.nodes ?? []) nodes.set(node.id, node);
+    const samples = data.cpuProfile?.samples ?? [];
+    const deltas = data.timeDeltas ?? [];
+    for (let index = 0; index < samples.length; index += 1) {
+      const deltaUs = Number.isFinite(deltas[index]) ? deltas[index] : 0;
+      timestamp += deltaUs;
+      rawSamples.push({
+        ts: timestamp,
+        deltaUs,
+        nodeId: samples[index],
+        line: Number.isFinite(data.lines?.[index]) && data.lines[index] > 0 ? data.lines[index] : null,
+        column: Number.isFinite(data.columns?.[index]) && data.columns[index] > 0 ? data.columns[index] : null,
+      });
+    }
+  }
+  let unresolvedSampleCount = 0;
+  const samples = [];
+  for (const sample of rawSamples) {
+    const node = nodes.get(sample.nodeId);
+    if (!node?.callFrame) {
+      unresolvedSampleCount += 1;
+      continue;
+    }
+    const frame = node.callFrame;
+    const functionName = frame.functionName || "(anonymous)";
+    const file = frame.url ? basenameFromUrl(frame.url) : frame.codeType || "unknown";
+    const line = sample.line ?? (Number.isFinite(frame.lineNumber) ? frame.lineNumber + 1 : null);
+    samples.push({
+      ts: sample.ts,
+      sampledMs: round(Math.max(0, sample.deltaUs) / 1000),
+      functionName,
+      file,
+      line,
+      column: sample.column,
+      codeType: frame.codeType || null,
+      label: `${functionName} — ${file}`,
+      location: line == null ? file : `${file}:${line}`,
+    });
+  }
+  return {
+    available: samples.length > 0,
+    chunkCount: chunks.length,
+    unresolvedSampleCount,
+    samples,
+  };
+}
+
+function summarizeCpuSamples(samples, range, available = samples.length > 0) {
+  const selected = samples.filter((sample) => sample.ts >= range.startTs && sample.ts < range.endTs);
+  const groups = new Map();
+  for (const sample of selected) {
+    const group = groups.get(sample.label) ?? {
+      label: sample.label,
+      functionName: sample.functionName,
+      file: sample.file,
+      codeType: sample.codeType,
+      sampleCount: 0,
+      sampledMs: 0,
+      lines: new Map(),
+    };
+    group.sampleCount += 1;
+    group.sampledMs += sample.sampledMs;
+    if (sample.line != null) {
+      const line = group.lines.get(sample.line) ?? { line: sample.line, sampleCount: 0, sampledMs: 0 };
+      line.sampleCount += 1;
+      line.sampledMs += sample.sampledMs;
+      group.lines.set(sample.line, line);
+    }
+    groups.set(sample.label, group);
+  }
+  const topSelf = [...groups.values()]
+    .map((group) => {
+      const hotLine = [...group.lines.values()].sort((a, b) => b.sampledMs - a.sampledMs || b.sampleCount - a.sampleCount)[0] ?? null;
+      return {
+        label: group.label,
+        functionName: group.functionName,
+        file: group.file,
+        codeType: group.codeType,
+        sampleCount: group.sampleCount,
+        sampledMs: round(group.sampledMs),
+        hotLine: hotLine ? { ...hotLine, sampledMs: round(hotLine.sampledMs) } : null,
+      };
+    })
+    .sort((a, b) => b.sampledMs - a.sampledMs || b.sampleCount - a.sampleCount)
+    .slice(0, 20);
+  return {
+    available,
+    sampleCount: selected.length,
+    sampledMs: round(selected.reduce((sum, sample) => sum + sample.sampledMs, 0)),
+    topSelf,
+  };
+}
+
+function capability(eventCount, supports, minimum = 1) {
+  return { available: eventCount >= minimum, eventCount, minimum, supports };
+}
+
+function summarizeGarbageCollection(mainEvents, window) {
+  const events = mainEvents.filter((event) => isComplete(event) && isGcEvent(event.name));
+  const durations = events.map((event) => clippedDuration(event, window.startTs, window.endTs) / 1000);
+  return {
+    available: events.length > 0,
+    eventCount: events.length,
+    totalMs: round(durations.reduce((sum, value) => sum + value, 0)),
+    occupancyMs: round(unionDuration(events.map((event) => clipInterval(event, window.startTs, window.endTs))) / 1000),
+    maxMs: nullableMax(durations),
+    events: events
+      .map((event) => ({ name: event.name, atMs: offsetMs(event.ts, window.startTs), durationMs: round(event.dur / 1000) }))
+      .sort((a, b) => b.durationMs - a.durationMs)
+      .slice(0, 20),
+  };
+}
+
+function summarizeLongTasks(mainEvents, window, thresholdMs) {
+  const intervals = mainEvents
+    .filter((event) => isComplete(event) && isTask(event) && event.dur / 1000 >= thresholdMs)
+    .map((event) => clipInterval(event, window.startTs, window.endTs))
+    .filter(([start, end]) => end > start)
+    .sort((a, b) => a[0] - b[0] || b[1] - a[1]);
+  const merged = [];
+  for (const interval of intervals) {
+    const previous = merged.at(-1);
+    if (previous && interval[0] < previous[1]) previous[1] = Math.max(previous[1], interval[1]);
+    else merged.push([...interval]);
+  }
+  return merged.map(([start, end]) => ({
+    atMs: offsetMs(start, window.startTs),
+    durationMs: round((end - start) / 1000),
+  }));
+}
+
+function collectScreenshotEvents(events) {
+  return events
+    .filter((event) => event.name === "Screenshot" && screenshotPayload(event))
+    .sort((a, b) => screenshotTimestamp(a) - screenshotTimestamp(b));
+}
+
+function nearestScreenshotMetadata(screenshots, frame, traceStartTs) {
+  const screenshot = nearestScreenshot(screenshots, frame);
+  if (!screenshot) return null;
+  return {
+    atMs: offsetMs(screenshotTimestamp(screenshot), traceStartTs),
+    deltaFromFrameEndMs: round(Math.abs(screenshotTimestamp(screenshot) - frame.endTs) / 1000),
+    frameSequence: screenshot.args?.frame_sequence ?? null,
+    exactFrameSequence: screenshot.args?.frame_sequence != null && screenshot.args.frame_sequence === frame.frameSeqId,
+    mimeType: screenshotMimeType(screenshotPayload(screenshot)),
+  };
+}
+
+function nearestScreenshot(screenshots, frame) {
+  const exact = screenshots.find(
+    (event) => frame.frameSeqId != null && event.args?.frame_sequence != null && event.args.frame_sequence === frame.frameSeqId,
+  );
+  if (exact) return exact;
+  const legacy = screenshots.filter((event) => event.args?.frame_sequence == null);
+  if (frame.frameSeqId != null && legacy.length === 0) return null;
+  const candidates = legacy.length > 0 ? legacy : screenshots;
+  return candidates.reduce((best, event) => {
+    if (!best) return event;
+    return Math.abs(screenshotTimestamp(event) - frame.endTs) < Math.abs(screenshotTimestamp(best) - frame.endTs) ? event : best;
+  }, null);
+}
+
+function screenshotTimestamp(event) {
+  return Number.isFinite(event.args?.expected_display_time) ? event.args.expected_display_time : event.ts;
+}
+
+function screenshotMimeType(snapshot) {
+  const bytes = Buffer.from(normalizeBase64(snapshot).slice(0, 32), "base64");
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
+  if (bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) return "image/png";
+  return "application/octet-stream";
+}
+
+function screenshotPayload(event) {
+  const snapshot = event.args?.snapshot ?? event.args?.data?.snapshot;
+  return typeof snapshot === "string" && snapshot.length > 0 ? snapshot : null;
+}
+
+function normalizeBase64(snapshot) {
+  const comma = snapshot.indexOf(",");
+  return snapshot.startsWith("data:") && comma >= 0 ? snapshot.slice(comma + 1) : snapshot;
+}
+
+export async function extractFrameScreenshots(loaded, analysis, directory) {
+  const screenshots = collectScreenshotEvents(loaded.events).filter((event) => {
+    const timestamp = screenshotTimestamp(event);
+    return timestamp >= analysis.window.startTs && timestamp <= analysis.window.endTs;
+  });
+  if (screenshots.length === 0) throw new Error("This trace contains no Screenshot events to extract.");
+  const absoluteDirectory = resolve(directory);
+  await mkdir(absoluteDirectory, { recursive: true });
+  const frames = analysis.requestedFrame
+    ? [analysis.requestedFrame]
+    : [analysis.timeline.worstFrame ?? analysis.worstFrames[0]].filter(Boolean);
+  const extracted = [];
+  const used = new Set();
+  for (const [rank, frame] of frames.entries()) {
+    const screenshot = nearestScreenshot(screenshots, frame);
+    if (!screenshot) continue;
+    const key = `${screenshot.ts}:${screenshot.args?.frame_sequence ?? "?"}`;
+    if (used.has(key)) continue;
+    used.add(key);
+    const payload = screenshotPayload(screenshot);
+    const mimeType = screenshotMimeType(payload);
+    if (mimeType === "application/octet-stream") throw new Error(`Screenshot nearest interval ${frame.index} has an unsupported image encoding.`);
+    const extension = mimeType === "image/png" ? "png" : "jpg";
+    const path = resolve(absoluteDirectory, `rank-${String(rank + 1).padStart(2, "0")}-interval-${frame.index}.${extension}`);
+    await writeFile(path, Buffer.from(normalizeBase64(payload), "base64"));
+    extracted.push({ rank: rank + 1, frameIndex: frame.index, path, mimeType });
+  }
+  if (extracted.length === 0) throw new Error("Screenshot events were captured, but none matched the selected frame sequence.");
+  return extracted;
+}
+
+function analyzeFrame(context) {
+  const { frame, frameEvents, metadata, selection, rasterTids, cadence, rafEvents, updateEvents, timerToRaf, pipelineRecords, traceStartTs, capabilities, schedulerCoupling, drawBaselineMs, cpuProfile, intervalKind = "DrawFrame" } = context;
+  const attributed = frameEvents.filter((event) => {
+    if (!isFocusEvent(event.name)) return false;
+    const role = roleFor(event, selection, metadata, rasterTids);
+    return role.startsWith("renderer-") || (role === "gpu-global" && event.name === "GPUTask");
+  });
+  const namedWork = aggregateRoleNamedWork(attributed, frame, (event) => roleFor(event, selection, metadata, rasterTids));
+  const roleIntervals = new Map();
+  for (const event of frameEvents) {
+    const role = roleFor(event, selection, metadata, rasterTids);
+    if (role === "other-global") continue;
+    const clipped = clipInterval(event, frame.startTs, frame.endTs);
+    const intervals = roleIntervals.get(role) ?? [];
+    intervals.push(clipped);
+    roleIntervals.set(role, intervals);
+  }
+  const roleBusyMs = Object.fromEntries(
+    [...roleIntervals]
+      .map(([role, intervals]) => [role, round(unionDuration(intervals) / 1000)])
+      .filter(([, duration]) => duration > 0)
+      .sort((a, b) => b[1] - a[1]),
+  );
+  const functions = aggregateFunctions(
+    frameEvents.filter((event) => event.pid === selection.pid && event.tid === selection.mainTid && event.name === "FunctionCall"),
+    frame,
+  );
+  const rafInRange = rafEvents.filter((event) => event.ts >= frame.startTs - cadence.ms * 1000 && event.ts <= frame.endTs);
+  const updateInRange = updateEvents.filter((event) => event.ts >= frame.startTs - cadence.ms * 1000 && event.ts <= frame.endTs);
+  const timerPairs = timerToRaf.filter((pair) => pair.rafTs >= frame.startTs && pair.rafTs <= frame.endTs);
+  const framePipeline = pipelineRecords.filter((record) => record.ts >= frame.startTs && record.ts <= frame.endTs);
+  const frameGcEvents = frameEvents.filter(
+    (event) => event.pid === selection.pid && event.tid === selection.mainTid && isGcEvent(event.name),
+  );
+  const mainGcWork = namedWork.filter((entry) => entry.role === "renderer-main" && isGcEvent(entry.name));
+  const frameCpuProfile = summarizeCpuSamples(cpuProfile.samples, frame, cpuProfile.available);
+  const metrics = {
+    mainBusyMs: roleBusyMs["renderer-main"] ?? 0,
+    maxRunTaskMs: namedWork.find((entry) => entry.name === "RunTask" && entry.role === "renderer-main")?.maxMs ?? 0,
+    paintTotalMs: namedWork.find((entry) => entry.name === "Paint")?.totalMs ?? 0,
+    paintMaxMs: namedWork.find((entry) => entry.name === "Paint")?.maxMs ?? 0,
+    rasterTotalMs: namedWork.find((entry) => entry.name === "RasterTask")?.totalMs ?? 0,
+    rasterMaxMs: namedWork.find((entry) => entry.name === "RasterTask")?.maxMs ?? 0,
+    gcTotalMs: mainGcWork.reduce((sum, entry) => sum + entry.totalMs, 0),
+    gcOccupancyMs: round(unionDuration(frameGcEvents.map((event) => clipInterval(event, frame.startTs, frame.endTs))) / 1000),
+    gcMaxMs: nullableMax(mainGcWork.map((entry) => entry.maxMs)) ?? 0,
+    maxRafGapMs: summarizeTimestamps(rafInRange.map((event) => event.ts)).maxMs,
+    maxUpdateGapMs: summarizeTimestamps(updateInRange.map((event) => event.ts)).maxMs,
+    maxTimerToRafDelayMs: schedulerCoupling.coupled ? nullableMax(timerPairs.map((pair) => pair.delayMs)) : null,
+  };
+  return {
+    index: frame.index,
+    intervalMs: frame.intervalMs,
+    startTs: frame.startTs,
+    endTs: frame.endTs,
+    startMs: offsetMs(frame.startTs, traceStartTs),
+    endMs: offsetMs(frame.endTs, traceStartTs),
+    frameSeqId: frame.frameSeqId,
+    previousFrameSeqId: frame.previousFrameSeqId,
+    intervalKind,
+    roleBusyMs,
+    namedWork,
+    topMainFunctions: functions.slice(0, 12),
+    cpuProfile: frameCpuProfile,
+    scheduling: {
+      rafCallbacks: rafInRange.length,
+      styleAndLayoutUpdates: updateInRange.length,
+      timerToRafPairs: timerPairs,
+      pipelineStates: framePipeline.map((record) => ({ state: record.state, affectsSmoothness: record.affectsSmoothness, frameType: record.frameType })),
+    },
+    metrics,
+    diagnoses: diagnoseFrame({ frame, metrics, cadence, timerPairs, framePipeline, capabilities, schedulerCoupling, drawBaselineMs, cpuProfile: frameCpuProfile, intervalKind }),
+  };
+}
+
+function diagnoseFrame({ frame, metrics, cadence, timerPairs, framePipeline, capabilities, schedulerCoupling, drawBaselineMs, cpuProfile, intervalKind }) {
+  const diagnoses = [];
+  const budget = cadence.ms;
+  const topCpuSamples = cpuProfile.topSelf.filter((entry) => entry.codeType === "JS").slice(0, 3);
+  const sampledApplicationMs = round(topCpuSamples.reduce((sum, entry) => sum + entry.sampledMs, 0));
+  if (metrics.maxRunTaskMs > Math.max(12, budget * 0.8) || metrics.mainBusyMs > frame.intervalMs * 0.7) {
+    diagnoses.push({
+      id: "main-thread-blocking",
+      label: "main-thread blocking",
+      confidence: "high",
+      evidence: `renderer-main was busy ${formatMs(metrics.mainBusyMs)}; its longest RunTask was ${formatMs(metrics.maxRunTaskMs)}.${topCpuSamples.length ? ` CPU samples attribute ${formatMs(sampledApplicationMs)} of estimated self time to ${topCpuSamples.map((entry) => `${entry.functionName} (${formatMs(entry.sampledMs)})`).join(", ")}${topCpuSamples[0].hotLine ? `; the hottest source line is ${topCpuSamples[0].file}:${topCpuSamples[0].hotLine.line}` : ""}.` : ""}`,
+    });
+  }
+  if (schedulerCoupling.coupled && (metrics.maxTimerToRafDelayMs ?? 0) > budget * 0.75 && (metrics.maxRafGapMs ?? 0) > budget * 1.6 && metrics.mainBusyMs < budget * 0.6) {
+    diagnoses.push({
+      id: "timer-to-raf-handoff",
+      label: "timer-to-rAF phase delay",
+      confidence: "medium",
+      evidence: `timer → next-rAF correlation reached ${formatMs(metrics.maxTimerToRafDelayMs)} while rAF spacing reached ${formatMs(metrics.maxRafGapMs)}; timer/rAF counts and cadence support a handoff pattern, and captured main-thread work remained cheap.`,
+    });
+  }
+  if (!schedulerCoupling.coupled && (metrics.maxRafGapMs ?? 0) > budget * 1.25 && metrics.mainBusyMs < budget * 0.7) {
+    diagnoses.push({
+      id: "raf-delivery-jitter",
+      label: "rAF delivery jitter",
+      confidence: "medium",
+      evidence: `rAF spacing reached ${formatMs(metrics.maxRafGapMs)} against a ${formatMs(budget)} display cadence without a long captured main-thread task.`,
+    });
+  }
+  if (metrics.paintTotalMs > budget * 0.35 || metrics.paintMaxMs > budget * 0.25) {
+    diagnoses.push({
+      id: "paint-heavy",
+      label: "paint pressure",
+      confidence: "high",
+      evidence: `Paint consumed ${formatMs(metrics.paintTotalMs)} inclusive, with a ${formatMs(metrics.paintMaxMs)} maximum event.`,
+    });
+  }
+  if (metrics.rasterTotalMs > budget * 0.6 || metrics.rasterMaxMs > budget * 0.3) {
+    diagnoses.push({
+      id: "raster-heavy",
+      label: "raster pressure",
+      confidence: "high",
+      evidence: `RasterTask consumed ${formatMs(metrics.rasterTotalMs)} inclusive, with a ${formatMs(metrics.rasterMaxMs)} maximum event.`,
+    });
+  }
+  if (metrics.gcOccupancyMs > budget * 0.2 || metrics.gcMaxMs > Math.max(2, budget * 0.15)) {
+    diagnoses.push({
+      id: "garbage-collection",
+      label: "garbage collection pressure",
+      confidence: "high",
+      evidence: `GC occupied ${formatMs(metrics.gcOccupancyMs)} on renderer-main (${formatMs(metrics.gcTotalMs)} inclusive nested slices), with a ${formatMs(metrics.gcMaxMs)} maximum event.`,
+    });
+  }
+  const dropped = framePipeline.filter((record) => record.state.includes("DROPPED") || record.affectsSmoothness);
+  if (dropped.length > 0) {
+    diagnoses.push({
+      id: "pipeline-drop-marker",
+      label: "pipeline drop marker",
+      confidence: frame.intervalMs >= Math.max(budget * 2.4, drawBaselineMs * 1.5) ? "high" : "low",
+      evidence: `${dropped.length} drop/affects-smoothness marker(s) overlap this ${formatMs(frame.intervalMs)} ${intervalKind} interval.`,
+    });
+  }
+  if (diagnoses.length === 0) {
+    const missing = [
+      !capabilities.signals.runTask.available && "RunTask",
+      !capabilities.signals.paint.available && "Paint",
+      !capabilities.signals.raster.available && "RasterTask",
+    ].filter(Boolean);
+    diagnoses.push({
+      id: "no-dominant-cpu-work",
+      label: "no dominant captured CPU work",
+      confidence: missing.length === 0 ? "medium" : "low",
+      evidence: `the ${formatMs(frame.intervalMs)} ${intervalKind} interval contains ${formatMs(metrics.mainBusyMs)} of renderer-main work, Paint max ${formatMs(metrics.paintMaxMs)}, and RasterTask max ${formatMs(metrics.rasterMaxMs)}.${missing.length ? ` Missing evidence: ${missing.join(", ")}.` : ""}`,
+    });
+  }
+  return diagnoses;
+}
+
+function summarizeWorkload({ events, mainEvents, selection, metadata, rasterTids, window }) {
+  const named = {};
+  const attributable = events.filter((event) => {
+    if (!isComplete(event) || !isFocusEvent(event.name)) return false;
+    const role = roleFor(event, selection, metadata, rasterTids);
+    return role.startsWith("renderer-") || (role === "gpu-global" && event.name === "GPUTask");
+  });
+  for (const entry of aggregateNamedWork(attributable, window)) {
+    named[entry.name] = entry;
+  }
+  const roles = {};
+  const byRole = new Map();
+  for (const event of events.filter(isComplete)) {
+    const role = roleFor(event, selection, metadata, rasterTids);
+    if (role === "other-global") continue;
+    const intervals = byRole.get(role) ?? [];
+    intervals.push(clipInterval(event, window.startTs, window.endTs));
+    byRole.set(role, intervals);
+  }
+  for (const [role, intervals] of byRole) roles[role] = round(unionDuration(intervals) / 1000);
+  return {
+    roles,
+    named,
+    mainThreadFunctions: aggregateFunctions(mainEvents.filter((event) => event.name === "FunctionCall"), window).slice(0, 20),
+  };
+}
+
+function aggregateNamedWork(events, window) {
+  const groups = new Map();
+  for (const event of events) {
+    const duration = clippedDuration(event, window.startTs, window.endTs) / 1000;
+    const group = groups.get(event.name) ?? { name: event.name, count: 0, totalMs: 0, maxMs: 0 };
+    group.count += 1;
+    group.totalMs += duration;
+    group.maxMs = Math.max(group.maxMs, duration);
+    groups.set(event.name, group);
+  }
+  return [...groups.values()]
+    .map((group) => ({ ...group, totalMs: round(group.totalMs), maxMs: round(group.maxMs) }))
+    .sort((a, b) => b.totalMs - a.totalMs || b.maxMs - a.maxMs);
+}
+
+function aggregateRoleNamedWork(events, window, getRole) {
+  const groups = new Map();
+  for (const event of events) {
+    const role = getRole(event);
+    const key = `${role}:${event.name}`;
+    const duration = clippedDuration(event, window.startTs, window.endTs) / 1000;
+    const group = groups.get(key) ?? { role, name: event.name, count: 0, totalMs: 0, maxMs: 0 };
+    group.count += 1;
+    group.totalMs += duration;
+    group.maxMs = Math.max(group.maxMs, duration);
+    groups.set(key, group);
+  }
+  return [...groups.values()]
+    .map((group) => ({ ...group, totalMs: round(group.totalMs), maxMs: round(group.maxMs) }))
+    .sort((a, b) => b.totalMs - a.totalMs || b.maxMs - a.maxMs);
+}
+
+function aggregateFunctions(events, window) {
+  const groups = new Map();
+  for (const event of events) {
+    const data = event.args?.data ?? {};
+    const functionName = data.functionName || "(anonymous)";
+    const url = data.url ? `${basenameFromUrl(data.url)}:${data.lineNumber ?? "?"}` : "";
+    const label = url ? `${functionName} — ${url}` : functionName;
+    const group = groups.get(label) ?? { label, count: 0, totalMs: 0, maxMs: 0 };
+    const duration = clippedDuration(event, window.startTs, window.endTs) / 1000;
+    group.count += 1;
+    group.totalMs += duration;
+    group.maxMs = Math.max(group.maxMs, duration);
+    groups.set(label, group);
+  }
+  return [...groups.values()]
+    .map((group) => ({ ...group, totalMs: round(group.totalMs), maxMs: round(group.maxMs) }))
+    .sort((a, b) => b.totalMs - a.totalMs);
+}
+
+function buildVerdict({ slowest, timelineWorst, timelineBaselineMs, cadence, drawStats, pipeline, longTasks, capabilities }) {
+  const worst = timelineWorst ?? slowest[0];
+  if (!worst) return "No consecutive DrawFrame events were captured.";
+  const primary = worst.diagnoses[0];
+  const qualification = !capabilities.signals.runTask.available
+    ? "RunTask evidence was not captured, so long tasks are unknown."
+    : longTasks.length === 0
+      ? "No 50 ms main-thread long tasks were captured."
+      : `${longTasks.length} main-thread long task(s) were captured.`;
+  const drops = !pipeline.available
+    ? "PipelineReporter evidence was not captured, so dropped-frame markers are unknown."
+    : pipeline.droppedCount === 0
+      ? "No pipeline drop markers were captured."
+      : `${pipeline.droppedCount} pipeline drop marker(s) were captured; ${pipeline.severeDrawStallAlignedCount} align with a severe DrawFrame gap.`;
+  const intervalLabel = worst.intervalKind === "presented animation frame"
+    ? "presented animation-frame interval"
+    : "DrawFrame gap";
+  const baseline = worst.intervalKind === "presented animation frame"
+    ? timelineBaselineMs == null ? "unknown" : `${round(worst.intervalMs / timelineBaselineMs)}× presented-animation p50`
+    : drawStats.p50Ms == null ? "unknown" : `${round(worst.intervalMs / drawStats.p50Ms)}× DrawFrame p50`;
+  return `Worst ${intervalLabel} ${formatMs(worst.intervalMs)} (${round(worst.intervalMs / cadence.ms)}× display interval; ${baseline}). Primary evidence: ${primary.label}. ${qualification} ${drops}`;
+}
+
+function answerQuestion(analysis, frame, comparison) {
+  if (analysis.focus === "comparison") {
+    if (!comparison) return "A before/after answer requires --compare <trace>.";
+    const worst = comparison.metrics.worstDrawGapMs;
+    const stalls = comparison.metrics.drawGapsAbove1_5xBaseline;
+    return `Worst DrawFrame gap changed ${formatMetric(worst.before)} → ${formatMetric(worst.after)} ms (${formatSigned(worst.delta)} ms); gaps above 1.5× each trace's DrawFrame p50 changed ${formatMetric(stalls.before)} → ${formatMetric(stalls.after)} (${formatSigned(stalls.delta)}).`;
+  }
+  if (analysis.focus === "pipeline") {
+    if (!analysis.pipeline.available) return "PipelineReporter was not captured, so this trace cannot answer whether Chrome marked frames dropped.";
+    const cadenceQualification = analysis.cadence.drawFrame.p50Ms > analysis.cadence.display.ms * 1.5
+      ? ` The app's DrawFrame p50 is ${formatMs(analysis.cadence.drawFrame.p50Ms)} against a ${formatMs(analysis.cadence.display.ms)} display interval, so missed-vsync markers are expected even without application-cadence outliers.`
+      : "";
+    return `${analysis.pipeline.droppedCount} drop/affects-smoothness records were captured; ${analysis.pipeline.severeDrawStallAlignedCount} align with a severe DrawFrame stall.${cadenceQualification}`;
+  }
+  if (analysis.focus === "rendering") {
+    const paint = analysis.capabilities.signals.paint.available ? formatMs(analysis.workload.named.Paint?.maxMs) : "not captured";
+    const raster = analysis.capabilities.signals.raster.available ? formatMs(analysis.workload.named.RasterTask?.maxMs) : "not captured";
+    const lightingConclusion = frame && /lighting/iu.test(analysis.question ?? "")
+      ? frame.metrics.paintMaxMs < analysis.cadence.display.ms * 0.1 && frame.metrics.rasterMaxMs < analysis.cadence.display.ms * 0.1
+        ? `Captured paint/raster evidence does not implicate lighting in this performance stall; the interval's primary evidence is ${frame.diagnoses[0].label}. `
+        : "Lighting-related publication may be contributing to the captured rendering pressure. "
+      : "";
+    const selected = frame
+      ? ` On the selected interval they maxed at ${formatMs(frame.metrics.paintMaxMs)} and ${formatMs(frame.metrics.rasterMaxMs)}.`
+      : " No DrawFrame interval was available for frame-local attribution.";
+    return `${lightingConclusion}Style/layout published ${analysis.cadence.styleAndLayout.eventCount} times at p50 ${formatMs(analysis.cadence.styleAndLayout.p50Ms)}. Across the trace, Paint max was ${paint} and RasterTask max was ${raster}.${selected}`;
+  }
+  if (analysis.focus === "scheduler") {
+    return `rAF p50/max were ${formatMs(analysis.cadence.requestAnimationFrame.p50Ms)}/${formatMs(analysis.cadence.requestAnimationFrame.maxMs)}. Timer/rAF handoff pattern: ${analysis.cadence.schedulerCoupling.coupled ? "compatible" : "not supported"}; correlated timer → next-rAF delay max ${formatMs(analysis.cadence.timerToRafDelay.maxMs)}.${frame ? ` ${frame.diagnoses[0].evidence}` : " No DrawFrame interval was available for local attribution."}`;
+  }
+  if (analysis.focus === "worst-frame") {
+    if (!frame) return analysis.verdict;
+    const top = frame.namedWork.find((entry) => entry.role === "renderer-main" && !isTaskName(entry.name));
+    const topCpuSamples = frame.cpuProfile.topSelf.filter((entry) => entry.codeType === "JS").slice(0, 3);
+    const sampledApplicationMs = round(topCpuSamples.reduce((sum, entry) => sum + entry.sampledMs, 0));
+    const intervalLabel = frame.intervalKind === "presented animation frame"
+      ? "presented animation-frame interval"
+      : "DrawFrame interval";
+    return `The worst ${intervalLabel} was ${formatMs(frame.intervalMs)}. Renderer-main was busy ${formatMs(frame.metrics.mainBusyMs)}${top ? `, including ${formatMs(top.totalMs)} inclusive in ${top.name}` : ""}; its longest RunTask was ${formatMs(frame.metrics.maxRunTaskMs)}.${topCpuSamples.length ? ` CPU samples attribute ${formatMs(sampledApplicationMs)} of estimated self time to ${topCpuSamples.map((entry) => entry.functionName).join(", ")}, led by ${topCpuSamples[0].file}:${topCpuSamples[0].hotLine?.line ?? "?"}.` : ""}`;
+  }
+  if (analysis.focus === "garbage-collection") {
+    return analysis.garbageCollection.available
+      ? `${analysis.garbageCollection.eventCount} renderer-main GC slices occupied ${formatMs(analysis.garbageCollection.occupancyMs)} (${formatMs(analysis.garbageCollection.totalMs)} inclusive nested time); the maximum slice was ${formatMs(analysis.garbageCollection.maxMs)}${frame ? `, and the selected interval contains ${formatMs(frame.metrics.gcOccupancyMs)} occupancy` : ""}.`
+      : "No renderer-main GC slices were captured. This excludes captured GC work, not uninstrumented memory pressure.";
+  }
+  if (analysis.focus === "long-tasks") {
+    return analysis.longTasks.available
+      ? `${analysis.longTasks.count} renderer-main RunTask slices reached the 50 ms long-task threshold; maximum ${formatMs(analysis.longTasks.maxMs)}.`
+      : "RunTask slices were not captured, so this trace cannot establish whether long main-thread tasks occurred.";
+  }
+  if (analysis.focus === "javascript") {
+    const sampled = (frame?.cpuProfile ?? analysis.cpuProfile).topSelf.slice(0, 3);
+    if (sampled.length > 0) {
+      return `Top sampled main-thread self time: ${sampled.map((entry) => `${entry.label} ${formatMs(entry.sampledMs)}${entry.hotLine ? ` (line ${entry.hotLine.line})` : ""}`).join("; ")}. CPU-profile durations are sampling estimates.`;
+    }
+    const functions = (frame?.topMainFunctions ?? analysis.workload.mainThreadFunctions).slice(0, 3);
+    return functions.length
+      ? `Top captured main-thread functions in the selected interval: ${functions.map((entry) => `${entry.label} ${formatMs(entry.totalMs)}`).join("; ")}.`
+      : "No FunctionCall slices were captured in the selected interval; JavaScript attribution is unavailable there.";
+  }
+  if (analysis.focus === "gpu") {
+    if (!frame) return `The global GPU process occupied ${formatMs(analysis.workload.roles["gpu-global"] ?? 0)} in the analysis window. Chrome traces do not scope this global process work exclusively to the selected page.`;
+    return `The global GPU process had ${formatMs(frame.roleBusyMs["gpu-global"] ?? 0)} of trace-slice occupancy during the interval, including ${formatMs(frame.namedWork.find((entry) => entry.role === "gpu-global" && entry.name === "GPUTask")?.totalMs)} of GPUTask slices. Chrome traces do not scope this global process work exclusively to the selected page.`;
+  }
+  if (analysis.focus === "coverage") {
+    const missing = Object.entries(analysis.capabilities.signals).filter(([, signal]) => !signal.available).map(([name]) => name);
+    return missing.length ? `Missing trace evidence: ${missing.join(", ")}. Conclusions depending on those signals are reported as unavailable.` : "All FrameSleuth evidence channels were captured.";
+  }
+  if (analysis.focus === "screenshots") {
+    const nearest = analysis.screenshots.nearestToSelectedFrame;
+    if (!nearest) return "Screenshot events were not captured in the selected analysis window.";
+    const extracted = analysis.screenshots.extracted.length
+      ? ` Extracted: ${analysis.screenshots.extracted.map((entry) => entry.path).join(", ")}.`
+      : " Use --screenshots <directory> to extract the image bytes.";
+    return `The nearest screenshot is ${formatMs(nearest.deltaFromFrameEndMs)} from the selected interval end${nearest.exactFrameSequence ? " with an exact frame-sequence match" : ""}.${extracted}`;
+  }
+  if (!frame) return analysis.verdict;
+  return analysis.verdict;
+}
+
+function inferQuestionFocus(question) {
+  if (!question) return "summary";
+  if (/worst|slowest|work.*frame|frame.*work/iu.test(question)) return "worst-frame";
+  if (/compar|regress|better|worse|improv|fixed|difference/iu.test(question)) return "comparison";
+  if (/drop|pipeline|present|flicker|flash|artifact/iu.test(question)) return "pipeline";
+  if (/garbage|\bgc\b|memory/iu.test(question)) return "garbage-collection";
+  if (/long.?task|blocked|blocking/iu.test(question)) return "long-tasks";
+  if (/javascript|function|script|\bjs\b/iu.test(question)) return "javascript";
+  if (/\bgpu\b|compositor/iu.test(question)) return "gpu";
+  if (/screenshot|visual|image|show.*frame/iu.test(question)) return "screenshots";
+  if (/coverage|captur|missing|trust|evidence/iu.test(question)) return "coverage";
+  if (/paint|raster|render|lighting|style|layout/iu.test(question)) return "rendering";
+  if (/timer|scheduler|raf|cadence|jitter|stutter|smooth/iu.test(question)) return "scheduler";
+  return "summary";
+}
+
+function roleFor(event, selection, metadata, rasterTids) {
+  if (event.pid === selection.pid && event.tid === selection.mainTid) return "renderer-main";
+  if (event.pid === selection.pid && event.tid === selection.compositorTid) return "renderer-compositor";
+  if (event.pid === selection.pid && (rasterTids.has(event.tid) || event.name === "RasterTask")) return "renderer-raster";
+  const processName = metadata.processNames.get(event.pid) ?? "";
+  const threadName = metadata.threadNames.get(threadKey(event.pid, event.tid)) ?? "";
+  if (processName === "GPU Process") return "gpu-global";
+  if (processName === "Browser" && threadName === "CrBrowserMain") return "browser-main-global";
+  if (event.pid === selection.pid) return "renderer-other";
+  return "other-global";
+}
+
+function summarizeTimestamps(timestamps) {
+  const sorted = [...new Set(timestamps)].sort((a, b) => a - b);
+  const intervals = [];
+  for (let index = 1; index < sorted.length; index += 1) intervals.push((sorted[index] - sorted[index - 1]) / 1000);
+  return { eventCount: sorted.length, ...summarizeNumbers(intervals) };
+}
+
+function summarizeNumbers(numbers) {
+  const values = numbers.filter(Number.isFinite).sort((a, b) => a - b);
+  return {
+    count: values.length,
+    p50Ms: quantile(values, 0.5),
+    p95Ms: quantile(values, 0.95),
+    p99Ms: quantile(values, 0.99),
+    maxMs: values.length ? round(values.at(-1)) : null,
+    meanMs: values.length ? round(values.reduce((sum, value) => sum + value, 0) / values.length) : null,
+  };
+}
+
+function quantile(sorted, fraction) {
+  if (sorted.length === 0) return null;
+  const position = (sorted.length - 1) * fraction;
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  const value = sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
+  return round(value);
+}
+
+function surroundingGap(events, timestamp) {
+  const before = lastAtOrBefore(events, timestamp);
+  const after = events.find((event) => event.ts > timestamp);
+  return before && after ? round((after.ts - before.ts) / 1000) : null;
+}
+
+function lastAtOrBefore(events, timestamp) {
+  let result = null;
+  for (const event of events) {
+    if (event.ts > timestamp) break;
+    result = event;
+  }
+  return result;
+}
+
+function unionDuration(intervals) {
+  if (intervals.length === 0) return 0;
+  const sorted = intervals.filter(([start, end]) => end > start).sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  if (sorted.length === 0) return 0;
+  let total = 0;
+  let [start, end] = sorted[0];
+  for (let index = 1; index < sorted.length; index += 1) {
+    const [nextStart, nextEnd] = sorted[index];
+    if (nextStart <= end) end = Math.max(end, nextEnd);
+    else {
+      total += end - start;
+      [start, end] = [nextStart, nextEnd];
+    }
+  }
+  return total + end - start;
+}
+
+function clipInterval(event, startTs, endTs) {
+  return [Math.max(event.ts, startTs), Math.min(eventEnd(event), endTs)];
+}
+
+function clippedDuration(event, startTs, endTs) {
+  const [start, end] = clipInterval(event, startTs, endTs);
+  return Math.max(0, end - start);
+}
+
+function overlaps(event, startTs, endTs) {
+  return event.ts < endTs && eventEnd(event) > startTs;
+}
+
+function overlapsWindow(event, window) {
+  if (!Number.isFinite(event.ts)) return false;
+  if (isComplete(event)) return overlaps(event, window.startTs, window.endTs);
+  return event.ts >= window.startTs && event.ts <= window.endTs;
+}
+
+function isComplete(event) {
+  return event.ph === "X" && Number.isFinite(event.dur) && event.dur >= 0;
+}
+
+function isTask(event) {
+  return isTaskName(event.name);
+}
+
+function isTaskName(name) {
+  return name === "RunTask" || name === "ThreadControllerImpl::RunTask";
+}
+
+function isFocusEvent(name) {
+  return FOCUS_EVENTS.has(name) || isGcEvent(name);
+}
+
+function isGcEvent(name) {
+  return /^(?:MinorGC|MajorGC|V8\.GC)/u.test(name);
+}
+
+function eventEnd(event) {
+  return event.ts + (Number.isFinite(event.dur) ? event.dur : 0);
+}
+
+function sortedEvents(events, name) {
+  return events.filter((event) => event.name === name && Number.isFinite(event.ts)).sort((a, b) => a.ts - b.ts);
+}
+
+function uniqueTimestampEvents(events) {
+  const result = [];
+  let previous = null;
+  for (const event of events) {
+    if (event.ts === previous) continue;
+    result.push(event);
+    previous = event.ts;
+  }
+  return result;
+}
+
+function countNamed(events, name) {
+  return events.reduce((count, event) => count + Number(event.name === name), 0);
+}
+
+function dominantValue(values) {
+  if (values.length === 0) return null;
+  const counts = new Map();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return [...counts].sort((a, b) => b[1] - a[1])[0][0];
+}
+
+function threadKey(pid, tid) {
+  return `${pid}:${tid}`;
+}
+
+function offsetMs(timestamp, startTs) {
+  return round((timestamp - startTs) / 1000);
+}
+
+function nullableMax(values) {
+  return values.length ? round(Math.max(...values)) : null;
+}
+
+function round(value) {
+  return Number(value.toFixed(3));
+}
+
+function formatMs(value) {
+  return value == null ? "n/a" : `${round(value).toFixed(3)} ms`;
+}
+
+function formatMetric(value) {
+  return value == null ? "n/a" : String(round(value));
+}
+
+function formatSigned(value) {
+  if (value == null) return "n/a";
+  return `${value > 0 ? "+" : ""}${round(value)}`;
+}
+
+function formatAvailabilityCount(available, value) {
+  return available ? String(value) : "not captured";
+}
+
+function cadenceRow(label, stats) {
+  return `| ${label} | ${stats.eventCount ?? stats.count ?? 0} | ${formatMs(stats.p50Ms)} | ${formatMs(stats.p95Ms)} | ${formatMs(stats.maxMs)} |`;
+}
+
+function escapeTable(value) {
+  return String(value).replaceAll("|", "\\|");
+}
+
+function basenameFromUrl(value) {
+  try {
+    return basename(new URL(value).pathname) || new URL(value).hostname;
+  } catch {
+    return basename(value);
+  }
+}
+
+function parseCli(argv) {
+  const options = { format: "markdown", top: 5 };
+  const paths = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--") continue;
+    else if (argument === "--help" || argument === "-h") options.help = true;
+    else if (argument === "--compare") options.compare = requiredValue(argv, ++index, argument);
+    else if (argument === "--format") options.format = requiredValue(argv, ++index, argument);
+    else if (argument === "--output") options.output = requiredValue(argv, ++index, argument);
+    else if (argument === "--top") options.top = positiveInteger(requiredValue(argv, ++index, argument), argument);
+    else if (argument === "--frame") options.frame = positiveInteger(requiredValue(argv, ++index, argument), argument);
+    else if (argument === "--rank") options.rank = positiveInteger(requiredValue(argv, ++index, argument), argument);
+    else if (argument === "--around-ms") options.aroundMs = nonNegativeNumber(requiredValue(argv, ++index, argument), argument);
+    else if (argument === "--screenshots") options.screenshots = requiredValue(argv, ++index, argument);
+    else if (argument === "--url") options.url = requiredValue(argv, ++index, argument);
+    else if (argument === "--start-ms") options.startMs = nonNegativeNumber(requiredValue(argv, ++index, argument), argument);
+    else if (argument === "--end-ms") options.endMs = nonNegativeNumber(requiredValue(argv, ++index, argument), argument);
+    else if (argument === "--question") options.question = requiredValue(argv, ++index, argument);
+    else if (argument.startsWith("-")) throw new Error(`Unknown option ${argument}.`);
+    else paths.push(argument);
+  }
+  if (!options.help && paths.length !== 1) throw new Error("Provide exactly one trace path.");
+  if (!new Set(["markdown", "json"]).has(options.format)) throw new Error("--format must be markdown or json.");
+  return { path: paths[0], ...options };
+}
+
+function requiredValue(argv, index, option) {
+  const value = argv[index];
+  if (value == null || value.startsWith("--")) throw new Error(`${option} requires a value.`);
+  return value;
+}
+
+function positiveInteger(value, option) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0) throw new Error(`${option} requires a positive integer.`);
+  return number;
+}
+
+function nonNegativeNumber(value, option) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) throw new Error(`${option} requires a non-negative number.`);
+  return number;
+}
+
+async function main(argv) {
+  const options = parseCli(argv);
+  if (options.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  const beforeTrace = await loadTrace(options.path);
+  const before = analyzeTrace(beforeTrace, options);
+  let after = null;
+  let comparison = null;
+  if (options.compare) {
+    after = analyzeTrace(await loadTrace(options.compare), options);
+    comparison = compareAnalyses(before, after);
+  }
+  if (options.screenshots) before.screenshots.extracted = await extractFrameScreenshots(beforeTrace, before, options.screenshots);
+  const output = options.format === "json"
+    ? `${JSON.stringify({ analysis: before, comparedAnalysis: after, comparison }, null, 2)}\n`
+    : renderMarkdown(before, comparison);
+  if (options.output) {
+    const outputPath = resolve(options.output);
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, output);
+  }
+  else process.stdout.write(output);
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (invokedDirectly) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`FrameSleuth: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/frame-sleuth.test.mjs
+++ b/scripts/frame-sleuth.test.mjs
@@ -1,0 +1,402 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { gzipSync } from "node:zlib";
+import { analyzeTrace, compareAnalyses, extractFrameScreenshots, loadTrace, renderFrameChartSvg, renderMarkdown, SCHEMA } from "./frame-sleuth.mjs";
+
+test("selects the active renderer and attributes a cheap worst frame to timer-to-rAF delay", () => {
+  const events = syntheticTrace({ delayedRaf: true });
+  const analysis = analyzeTrace(loaded(events), { top: 3, question: "what work did we do on the worst frame?" });
+
+  assert.equal(analysis.schema, SCHEMA);
+  assert.equal(analysis.selection.rendererPid, 10);
+  assert.equal(analysis.worstFrames[0].intervalMs, 46);
+  assert.equal(analysis.worstFrames[0].metrics.maxTimerToRafDelayMs, 16);
+  assert.equal(analysis.worstFrames[0].diagnoses[0].id, "timer-to-raf-handoff");
+  assert.ok(analysis.worstFrames[0].metrics.paintMaxMs < 1);
+  assert.equal(analysis.longTasks.count, 0);
+  assert.match(renderMarkdown(analysis), /timer-to-rAF phase delay/);
+});
+
+test("follows a renderer navigation instead of retaining the initial about:blank URL", () => {
+  const events = syntheticTrace({});
+  const started = events.find((event) => event.name === "TracingStartedInBrowser");
+  started.args.data.frames[0].url = "about:blank";
+  events.push({
+    name: "FrameCommittedInBrowser",
+    ph: "I",
+    pid: 1,
+    tid: 1,
+    ts: 2_000,
+    args: { data: { processId: 10, url: "https://example.test/demo/" } },
+  });
+  const analysis = analyzeTrace(loaded(events), { url: "/demo/" });
+  assert.deepEqual(analysis.selection.urls, ["https://example.test/demo/"]);
+});
+
+test("does not mistake after-startup worst-frame wording for a comparison request", () => {
+  const analysis = analyzeTrace(loaded(syntheticTrace({ delayedRaf: true })), {
+    question: "after startup, what work happened on the worst frame?",
+  });
+  assert.equal(analysis.focus, "worst-frame");
+  assert.doesNotMatch(renderMarkdown(analysis), /requires --compare/);
+});
+
+test("does not present an isolated BACKFILL record as a visible stall", () => {
+  const events = syntheticTrace({ droppedBackfill: true });
+  const duplicate = events.find((event) => event.name === "PipelineReporter");
+  events.push({ ...duplicate, ts: duplicate.ts + 1 });
+  events.push({
+    ...duplicate,
+    ts: duplicate.ts + 2,
+    args: { frame_reporter: { ...duplicate.args.frame_reporter, layer_tree_host_id: 2, frame_sequence: 100 } },
+  });
+  const analysis = analyzeTrace(loaded(events));
+
+  assert.equal(analysis.pipeline.droppedCount, 1);
+  assert.equal(analysis.pipeline.severeDrawStallAlignedCount, 0);
+  assert.equal(analysis.pipeline.dropped[0].classification, "not aligned with a severe DrawFrame stall");
+});
+
+test("deduplicates nested long-task wrappers", () => {
+  const events = syntheticTrace({});
+  events.push(complete("ThreadControllerImpl::RunTask", 10, 11, 20_000, 60_000));
+  events.push(complete("RunTask", 10, 11, 21_000, 58_000));
+  const analysis = analyzeTrace(loaded(events));
+  assert.equal(analysis.longTasks.count, 1);
+  assert.equal(analysis.longTasks.maxMs, 60);
+});
+
+test("loads raw and gzip DevTools traces", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "framesleuth-"));
+  try {
+    const rawPath = join(directory, "trace.json");
+    const gzipPath = join(directory, "trace.json.gz");
+    const body = JSON.stringify({ traceEvents: syntheticTrace({}) });
+    await writeFile(rawPath, body);
+    await writeFile(gzipPath, gzipSync(body));
+
+    const raw = await loadTrace(rawPath);
+    const gzip = await loadTrace(gzipPath);
+    assert.equal(raw.compressed, false);
+    assert.equal(gzip.compressed, true);
+    assert.equal(raw.events.length, gzip.events.length);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("compares before and after without hiding null metrics", () => {
+  const before = analyzeTrace(loaded(syntheticTrace({ delayedRaf: true })));
+  const after = analyzeTrace(loaded(syntheticTrace({})));
+  const comparison = compareAnalyses(before, after);
+
+  assert.equal(comparison.metrics.worstDrawGapMs.before, 46);
+  assert.equal(comparison.metrics.worstDrawGapMs.after, 17);
+  assert.equal(comparison.metrics.worstDrawGapMs.delta, -29);
+  assert.equal(comparison.metrics.longTaskCount.delta, 0);
+});
+
+test("reports unavailable evidence as unknown instead of zero", () => {
+  const events = syntheticTrace({}).filter(
+    (event) => !new Set(["RunTask", "PipelineReporter", "Paint", "RasterTask"]).has(event.name),
+  );
+  const analysis = analyzeTrace(loaded(events));
+
+  assert.equal(analysis.longTasks.available, false);
+  assert.equal(analysis.longTasks.count, null);
+  assert.equal(analysis.pipeline.available, false);
+  assert.equal(analysis.pipeline.droppedCount, null);
+  assert.equal(analysis.capabilities.signals.paint.available, false);
+  assert.match(renderMarkdown(analysis), /Long main-thread tasks: not captured/);
+});
+
+test("rejects ambiguous and nonexistent frame selectors", () => {
+  const trace = loaded(syntheticTrace({}));
+  assert.throws(() => analyzeTrace(trace, { frame: 999 }), /does not exist/);
+  assert.throws(() => analyzeTrace(trace, { frame: 1, rank: 1 }), /only one/);
+  assert.equal(analyzeTrace(trace, { rank: 2 }).requestedFrame.index, 2);
+  assert.equal(analyzeTrace(trace, { aroundMs: 20 }).requestedFrame.index, 2);
+});
+
+test("uses the observed compositor clock on a 90 Hz trace", () => {
+  const analysis = analyzeTrace(loaded(syntheticTrace({ refreshUs: 11_111 })));
+  assert.equal(analysis.cadence.display.ms, 11.111);
+  assert.equal(analysis.cadence.display.basis, "Compositor BeginFrame");
+});
+
+test("attributes renderer-main GC occupancy without double-counting nested slices", () => {
+  const analysis = analyzeTrace(loaded(syntheticTrace({ garbageCollection: true })), { frame: 2 });
+  assert.equal(analysis.requestedFrame.metrics.gcOccupancyMs, 5);
+  assert.equal(analysis.requestedFrame.metrics.gcTotalMs, 7);
+  assert.ok(analysis.requestedFrame.diagnoses.some((diagnosis) => diagnosis.id === "garbage-collection"));
+});
+
+test("decodes CPU profile chunks to identify work hidden inside microtasks", () => {
+  const analysis = analyzeTrace(loaded(syntheticTrace({ cpuProfile: true })), { frame: 2 });
+  const sampled = analysis.requestedFrame.cpuProfile;
+  assert.equal(analysis.capabilities.signals.cpuProfile.available, true);
+  assert.equal(sampled.sampleCount, 2);
+  assert.equal(sampled.topSelf[0].label, "decodePreparedTransformBlock — preparedAssets.mjs");
+  assert.equal(sampled.topSelf[0].hotLine.line, 670);
+  assert.match(renderMarkdown(analysis), /Sampled main-thread self time/);
+});
+
+test("renders the standard frame-time chart without an instantaneous FPS axis", () => {
+  const analysis = analyzeTrace(loaded(syntheticTrace({ delayedRaf: true })));
+  const svg = renderFrameChartSvg(analysis);
+  assert.match(svg, /FrameSleuth presented animation-frame times/u);
+  assert.match(svg, /p50 17.0 ms \(~58.8 FPS\)/);
+  assert.match(svg, /worst 46.0 ms gap/);
+  assert.match(svg, /DrawFrame interval \(ms, presentation fallback\)/);
+  assert.doesNotMatch(svg, /Pacing equivalent|rolling FPS|Effective frame rate/u);
+  assert.doesNotMatch(svg, /Main-thread busy time \(ms\)/);
+  assert.equal((svg.match(/<polyline/g) ?? []).length, 1);
+  assert.doesNotMatch(svg, /Right axis/u);
+  assert.match(svg, /color-scheme: dark/);
+  assert.doesNotMatch(svg, /prefers-color-scheme/u);
+  assert.doesNotMatch(svg, /NaN|undefined/u);
+});
+
+test("prefers renderer presentation timestamps for the frame-time chart", () => {
+  const events = syntheticTrace({ delayedRaf: true });
+  [11_000, 27_000, 73_000, 90_000, 107_000].forEach((ts) => {
+    events.push(instant("AnimationFrame::Presentation", 10, 11, ts));
+  });
+  const analysis = analyzeTrace(loaded(events));
+  assert.equal(analysis.timeline.source, "AnimationFrame::Presentation");
+  assert.equal(analysis.timeline.baselineMs, 17);
+  assert.equal(analysis.timeline.worstFrame.intervalKind, "presented animation frame");
+  assert.equal(analysis.timeline.worstFrame.intervalMs, 46);
+  assert.match(renderFrameChartSvg(analysis), /Presented animation-frame interval \(ms\)/);
+  assert.match(renderMarkdown(analysis, null, { frameChart: "frame-times.svg" }), /Worst presented animation-frame interval/u);
+});
+
+test("attributes the same presentation interval highlighted by the chart", () => {
+  const events = syntheticTrace({});
+  [11_000, 27_000, 73_000, 90_000, 107_000].forEach((ts) => {
+    events.push(instant("AnimationFrame::Presentation", 10, 11, ts));
+  });
+  [35_000, 52_000, 69_000].forEach((ts, index) => {
+    events.push({
+      name: "PipelineReporter",
+      ph: "b",
+      pid: 10,
+      tid: 12,
+      ts,
+      args: { frame_reporter: {
+        state: "STATE_PRESENTED_ALL",
+        affects_smoothness: false,
+        frame_sequence: 200 + index,
+        frame_source: 1,
+        layer_tree_host_id: 1,
+      } },
+    });
+  });
+  events.push(complete("RunMicrotasks", 10, 11, 40_000, 12_000));
+
+  const analysis = analyzeTrace(loaded(events), { question: "what work happened on the worst frame?" });
+  const highlighted = analysis.timeline.frames.reduce(
+    (worst, frame) => frame.intervalMs > worst.intervalMs ? frame : worst,
+    analysis.timeline.frames[0],
+  );
+  assert.equal(highlighted.intervalMs, 46);
+  assert.equal(analysis.timeline.worstFrame.intervalMs, highlighted.intervalMs);
+  assert.equal(analysis.timeline.worstFrame.metrics.mainBusyMs, 13.2);
+  assert.match(renderMarkdown(analysis), /worst presented animation-frame interval was 46\.000 ms/u);
+  assert.match(renderMarkdown(analysis), /RunMicrotasks/u);
+});
+
+test("uses temporal next-callback correlation without trusting cross-type ids", () => {
+  const events = syntheticTrace({ delayedRaf: true });
+  events.push(complete("TimerFire", 10, 11, 105_000, 50, { data: { timerId: 2 } }));
+  const analysis = analyzeTrace(loaded(events));
+  assert.equal(analysis.worstFrames[0].diagnoses[0].id, "timer-to-raf-handoff");
+  assert.equal(analysis.worstFrames[0].diagnoses[0].confidence, "medium");
+  assert.equal(analysis.cadence.schedulerCoupling.coupled, true);
+  assert.equal(analysis.worstFrames[0].scheduling.timerToRafPairs[0].correlation, "temporal-next-callback");
+});
+
+test("does not infer timer-to-rAF handoff when timer and rAF cadences are unrelated", () => {
+  const events = syntheticTrace({});
+  for (const [index, ts] of [10_500, 40_500, 70_500, 100_500, 110_000].entries()) {
+    events.push(complete("TimerFire", 10, 11, ts, 50, { data: { timerId: index } }));
+  }
+  const analysis = analyzeTrace(loaded(events));
+  assert.equal(analysis.cadence.schedulerCoupling.coupled, false);
+  assert.ok(analysis.worstFrames.every((frame) => frame.diagnoses.every((diagnosis) => diagnosis.id !== "timer-to-raf-handoff")));
+});
+
+test("extracts screenshot evidence nearest the selected frame", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "framesleuth-shots-"));
+  try {
+    const trace = loaded(syntheticTrace({ screenshot: true }));
+    const analysis = analyzeTrace(trace, { frame: 2, question: "show visual evidence for this frame" });
+    const extracted = await extractFrameScreenshots(trace, analysis, directory);
+    analysis.screenshots.extracted = extracted;
+    assert.equal(analysis.screenshots.nearestToSelectedFrame.exactFrameSequence, true);
+    assert.equal(extracted.length, 1);
+    const bytes = await readFile(extracted[0].path);
+    assert.deepEqual([...bytes.subarray(0, 8)], [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    assert.match(renderMarkdown(analysis), /Extracted:/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("answers before-and-after questions from comparison evidence", () => {
+  const before = analyzeTrace(loaded(syntheticTrace({ delayedRaf: true })), { question: "is this better?" });
+  const after = analyzeTrace(loaded(syntheticTrace({})));
+  const markdown = renderMarkdown(before, compareAnalyses(before, after));
+  assert.match(markdown, /Worst DrawFrame gap changed 46 → 17 ms/);
+});
+
+test("answers aggregate questions when no DrawFrame interval exists", () => {
+  const events = syntheticTrace({}).filter((event) => event.name !== "DrawFrame");
+  events.push({ ...instant("DrawFrame", 10, 12, 44_000), args: { frameSeqId: 3, layerTreeId: 1 } });
+  const coverage = analyzeTrace(loaded(events), { question: "what evidence is missing?" });
+  const rendering = analyzeTrace(loaded(events), { question: "is paint the bottleneck?" });
+  assert.match(renderMarkdown(coverage), /Missing trace evidence: drawFrame/);
+  assert.match(renderMarkdown(rendering), /No DrawFrame interval was available for frame-local attribution/);
+});
+
+function loaded(events) {
+  return {
+    path: "/tmp/synthetic-trace.json",
+    bytes: 1,
+    decodedBytes: 1,
+    compressed: false,
+    events,
+  };
+}
+
+function syntheticTrace({ delayedRaf = false, droppedBackfill = false, refreshUs = 16_667, garbageCollection = false, screenshot = false, cpuProfile = false }) {
+  const events = [
+    metadata("process_name", 10, 0, "Renderer"),
+    metadata("thread_name", 10, 11, "CrRendererMain"),
+    metadata("thread_name", 10, 12, "Compositor"),
+    metadata("thread_name", 10, 13, "CompositorTileWorker1"),
+    metadata("process_name", 20, 0, "Renderer"),
+    metadata("thread_name", 20, 21, "CrRendererMain"),
+    metadata("thread_name", 20, 22, "Compositor"),
+    {
+      name: "TracingStartedInBrowser",
+      ph: "I",
+      pid: 1,
+      tid: 1,
+      ts: 1,
+      args: { data: { frames: [
+        { processId: 10, url: "https://example.test/demo/" },
+        { processId: 20, url: "https://example.test/idle/" },
+      ] } },
+    },
+  ];
+
+  const beginFrames = Array.from({ length: 10 }, (_, index) => 1_000 + index * refreshUs);
+  for (const ts of beginFrames) events.push(instant("BeginFrame", 10, 12, ts));
+
+  const drawFrames = delayedRaf
+    ? [10_000, 27_000, 73_000, 90_000, 107_000]
+    : [10_000, 27_000, 44_000, 61_000, 78_000, 95_000, 112_000];
+  drawFrames.forEach((ts, index) => events.push({ ...instant("DrawFrame", 10, 12, ts), args: { frameSeqId: index + 1, layerTreeId: 1 } }));
+
+  const rafTimes = delayedRaf ? [11_000, 27_000, 73_000, 90_000, 107_000] : [11_000, 28_000, 45_000, 62_000, 79_000, 96_000, 113_000];
+  const timerTimes = delayedRaf ? [10_000, 26_000, 57_000, 89_000, 106_000] : [];
+  rafTimes.forEach((ts, index) => {
+    if (delayedRaf) events.push(complete("TimerFire", 10, 11, timerTimes[index], 50, { data: { timerId: index } }));
+    events.push(complete("FireAnimationFrame", 10, 11, ts, 100, { data: { id: index } }));
+    events.push(complete("UpdateLayoutTree", 10, 11, ts + 150, 120));
+    events.push(complete("Paint", 10, 11, ts + 300, 200));
+    events.push(complete("RunTask", 10, 11, ts - 50, 600));
+    events.push(complete("RasterTask", 10, 13, ts + 600, 100));
+  });
+
+  if (droppedBackfill) {
+    events.push({
+      name: "PipelineReporter",
+      ph: "b",
+      pid: 10,
+      tid: 12,
+      ts: 52_000,
+      args: { frame_reporter: {
+        state: "STATE_DROPPED",
+        affects_smoothness: true,
+        frame_type: "BACKFILL",
+        frame_sequence: 99,
+        layer_tree_host_id: 1,
+      } },
+    });
+  }
+  if (garbageCollection) {
+    events.push(complete("MinorGC", 10, 11, 30_000, 5_000));
+    events.push(complete("V8.GC_SCAVENGER", 10, 11, 31_000, 2_000));
+  }
+  if (cpuProfile) {
+    events.push({
+      name: "Profile",
+      ph: "P",
+      id: "0x1",
+      pid: 10,
+      tid: 11,
+      ts: 1,
+      args: { data: { source: "Internal", startTime: 0 } },
+    });
+    events.push({
+      name: "ProfileChunk",
+      ph: "P",
+      id: "0x1",
+      pid: 10,
+      tid: 14,
+      ts: 40_000,
+      args: { data: {
+        source: "Internal",
+        cpuProfile: {
+          nodes: [{
+            id: 30,
+            parent: 1,
+            callFrame: {
+              codeType: "JS",
+              functionName: "decodePreparedTransformBlock",
+              lineNumber: 573,
+              scriptId: 14,
+              url: "https://example.test/src/cssgravitywell/preparedAssets.mjs",
+            },
+          }],
+          samples: [30, 30],
+        },
+        timeDeltas: [30_000, 5_000],
+        lines: [670, 670],
+        columns: [23, 23],
+      } },
+    });
+  }
+  if (screenshot) {
+    events.push({
+      name: "Screenshot",
+      ph: "I",
+      pid: 1,
+      tid: 1,
+      ts: 43_500,
+      args: {
+        expected_display_time: 44_000,
+        frame_sequence: 3,
+        snapshot: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+      },
+    });
+  }
+  return events;
+}
+
+function metadata(name, pid, tid, value) {
+  return { name, ph: "M", pid, tid, ts: 0, args: { name: value } };
+}
+
+function instant(name, pid, tid, ts) {
+  return { name, ph: "I", pid, tid, ts, args: {} };
+}
+
+function complete(name, pid, tid, ts, dur, args = {}) {
+  return { name, ph: "X", pid, tid, ts, dur, args };
+}

--- a/scripts/prepare/cssgravitywell-product-bank.mjs
+++ b/scripts/prepare/cssgravitywell-product-bank.mjs
@@ -24,7 +24,8 @@ if (lock.schema !== "cssgravitywell-prepared-bank-lock@2" || lock.bankCount !== 
     lock.maximumTransformBlockPreparedCssStringBytes >= 4_000_000 ||
     lock.maximumResidentTransformPreparedCssStringBytes >= 8_000_000 ||
     lock.colorAssetCount !== 24 || lock.changeAssetCount !== 24 ||
-    lock.visibilityAssetCount !== 24 || lock.visibilityEncodedBytes !== 109_999) {
+    lock.visibilityAssetCount !== 24 || !Number.isSafeInteger(lock.visibilityEncodedBytes) ||
+    lock.visibilityEncodedBytes < 100_000 || lock.visibilityEncodedBytes > 500_000) {
   throw new Error("cssGravityWell prepared-bank lock does not bind the retained 24-bank product");
 }
 const generatedRoot = resolve(

--- a/src/adapters/gravitywell/README.md
+++ b/src/adapters/gravitywell/README.md
@@ -15,6 +15,11 @@ pnpm perf:gravitywell:frame-work
 CSSGRAVITYWELL_SOURCE_ROOT=/path/to/xscreensaver pnpm oracle:gravitywell:visual
 ```
 
+The performance command preserves its prepared worst-transition proof and also
+records the 1.8-second canonical scheduler trial inside the Chrome trace. It
+then writes a generic FrameSleuth worst-frame report to
+`bench/results/cssgravitywell/performance/frame-sleuth-report.md`.
+
 The product route contains no Canvas, WebGL, SVG scene geometry, mask, or clip
 path. See `notes/provenance-bible.md` for the exact preparation and proof
 boundary.
@@ -26,11 +31,17 @@ The 24 selected-bank products use 384 content-addressed sparse transform blocks
 zero also carries the selected bank's sparse write indices. The shared prepared
 palette is stored once in the catalog: 412 hash-bound
 closure files, or 413 on disk including the self-describing product descriptor,
-with one-time block expansion and no per-frame decoding, transform formatting,
-or block reconstruction. A block expands to at most 3,449,674 bytes of final
-CSS strings, and every prepared current-plus-lookahead pair stays below
-6,754,392 bytes. Each bank also embeds one small viewport-visibility
-schedule with five conservative profiles. Playback consumes its sparse assignments,
-publishes transforms and colors only to selected leaves, and catches a leaf up
-from its exact prepared state before making it visible again. Projection and
-leaf visibility scans remain prepare-time work.
+with one-time block expansion and no decoding, transform formatting, or block
+reconstruction inside frame publication. The initial current-plus-lookahead
+pair expands beneath the loader. During endless playback, later blocks expand
+incrementally in request-idle slices with a two-millisecond target budget; the
+next slice is delayed by one source frame so lookahead formatting cannot bunch
+inside one idle window. The player retains only the current and one lookahead
+block, so activation does not wait for expansion. A block expands to at most
+3,449,674 bytes of final CSS strings, and every prepared current-plus-lookahead
+pair stays below 6,754,392 bytes. Each bank also embeds one small viewport-visibility
+schedule with 25 conservative portrait, landscape, and square profiles. Playback
+selects the smallest-area rectangle that covers the CSS viewport, consumes its
+sparse assignments, publishes transforms and colors only to selected leaves,
+and catches a leaf up from its exact prepared state before making it visible
+again. Projection and leaf visibility scans remain prepare-time work.

--- a/src/adapters/gravitywell/notes/provenance-bible.md
+++ b/src/adapters/gravitywell/notes/provenance-bible.md
@@ -57,19 +57,25 @@ native profile, not a claim about the default `grid-size = 1` raster.
 
 The browser loads the verified static Morph package and bank catalog, chooses
 the initial bank with `crypto.getRandomValues`, adopts its 1,922 retained
-solid-quad line leaves with `createPolyMorphPreparedDomTarget`, and loads only
-that bank's descriptor and first self-contained block for first paint. Its
-lookahead block starts halfway through block zero. The next shuffled bank starts
-prefetching only after the active bank's 240-frame source-authority window. The active
-bank retains only its current and one lookahead transform block. The shuffle
-visits the other 23 banks without replacement.
+solid-quad line leaves with `createPolyMorphPreparedDomTarget`, and expands the
+initial bank's current and lookahead blocks beneath the loader. Later lookahead
+blocks are fetched, verified, decompressed, decoded, and formatted ahead of
+activation. Decoding and fixed-two-decimal `matrix3d` formatting run in bounded
+request-idle slices with a two-millisecond target budget, outside frame
+publication. As in cssElectroPaint's prepared horizon, successive slices are
+separated by one source frame so they cannot bunch inside one idle window. The
+next shuffled bank starts prefetching only after the active
+bank's 240-frame source-authority window and uses the same incremental path.
+The active bank retains only its current and one lookahead transform block. The
+shuffle visits the other 23 banks without replacement.
 Sequential frames visit only their independently prepared transform and color
-write indices. Five conservative square viewport profiles prepare visible-leaf
-membership for every bank frame, including one-frame temporal dilation and
-sparse visibility assignments. Runtime chooses one profile on load or resize,
-keeps exact prepared transform and color state for hidden leaves, publishes
-styles only to selected leaves, and catches each newly selected leaf up before
-showing it. It performs no per-frame projection or viewport leaf scan. At the
+write indices. Twenty-five conservative rectangular viewport profiles prepare
+visible-leaf membership for every bank frame, including one-frame temporal
+dilation and sparse visibility assignments. Runtime chooses the smallest-area
+profile covering the CSS viewport on load or resize, keeps exact prepared
+transform and color state for hidden leaves, publishes styles only to selected
+leaves, and catches each newly selected leaf up before showing it. It performs
+no per-frame projection or viewport leaf scan. At the
 terminal flat frame, the player adopts the next bank at
 its identical frame 0 without a style write or DOM mutation. The absolute timer
 publishes one prepared frame per callback.
@@ -88,6 +94,17 @@ p95, and `9.2 ms` display-interval p95, with a `17.6 ms` maximum, no long tasks,
 no empty scheduler callbacks, no transform-block load, and no DOM growth. The
 same four deterministic browser frames remain pixel-exact against the deployed
 pre-optimization product.
+
+In the locally generated rectangular-profile candidate, a 390 by 844 viewport
+uses the 430 by 960 profile instead of the legacy 1,024-pixel square. Across
+three controlled FrameSleuth runs, the worst-transition selected transform
+writes fall from 1,113 to 753 and selected color writes from 811 to 519. Median
+total player publication work over the 1.8-second trial falls from 329.548 ms to
+220.656 ms; median maximum player callback work falls from 11.101 ms to 6.991
+ms. Four deterministic browser captures remain byte-identical to the legacy
+product. The 24-bank archive grows by 211,695 bytes. Browser compositor cadence
+does not materially change, so this is a page-owned work and headroom
+improvement rather than a claim that external compositor stalls are eliminated.
 
 At 960 by 600, a 5.5-second production/candidate streaming trace over the same
 bank reduces current-plus-lookahead prepared CSS string residency from

--- a/src/adapters/gravitywell/src/cssgravitywell/client.mjs
+++ b/src/adapters/gravitywell/src/cssgravitywell/client.mjs
@@ -26,7 +26,7 @@ export function mountGravityWellClient(host) {
   window.addEventListener("error", (event) => recordError(event.message || String(event.error || "error")));
   window.addEventListener("unhandledrejection", (event) => recordError(String(event.reason?.stack || event.reason || "unhandled rejection")));
   window.addEventListener("resize", () => {
-    state.player?.setViewportMaxAxis(Math.max(window.innerWidth, window.innerHeight));
+    state.player?.setViewportSize(window.innerWidth, window.innerHeight);
   }, { passive: true });
   main().catch((error) => recordError(error.stack || error.message || String(error)));
 
@@ -38,14 +38,14 @@ export function mountGravityWellClient(host) {
       loadPreparedGravityWellCatalog(),
     ]);
     const selection = selectInitialGravityWellBank(catalog);
-    const loadBank = async (bankIndex, { lookahead = false } = {}) => {
+    const loadBank = async (bankIndex, { lookahead = false, incremental = lookahead } = {}) => {
       const scene = await loadPreparedGravityWellBankScene(catalog, bankIndex);
       const transformBlocks = createTransformBlockLoader(scene.playback);
-      await transformBlocks.prime(0, { lookahead });
+      await transformBlocks.prime(0, { lookahead, incremental });
       const { changeSchedule } = transformBlocks.bankData();
       return Object.freeze({ scene, playback: scene.playback, transformBlocks, changeSchedule });
     };
-    const initialBank = await loadBank(selection.bankIndex);
+    const initialBank = await loadBank(selection.bankIndex, { lookahead: true, incremental: false });
     const scene = initialBank.scene;
     if (loaded.model.identity.id !== "gravitywell" ||
         loaded.model.render.leaves.length !== scene.metrics.preparedLeafCount) {

--- a/src/adapters/gravitywell/src/cssgravitywell/preparedAssets.mjs
+++ b/src/adapters/gravitywell/src/cssgravitywell/preparedAssets.mjs
@@ -98,7 +98,7 @@ export async function loadPreparedGravityWellBankScene(catalog, bankIndex) {
   return Object.freeze(scene);
 }
 
-export function createTransformBlockLoader(playback) {
+export function createTransformBlockLoader(playback, scheduling = {}) {
   const records = new Map();
   const frameView = { transforms: null, start: 0, count: 0, mode: "full" };
   const colorFrameView = { values: null, start: 0, count: 0, mode: "full" };
@@ -145,14 +145,29 @@ export function createTransformBlockLoader(playback) {
   let randomAccessReconstructionCount = 0;
   let randomAccessTransformAssignmentCount = 0;
   let randomAccessColorAssignmentCount = 0;
+  let activationWaitCount = 0;
+  let incrementalDecodeRequestCount = 0;
+  let incrementalDecodeCompletedBlockCount = 0;
+  let incrementalDecodeSliceCount = 0;
+  let incrementalDecodeOperationCount = 0;
+  let incrementalDecodeMaximumSliceMilliseconds = 0;
   let destroyed = false;
-
+  const requestIdle = scheduling.requestIdle ?? defaultRequestIdle;
+  const setDelay = scheduling.setDelay ?? globalThis.setTimeout.bind(globalThis);
+  const readNow = scheduling.readNow ?? defaultReadNow;
+  const incrementalSliceBudgetMilliseconds = scheduling.incrementalSliceBudgetMilliseconds ?? 2;
+  if (typeof requestIdle !== "function" || typeof setDelay !== "function" ||
+      typeof readNow !== "function" ||
+      !Number.isFinite(incrementalSliceBudgetMilliseconds) ||
+      incrementalSliceBudgetMilliseconds <= 0 || incrementalSliceBudgetMilliseconds > 4) {
+    throw new TypeError("Gravity Well incremental transform decoder scheduling is invalid");
+  }
   function nextBlockIndex(blockIndex) {
     const next = blockIndex + 1;
     return next < playback.blocks.length ? next : -1;
   }
 
-  async function ensure(blockIndex) {
+  async function ensure(blockIndex, { incremental = false } = {}) {
     if (destroyed) throw new Error("Gravity Well transform loader is destroyed");
     const descriptor = playback.blocks[blockIndex];
     if (!descriptor || descriptor.index !== blockIndex) throw new RangeError(`Missing transform block ${blockIndex}`);
@@ -166,7 +181,30 @@ export function createTransformBlockLoader(playback) {
       if (decoded.byteLength !== descriptor.decodedByteLength) {
         throw new Error(`Decoded transform block ${blockIndex} byte length drifted`);
       }
-      const prepared = decodePreparedTransformBlock(decoded, descriptor, playback, transformIndices);
+      const prepared = incremental
+        ? await decodePreparedTransformBlockIncrementally(
+          decoded,
+          descriptor,
+          playback,
+          transformIndices,
+          {
+            requestIdle,
+            setDelay,
+            readNow,
+            sliceBudgetMilliseconds: incrementalSliceBudgetMilliseconds,
+            isCurrent: () => !destroyed && (blockIndex === desiredCurrent || blockIndex === desiredNext),
+            onSlice(operationCount, durationMilliseconds) {
+              incrementalDecodeSliceCount += 1;
+              incrementalDecodeOperationCount += operationCount;
+              incrementalDecodeMaximumSliceMilliseconds = Math.max(
+                incrementalDecodeMaximumSliceMilliseconds,
+                durationMilliseconds,
+              );
+            },
+          },
+        )
+        : decodePreparedTransformBlock(decoded, descriptor, playback, transformIndices);
+      if (prepared === null) throw new Error(`Transform block ${blockIndex} incremental decode was cancelled`);
       if (prepared.bankSchedule && transformIndices === null) {
         transformIndices = prepared.bankSchedule.transformIndices;
         changeSchedule = createPreparedChangeSchedule(
@@ -186,6 +224,7 @@ export function createTransformBlockLoader(playback) {
       });
       records.set(blockIndex, record);
       loadCount += 1;
+      if (incremental) incrementalDecodeCompletedBlockCount += 1;
       residentDecodedBytes += descriptor.preparedCssStringByteLength;
       peakResidentDecodedBytes = Math.max(peakResidentDecodedBytes, residentDecodedBytes);
       if (blockIndex !== desiredCurrent && blockIndex !== desiredNext) release(blockIndex);
@@ -213,22 +252,24 @@ export function createTransformBlockLoader(playback) {
     desiredNext = next;
     activeBlockIndex = current;
     activeRecord = record;
-    if (next >= 0 && !records.has(next)) void ensure(next).catch(() => undefined);
+    if (next >= 0 && !records.has(next)) {
+      incrementalDecodeRequestCount += 1;
+      void ensure(next, { incremental: true }).catch(() => undefined);
+    }
     for (const blockIndex of records.keys()) {
       if (blockIndex !== current && blockIndex !== next) release(blockIndex);
     }
   }
 
   return Object.freeze({
-    async prime(frameIndex = 0, { lookahead = false } = {}) {
+    async prime(frameIndex = 0, { lookahead = false, incremental = false } = {}) {
       const current = Math.trunc(frameIndex / playback.blockFrameCount);
       if (current !== 0) throw new Error("Gravity Well prepared bank must prime from block zero");
       const next = lookahead ? nextBlockIndex(current) : -1;
       desiredCurrent = current;
       desiredNext = next;
-      const requests = [ensure(current)];
-      if (next >= 0) requests.push(ensure(next));
-      const [record] = await Promise.all(requests);
+      const record = await ensure(current, { incremental });
+      if (next >= 0) await ensure(next, { incremental });
       activeBlockIndex = current;
       activeRecord = record;
     },
@@ -242,7 +283,8 @@ export function createTransformBlockLoader(playback) {
       const next = nextBlockIndex(activeBlockIndex);
       desiredNext = next;
       if (next < 0 || records.has(next)) return null;
-      return ensure(next);
+      incrementalDecodeRequestCount += 1;
+      return ensure(next, { incremental: true });
     },
     activate(frameIndex) {
       const current = Math.trunc(frameIndex / playback.blockFrameCount);
@@ -255,7 +297,8 @@ export function createTransformBlockLoader(playback) {
         adopt(current, next, existing);
         return null;
       }
-      return ensure(current).then((record) => adopt(current, next, record));
+      activationWaitCount += 1;
+      return ensure(current, { incremental: true }).then((record) => adopt(current, next, record));
     },
     selectFrame(frameIndex, sequential = false) {
       const current = Math.trunc(frameIndex / playback.blockFrameCount);
@@ -356,6 +399,12 @@ export function createTransformBlockLoader(playback) {
         randomAccessReconstructionCount,
         randomAccessTransformAssignmentCount,
         randomAccessColorAssignmentCount,
+        activationWaitCount,
+        incrementalDecodeRequestCount,
+        incrementalDecodeCompletedBlockCount,
+        incrementalDecodeSliceCount,
+        incrementalDecodeOperationCount,
+        incrementalDecodeMaximumSliceMilliseconds,
       });
     },
     destroy() {
@@ -419,14 +468,22 @@ function decodeBase64(value) {
 }
 
 async function decodePreparedViewportVisibility(descriptor) {
-  if (descriptor?.schema !== CSSGRAVITYWELL_VISIBILITY_SCHEMA ||
+  const legacySquare = descriptor?.schema === "cssgravitywell-prepared-viewport-visibility@1";
+  const dimensions = legacySquare
+    ? descriptor.profileSizes?.map((size) => ({ width: size, height: size }))
+    : descriptor?.profileDimensions;
+  if ((!legacySquare && descriptor?.schema !== CSSGRAVITYWELL_VISIBILITY_SCHEMA) ||
       descriptor.distribution !== "embedded-prepared-bank-scene" ||
-      descriptor.encoding !== CSSGRAVITYWELL_VISIBILITY_ENCODING ||
-      descriptor.selection !== "smallest-square-profile-covering-maximum-css-viewport-axis-or-disabled" ||
+      descriptor.encoding !== (legacySquare
+        ? "gzip-cgwv1-square-profile-sparse-visibility-assignments"
+        : CSSGRAVITYWELL_VISIBILITY_ENCODING) ||
+      descriptor.selection !== (legacySquare
+        ? "smallest-square-profile-covering-maximum-css-viewport-axis-or-disabled"
+        : "smallest-area-rectangular-profile-covering-css-viewport-or-disabled") ||
       descriptor.marginPixels !== CSSGRAVITYWELL_VIEWPORT_MARGIN_PIXELS ||
       descriptor.dilationFrames !== CSSGRAVITYWELL_VIEWPORT_DILATION_FRAMES ||
-      !Array.isArray(descriptor.profileSizes) || descriptor.profileSizes.length < 1 ||
-      descriptor.profiles?.length !== descriptor.profileSizes.length) {
+      !Array.isArray(dimensions) || dimensions.length < 1 ||
+      descriptor.profiles?.length !== dimensions.length) {
     throw new Error("Gravity Well prepared viewport visibility descriptor drifted");
   }
   const encoded = decodeBase64(descriptor.encodedBase64);
@@ -434,24 +491,27 @@ async function decodePreparedViewportVisibility(descriptor) {
   const bytes = await decompressGzip(encoded);
   if (bytes.byteLength !== descriptor.decodedByteLength || bytes.byteLength < 8 ||
       String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]) !== "CGWV" ||
-      bytes[4] !== 1 || bytes[5] !== descriptor.profileSizes.length || bytes[6] !== 0 || bytes[7] !== 0) {
+      bytes[4] !== (legacySquare ? 1 : 2) || bytes[5] !== dimensions.length || bytes[6] !== 0 || bytes[7] !== 0) {
     throw new Error("Gravity Well prepared viewport visibility header drifted");
   }
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const profiles = [];
   let offset = 8;
-  for (let profileIndex = 0; profileIndex < descriptor.profileSizes.length; profileIndex += 1) {
-    if (offset + 16 > bytes.byteLength) throw new Error("Gravity Well viewport visibility profile is truncated");
-    const size = view.getUint16(offset, true);
-    const marginPixels = view.getUint16(offset + 2, true);
-    const dilationFrames = bytes[offset + 4];
-    const reserved = bytes[offset + 5];
-    const frameCount = view.getUint16(offset + 6, true);
-    const leafCount = view.getUint16(offset + 8, true);
-    const initialVisibleCount = view.getUint16(offset + 10, true);
-    const visibilityChangeCount = view.getUint32(offset + 12, true);
-    offset += 16;
-    if (size !== descriptor.profileSizes[profileIndex] || marginPixels !== descriptor.marginPixels ||
+  for (let profileIndex = 0; profileIndex < dimensions.length; profileIndex += 1) {
+    const headerBytes = legacySquare ? 16 : 18;
+    if (offset + headerBytes > bytes.byteLength) throw new Error("Gravity Well viewport visibility profile is truncated");
+    const profileDimensions = dimensions[profileIndex];
+    const width = legacySquare ? view.getUint16(offset, true) : view.getUint16(offset, true);
+    const height = legacySquare ? width : view.getUint16(offset + 2, true);
+    const marginPixels = view.getUint16(offset + (legacySquare ? 2 : 4), true);
+    const dilationFrames = bytes[offset + (legacySquare ? 4 : 6)];
+    const reserved = bytes[offset + (legacySquare ? 5 : 7)];
+    const frameCount = view.getUint16(offset + (legacySquare ? 6 : 8), true);
+    const leafCount = view.getUint16(offset + (legacySquare ? 8 : 10), true);
+    const initialVisibleCount = view.getUint16(offset + (legacySquare ? 10 : 12), true);
+    const visibilityChangeCount = view.getUint32(offset + (legacySquare ? 12 : 14), true);
+    offset += headerBytes;
+    if (width !== profileDimensions.width || height !== profileDimensions.height || marginPixels !== descriptor.marginPixels ||
         dilationFrames !== descriptor.dilationFrames || reserved !== 0 ||
         frameCount !== descriptor.frameCount || leafCount !== descriptor.leafCount ||
         initialVisibleCount !== descriptor.profiles[profileIndex].initialVisibleCount ||
@@ -471,7 +531,8 @@ async function decodePreparedViewportVisibility(descriptor) {
     const assignments = readPreparedUint16Rows(bytes, offset, visibilityChangeCount);
     offset += assignments.byteLength;
     validatePreparedVisibilityProfile({
-      size,
+      width,
+      height,
       frameCount,
       leafCount,
       initialVisibleIndices,
@@ -479,7 +540,8 @@ async function decodePreparedViewportVisibility(descriptor) {
       assignments,
     });
     profiles.push(Object.freeze({
-      size,
+      width,
+      height,
       frameCount,
       leafCount,
       initialVisibleIndices,
@@ -489,8 +551,8 @@ async function decodePreparedViewportVisibility(descriptor) {
   }
   if (offset !== bytes.byteLength) throw new Error("Gravity Well viewport visibility payload has trailing bytes");
   return Object.freeze({
-    schema: descriptor.schema,
-    selection: descriptor.selection,
+    schema: CSSGRAVITYWELL_VISIBILITY_SCHEMA,
+    selection: "smallest-area-rectangular-profile-covering-css-viewport-or-disabled",
     frameCount: descriptor.frameCount,
     leafCount: descriptor.leafCount,
     marginPixels: descriptor.marginPixels,
@@ -555,7 +617,63 @@ async function decompressGzip(encoded) {
   ).arrayBuffer());
 }
 
+function defaultRequestIdle(callback, options) {
+  if (typeof globalThis.requestIdleCallback === "function") {
+    return globalThis.requestIdleCallback(callback, options);
+  }
+  return globalThis.setTimeout(() => callback(Object.freeze({
+    didTimeout: true,
+    timeRemaining: () => 0,
+  })), 0);
+}
+
+function defaultReadNow() {
+  return globalThis.performance.now();
+}
+
 function decodePreparedTransformBlock(bytes, descriptor, playback, loadedTransformIndices) {
+  const decoder = createPreparedTransformBlockDecoder(bytes, descriptor, playback, loadedTransformIndices);
+  while (!decoder.done()) decoder.step(Number.MAX_SAFE_INTEGER, () => false);
+  return decoder.result();
+}
+
+async function decodePreparedTransformBlockIncrementally(
+  bytes,
+  descriptor,
+  playback,
+  loadedTransformIndices,
+  {
+    requestIdle,
+    setDelay,
+    readNow,
+    sliceBudgetMilliseconds,
+    isCurrent,
+    onSlice,
+  },
+) {
+  const decoder = createPreparedTransformBlockDecoder(bytes, descriptor, playback, loadedTransformIndices);
+  let firstSlice = true;
+  while (!decoder.done()) {
+    if (!firstSlice) {
+      await new Promise((resolveDelay) => setDelay(resolveDelay, playback.frameMilliseconds));
+      if (!isCurrent()) return null;
+    }
+    firstSlice = false;
+    const deadline = await new Promise((resolveIdle) => requestIdle(resolveIdle, {
+      timeout: Math.max(50, Math.ceil(playback.frameMilliseconds * 4)),
+    }));
+    if (!isCurrent()) return null;
+    const startedAt = readNow();
+    const operationCount = decoder.step(8_192, (processed) =>
+      processed >= 64 && processed % 64 === 0 &&
+      ((typeof deadline?.timeRemaining === "function" && deadline.timeRemaining() <= 1) ||
+        readNow() - startedAt >= sliceBudgetMilliseconds));
+    onSlice(operationCount, readNow() - startedAt);
+  }
+  return decoder.result();
+}
+
+function createPreparedTransformBlockDecoder(bytes, descriptor, playback, loadedTransformIndices) {
   if (!(bytes instanceof Uint8Array) || bytes.byteLength < MATRIX_BLOCK_HEADER_BYTES ||
       String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]) !== "CGWM" ||
       bytes[4] !== 2 || bytes[5] !== MATRIX_DECIMAL_PLACES ||
@@ -611,56 +729,93 @@ function decodePreparedTransformBlock(bytes, descriptor, playback, loadedTransfo
   }
   const componentCount = MATRIX_COMPONENTS.length;
   const state = new Int32Array(descriptor.keyframeTransformCount * componentCount);
-  for (let component = 0; component < componentCount; component += 1) {
-    const stream = streams[component];
-    let previous = 0;
-    for (let leafIndex = 0; leafIndex < descriptor.keyframeTransformCount; leafIndex += 1) {
-      previous = checkedInt32(previous + readSignedVarint(bytes, stream), descriptor.index);
-      state[leafIndex * componentCount + component] = previous;
-    }
-    assertStreamConsumed(stream, descriptor.index);
-  }
   const transforms = new Array(descriptor.transformCount);
   let preparedCssStringByteLength = 0;
-  for (let leafIndex = 0; leafIndex < descriptor.keyframeTransformCount; leafIndex += 1) {
-    const transform = formatPreparedMatrix(state, leafIndex * componentCount);
-    transforms[leafIndex] = transform;
-    preparedCssStringByteLength += transform.length;
-  }
   const maskStream = streams[componentCount];
   if (maskStream.end - maskStream.offset !== descriptor.deltaTransformCount * Uint16Array.BYTES_PER_ELEMENT) {
     throw new Error(`Transform block ${descriptor.index} mask stream drifted`);
   }
   const componentStreams = streams.slice(componentCount + 1, MATRIX_DATA_STREAM_COUNT);
-  for (let rowIndex = 0; rowIndex < descriptor.deltaTransformCount; rowIndex += 1) {
-    const mask = bytes[maskStream.offset] | (bytes[maskStream.offset + 1] << 8);
-    maskStream.offset += Uint16Array.BYTES_PER_ELEMENT;
-    if ((mask >>> componentCount) !== 0) {
-      throw new Error(`Transform block ${descriptor.index} component mask drifted`);
+  let stage = "components";
+  let component = 0;
+  let leafIndex = 0;
+  let previous = 0;
+  let rowIndex = 0;
+
+  function finish() {
+    assertStreamConsumed(maskStream, descriptor.index);
+    for (const stream of componentStreams) assertStreamConsumed(stream, descriptor.index);
+    if (preparedCssStringByteLength !== descriptor.preparedCssStringByteLength) {
+      throw new Error(`Transform block ${descriptor.index} prepared CSS byte length drifted`);
     }
-    const changeIndex = descriptor.transformChangeStart + rowIndex;
-    const leafIndex = transformIndices[changeIndex];
-    if (!Number.isSafeInteger(leafIndex) || leafIndex < 0 || leafIndex >= descriptor.keyframeTransformCount) {
-      throw new Error(`Transform block ${descriptor.index} prepared leaf index drifted`);
-    }
-    const stateOffset = leafIndex * componentCount;
-    for (let component = 0; component < componentCount; component += 1) {
-      if ((mask & (1 << component)) === 0) continue;
-      state[stateOffset + component] = checkedInt32(
-        state[stateOffset + component] + readSignedVarint(bytes, componentStreams[component]),
-        descriptor.index,
-      );
-    }
-    const transform = formatPreparedMatrix(state, stateOffset);
-    transforms[descriptor.keyframeTransformCount + rowIndex] = transform;
-    preparedCssStringByteLength += transform.length;
+    stage = "done";
   }
-  assertStreamConsumed(maskStream, descriptor.index);
-  for (const stream of componentStreams) assertStreamConsumed(stream, descriptor.index);
-  if (preparedCssStringByteLength !== descriptor.preparedCssStringByteLength) {
-    throw new Error(`Transform block ${descriptor.index} prepared CSS byte length drifted`);
-  }
-  return Object.freeze({ transforms, colorValues, bankSchedule });
+
+  return Object.freeze({
+    done() {
+      return stage === "done";
+    },
+    step(maximumOperations, shouldYield) {
+      let processed = 0;
+      while (stage !== "done" && processed < maximumOperations && !shouldYield(processed)) {
+        if (stage === "components") {
+          const stream = streams[component];
+          previous = checkedInt32(previous + readSignedVarint(bytes, stream), descriptor.index);
+          state[leafIndex * componentCount + component] = previous;
+          leafIndex += 1;
+          if (leafIndex === descriptor.keyframeTransformCount) {
+            assertStreamConsumed(stream, descriptor.index);
+            component += 1;
+            leafIndex = 0;
+            previous = 0;
+            if (component === componentCount) stage = "keyframes";
+          }
+        } else if (stage === "keyframes") {
+          const transform = formatPreparedMatrix(state, leafIndex * componentCount);
+          transforms[leafIndex] = transform;
+          preparedCssStringByteLength += transform.length;
+          leafIndex += 1;
+          if (leafIndex === descriptor.keyframeTransformCount) {
+            leafIndex = 0;
+            stage = descriptor.deltaTransformCount === 0 ? "done" : "deltas";
+            if (stage === "done") finish();
+          }
+        } else {
+          const mask = bytes[maskStream.offset] | (bytes[maskStream.offset + 1] << 8);
+          maskStream.offset += Uint16Array.BYTES_PER_ELEMENT;
+          if ((mask >>> componentCount) !== 0) {
+            throw new Error(`Transform block ${descriptor.index} component mask drifted`);
+          }
+          const changeIndex = descriptor.transformChangeStart + rowIndex;
+          const changedLeafIndex = transformIndices[changeIndex];
+          if (!Number.isSafeInteger(changedLeafIndex) || changedLeafIndex < 0 ||
+              changedLeafIndex >= descriptor.keyframeTransformCount) {
+            throw new Error(`Transform block ${descriptor.index} prepared leaf index drifted`);
+          }
+          const stateOffset = changedLeafIndex * componentCount;
+          for (let changedComponent = 0; changedComponent < componentCount; changedComponent += 1) {
+            if ((mask & (1 << changedComponent)) === 0) continue;
+            state[stateOffset + changedComponent] = checkedInt32(
+              state[stateOffset + changedComponent] +
+                readSignedVarint(bytes, componentStreams[changedComponent]),
+              descriptor.index,
+            );
+          }
+          const transform = formatPreparedMatrix(state, stateOffset);
+          transforms[descriptor.keyframeTransformCount + rowIndex] = transform;
+          preparedCssStringByteLength += transform.length;
+          rowIndex += 1;
+          if (rowIndex === descriptor.deltaTransformCount) finish();
+        }
+        processed += 1;
+      }
+      return processed;
+    },
+    result() {
+      if (stage !== "done") throw new Error(`Transform block ${descriptor.index} decode is incomplete`);
+      return Object.freeze({ transforms, colorValues, bankSchedule });
+    },
+  });
 }
 
 function readPreparedIndexRows(bytes, stream, offsets) {

--- a/src/adapters/gravitywell/src/cssgravitywell/preparedPlayback.mjs
+++ b/src/adapters/gravitywell/src/cssgravitywell/preparedPlayback.mjs
@@ -10,10 +10,12 @@ export async function createGravityWellPreparedPlayer({
   randomUint32 = cryptoRandomUint32,
   onBankChange = () => undefined,
   onError = () => undefined,
+  requestFrame = globalThis.requestAnimationFrame.bind(globalThis),
+  cancelFrame = globalThis.cancelAnimationFrame.bind(globalThis),
   setDelay = globalThis.setTimeout.bind(globalThis),
   clearDelay = globalThis.clearTimeout.bind(globalThis),
   readNow = globalThis.performance.now.bind(globalThis.performance),
-  viewportMaxAxis = defaultViewportMaxAxis(),
+  viewportSize = defaultViewportSize(),
 }) {
   const leaves = mounted.model.render.leaves.map((leaf) => mounted.leafHandles.get(leaf.id)?.element);
   const shapes = mounted.model.render.shapes.map((shape) => mounted.shapeElements.get(shape.id));
@@ -47,16 +49,22 @@ export async function createGravityWellPreparedPlayer({
   let playback = activeBank.playback;
   let transformBlocks = activeBank.transformBlocks;
   let changeSchedule = activeBank.changeSchedule;
-  let selectedViewportMaxAxis = validateViewportMaxAxis(viewportMaxAxis);
+  let selectedViewportSize = validateViewportSize(viewportSize.width, viewportSize.height);
   let visibilitySchedule = playback.visibilitySchedule;
-  let selectedVisibilityProfile = selectVisibilityProfile(visibilitySchedule, selectedViewportMaxAxis);
+  let selectedVisibilityProfile = selectVisibilityProfile(
+    visibilitySchedule,
+    selectedViewportSize.width,
+    selectedViewportSize.height,
+  );
   let presentedVisibilityFrameIndex = -1;
   let visibilityInitialized = false;
   let currentVisibleLeafCount = 0;
   let firstBlockLookaheadFrameIndex = Math.max(1, Math.floor(playback.blockFrameCount / 2));
   const frameMilliseconds = playback.frameMilliseconds;
+  const schedulerLeadMilliseconds = Math.min(10, frameMilliseconds / 3);
   let paused = true;
   let destroyed = false;
+  let frameRequest = null;
   let delayRequest = null;
   let nextFrameAt = null;
   let tick = 0;
@@ -73,6 +81,8 @@ export async function createGravityWellPreparedPlayer({
   let viewportProfileSwitchCount = 0;
   let viewportProfileRebuildLeafScanCount = 0;
   let schedulerCallbacks = 0;
+  let schedulerFrameRequests = 0;
+  let schedulerTimerCallbacks = 0;
   let schedulerTimerSchedules = 0;
   let bankSwitchCount = 0;
   let runtimeBankWaitCount = 0;
@@ -262,7 +272,10 @@ export async function createGravityWellPreparedPlayer({
   function queueNextBank() {
     if (!cycleBanks || bankCount === 1 || pendingBankPromise || pendingBank) return pendingBankPromise;
     pendingBankIndex = nextBankIndex();
-    pendingBankPromise = Promise.resolve(loadBank(pendingBankIndex)).then((loaded) => {
+    pendingBankPromise = Promise.resolve(loadBank(pendingBankIndex, {
+      lookahead: true,
+      incremental: true,
+    })).then((loaded) => {
       pendingBank = validateBank(loaded, pendingBankIndex, leaves.length);
       pendingBankPromise = null;
       return pendingBank;
@@ -286,7 +299,11 @@ export async function createGravityWellPreparedPlayer({
     transformBlocks = activeBank.transformBlocks;
     changeSchedule = activeBank.changeSchedule;
     visibilitySchedule = playback.visibilitySchedule;
-    selectedVisibilityProfile = selectVisibilityProfile(visibilitySchedule, selectedViewportMaxAxis);
+    selectedVisibilityProfile = selectVisibilityProfile(
+      visibilitySchedule,
+      selectedViewportSize.width,
+      selectedViewportSize.height,
+    );
     firstBlockLookaheadFrameIndex = Math.max(1, Math.floor(playback.blockFrameCount / 2));
     frameIndex = 0;
     selectVisibilityFrame(frameIndex, -1);
@@ -308,27 +325,30 @@ export async function createGravityWellPreparedPlayer({
     return applyFrame(frameIndex + 1);
   }
 
-  function schedule() {
-    if (paused || delayRequest !== null) return;
-    const delay = nextFrameAt === null ? 0 : Math.ceil(Math.max(0, nextFrameAt - readNow()));
-    schedulerTimerSchedules += 1;
-    delayRequest = setDelay(loop, delay);
+  function requestPaintAlignedPublication() {
+    frameRequest = requestFrame(loop);
+    schedulerFrameRequests += 1;
   }
 
-  function loop() {
-    delayRequest = null;
+  function schedule() {
+    if (paused || frameRequest !== null || delayRequest !== null) return;
+    const delay = Math.max(0, nextFrameAt - readNow() - schedulerLeadMilliseconds);
+    if (delay <= 1) {
+      requestPaintAlignedPublication();
+      return;
+    }
+    schedulerTimerSchedules += 1;
+    delayRequest = setDelay(() => {
+      delayRequest = null;
+      schedulerTimerCallbacks += 1;
+      if (!paused && frameRequest === null) requestPaintAlignedPublication();
+    }, delay);
+  }
+
+  function loop(timestamp) {
+    frameRequest = null;
     schedulerCallbacks += 1;
     if (paused) return;
-    const timestamp = readNow();
-    if (nextFrameAt === null) {
-      nextFrameAt = timestamp + frameMilliseconds;
-      schedule();
-      return;
-    }
-    if (timestamp < nextFrameAt) {
-      schedule();
-      return;
-    }
     nextFrameAt += frameMilliseconds;
     if (nextFrameAt <= timestamp) nextFrameAt = timestamp + frameMilliseconds;
     const pending = advanceOne();
@@ -339,6 +359,8 @@ export async function createGravityWellPreparedPlayer({
   function pause() {
     paused = true;
     nextFrameAt = null;
+    if (frameRequest !== null) cancelFrame(frameRequest);
+    frameRequest = null;
     if (delayRequest !== null) clearDelay(delayRequest);
     delayRequest = null;
     return tick;
@@ -358,7 +380,7 @@ export async function createGravityWellPreparedPlayer({
     resume() {
       if (!paused) return tick;
       paused = false;
-      nextFrameAt = null;
+      nextFrameAt = readNow() + frameMilliseconds;
       schedule();
       return tick;
     },
@@ -385,16 +407,20 @@ export async function createGravityWellPreparedPlayer({
       }
       return this.setTick(activeBank.scene.timeline.sourceFrameStartIndex + sourceTick);
     },
-    setViewportMaxAxis(value) {
-      const nextViewportMaxAxis = validateViewportMaxAxis(value);
-      const nextProfile = selectVisibilityProfile(visibilitySchedule, nextViewportMaxAxis);
-      selectedViewportMaxAxis = nextViewportMaxAxis;
-      if (nextProfile === selectedVisibilityProfile) return nextProfile?.size ?? null;
+    setViewportSize(width, height) {
+      const nextViewportSize = validateViewportSize(width, height);
+      const nextProfile = selectVisibilityProfile(
+        visibilitySchedule,
+        nextViewportSize.width,
+        nextViewportSize.height,
+      );
+      selectedViewportSize = nextViewportSize;
+      if (nextProfile === selectedVisibilityProfile) return profileDimensions(nextProfile);
       selectedVisibilityProfile = nextProfile;
       viewportProfileSwitchCount += 1;
       selectVisibilityFrame(frameIndex, -1);
       publishNewlyVisibleLeaves();
-      return nextProfile?.size ?? null;
+      return profileDimensions(nextProfile);
     },
     assertStableDomIdentity() {
       target.assertStableDomIdentity();
@@ -428,12 +454,17 @@ export async function createGravityWellPreparedPlayer({
         visibilityCatchupColorWrites,
         viewportProfileSwitchCount,
         viewportProfileRebuildLeafScanCount,
-        selectedViewportMaxAxis,
-        selectedViewportProfileSize: selectedVisibilityProfile?.size ?? null,
+        selectedViewportWidth: selectedViewportSize.width,
+        selectedViewportHeight: selectedViewportSize.height,
+        selectedViewportProfileWidth: selectedVisibilityProfile?.width ?? null,
+        selectedViewportProfileHeight: selectedVisibilityProfile?.height ?? null,
         currentVisibleLeafCount,
         schedulerCallbacks,
-        schedulerTimerCallbacks: schedulerCallbacks,
+        schedulerFrameRequests,
+        schedulerTimerCallbacks,
         schedulerTimerSchedules,
+        schedulerLeadMilliseconds,
+        runtimeSchedulerTransport: "deadline-setTimeout-requestAnimationFrame-prepared-publication",
         preparedTransformChangeIndexCount: changeSchedule.transformCount,
         preparedColorChangeIndexCount: changeSchedule.colorCount,
         runtimeGeometryConstructionCount: 0,
@@ -464,7 +495,7 @@ function validateBank(bank, bankIndex, leafCount) {
       typeof bank.transformBlocks?.activate !== "function" ||
       typeof bank.transformBlocks?.selectColorFrame !== "function" ||
       typeof bank.changeSchedule?.selectFrame !== "function" ||
-      bank.playback.visibilitySchedule?.schema !== "cssgravitywell-prepared-viewport-visibility@1" ||
+      bank.playback.visibilitySchedule?.schema !== "cssgravitywell-prepared-viewport-visibility@2" ||
       bank.playback.visibilitySchedule.frameCount !== bank.playback.frameCount ||
       bank.playback.visibilitySchedule.leafCount !== leafCount ||
       bank.scene.timeline?.firstAndLastGroundFlat !== true ||
@@ -474,28 +505,37 @@ function validateBank(bank, bankIndex, leafCount) {
   return bank;
 }
 
-function defaultViewportMaxAxis() {
+function defaultViewportSize() {
   const width = Number(globalThis.innerWidth);
   const height = Number(globalThis.innerHeight);
   return Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0
-    ? Math.max(width, height)
-    : Infinity;
+    ? Object.freeze({ width, height })
+    : Object.freeze({ width: Infinity, height: Infinity });
 }
 
-function validateViewportMaxAxis(value) {
-  const axis = Number(value);
-  if (axis !== Infinity && (!Number.isFinite(axis) || axis <= 0)) {
-    throw new RangeError("Gravity Well viewport maximum axis must be positive");
+function validateViewportSize(widthValue, heightValue) {
+  const width = Number(widthValue);
+  const height = Number(heightValue);
+  if ((width !== Infinity && (!Number.isFinite(width) || width <= 0)) ||
+      (height !== Infinity && (!Number.isFinite(height) || height <= 0))) {
+    throw new RangeError("Gravity Well viewport dimensions must be positive");
   }
-  return axis;
+  return Object.freeze({ width, height });
 }
 
-function selectVisibilityProfile(schedule, viewportMaxAxis) {
-  if (schedule?.schema !== "cssgravitywell-prepared-viewport-visibility@1" ||
+function selectVisibilityProfile(schedule, viewportWidth, viewportHeight) {
+  if (schedule?.schema !== "cssgravitywell-prepared-viewport-visibility@2" ||
       !Array.isArray(schedule.profiles) || schedule.profiles.length < 1) {
     throw new Error("Gravity Well prepared viewport visibility schedule is incomplete");
   }
-  return schedule.profiles.find((profile) => profile.size >= viewportMaxAxis) ?? null;
+  return schedule.profiles
+    .filter((profile) => profile.width >= viewportWidth && profile.height >= viewportHeight)
+    .sort((left, right) => left.width * left.height - right.width * right.height ||
+      left.width + left.height - right.width - right.height)[0] ?? null;
+}
+
+function profileDimensions(profile) {
+  return profile ? Object.freeze({ width: profile.width, height: profile.height }) : null;
 }
 
 function cryptoRandomUint32() {

--- a/src/adapters/gravitywell/src/prepare/cssgravitywell/visibilitySchedule.mjs
+++ b/src/adapters/gravitywell/src/prepare/cssgravitywell/visibilitySchedule.mjs
@@ -1,16 +1,32 @@
-export const CSSGRAVITYWELL_VIEWPORT_PROFILE_SIZES = Object.freeze([1_024, 1_536, 1_920, 2_560, 3_840]);
+export const CSSGRAVITYWELL_VIEWPORT_PROFILES = Object.freeze([
+  [430, 960], [960, 430],
+  [480, 960], [960, 480],
+  [640, 1_024], [1_024, 640],
+  [768, 1_024], [1_024, 768],
+  [1_024, 1_024],
+  [800, 1_280], [1_280, 800],
+  [900, 1_440], [1_440, 900],
+  [1_024, 1_536], [1_536, 1_024],
+  [1_536, 1_536],
+  [1_080, 1_920], [1_920, 1_080],
+  [1_920, 1_920],
+  [1_440, 2_560], [2_560, 1_440],
+  [2_560, 2_560],
+  [2_160, 3_840], [3_840, 2_160],
+  [3_840, 3_840],
+].map(([width, height]) => Object.freeze({ width, height })));
 export const CSSGRAVITYWELL_VIEWPORT_MARGIN_PIXELS = 8;
 export const CSSGRAVITYWELL_VIEWPORT_DILATION_FRAMES = 1;
-export const CSSGRAVITYWELL_VISIBILITY_SCHEMA = "cssgravitywell-prepared-viewport-visibility@1";
-export const CSSGRAVITYWELL_VISIBILITY_ENCODING = "gzip-cgwv1-square-profile-sparse-visibility-assignments";
+export const CSSGRAVITYWELL_VISIBILITY_SCHEMA = "cssgravitywell-prepared-viewport-visibility@2";
+export const CSSGRAVITYWELL_VISIBILITY_ENCODING = "gzip-cgwv2-rectangular-profile-sparse-visibility-assignments";
 
 const MAGIC = "CGWV";
 const HEADER_BYTES = 8;
-const PROFILE_HEADER_BYTES = 16;
+const PROFILE_HEADER_BYTES = 18;
 const PERSPECTIVE = 600 / (2 * Math.tan(20 * Math.PI / 180));
 
 export function prepareGravityWellViewportVisibility(quadsByFrame, {
-  profileSizes = CSSGRAVITYWELL_VIEWPORT_PROFILE_SIZES,
+  profileDimensions = CSSGRAVITYWELL_VIEWPORT_PROFILES,
   marginPixels = CSSGRAVITYWELL_VIEWPORT_MARGIN_PIXELS,
   dilationFrames = CSSGRAVITYWELL_VIEWPORT_DILATION_FRAMES,
 } = {}) {
@@ -18,17 +34,18 @@ export function prepareGravityWellViewportVisibility(quadsByFrame, {
   const leafCount = quadsByFrame?.[0]?.length ?? 0;
   if (!Array.isArray(quadsByFrame) || frameCount < 2 || leafCount < 1 ||
       quadsByFrame.some((quads) => !Array.isArray(quads) || quads.length !== leafCount) ||
-      !Array.isArray(profileSizes) || profileSizes.length < 1 ||
-      profileSizes.some((size, index) => !Number.isSafeInteger(size) || size < 1 ||
-        (index > 0 && size <= profileSizes[index - 1])) ||
+      !Array.isArray(profileDimensions) || profileDimensions.length < 1 ||
+      profileDimensions.some((profile) => !Number.isSafeInteger(profile?.width) || profile.width < 1 ||
+        !Number.isSafeInteger(profile?.height) || profile.height < 1) ||
+      new Set(profileDimensions.map((profile) => `${profile.width}x${profile.height}`)).size !== profileDimensions.length ||
       !Number.isSafeInteger(marginPixels) || marginPixels < 0 ||
       !Number.isSafeInteger(dilationFrames) || dilationFrames < 0 || dilationFrames > 4) {
     throw new TypeError("Complete prepared Gravity Well viewport visibility inputs are required");
   }
-  const profiles = profileSizes.map((size) => {
+  const profiles = profileDimensions.map(({ width, height }) => {
     const rawFrames = quadsByFrame.map((quads) => Uint8Array.from(
       quads,
-      (quad) => preparedQuadIntersectsSquareViewport(quad, size, marginPixels) ? 1 : 0,
+      (quad) => preparedQuadIntersectsViewport(quad, width, height, marginPixels) ? 1 : 0,
     ));
     const frames = rawFrames.map((frame, frameIndex) => Uint8Array.from(frame, (selected, leafIndex) => {
       if (selected === 1 || dilationFrames === 0) return selected;
@@ -64,7 +81,8 @@ export function prepareGravityWellViewportVisibility(quadsByFrame, {
     }
     changeOffsets[frameCount] = assignments.length;
     return Object.freeze({
-      size,
+      width,
+      height,
       frameCount,
       leafCount,
       initialVisibleIndices: Uint16Array.from(initialVisibleIndices),
@@ -78,7 +96,7 @@ export function prepareGravityWellViewportVisibility(quadsByFrame, {
   return Object.freeze({
     schema: CSSGRAVITYWELL_VISIBILITY_SCHEMA,
     encoding: CSSGRAVITYWELL_VISIBILITY_ENCODING,
-    selection: "smallest-square-profile-covering-maximum-css-viewport-axis-or-disabled",
+    selection: "smallest-area-rectangular-profile-covering-css-viewport-or-disabled",
     frameCount,
     leafCount,
     marginPixels,
@@ -101,18 +119,19 @@ export function encodeGravityWellViewportVisibility(schedule) {
   const bytes = new Uint8Array(byteLength);
   const view = new DataView(bytes.buffer);
   for (let index = 0; index < MAGIC.length; index += 1) bytes[index] = MAGIC.charCodeAt(index);
-  bytes[4] = 1;
+  bytes[4] = 2;
   bytes[5] = schedule.profiles.length;
   let offset = HEADER_BYTES;
   for (const profile of schedule.profiles) {
-    view.setUint16(offset, profile.size, true);
-    view.setUint16(offset + 2, schedule.marginPixels, true);
-    bytes[offset + 4] = schedule.dilationFrames;
-    bytes[offset + 5] = 0;
-    view.setUint16(offset + 6, profile.frameCount, true);
-    view.setUint16(offset + 8, profile.leafCount, true);
-    view.setUint16(offset + 10, profile.initialVisibleIndices.length, true);
-    view.setUint32(offset + 12, profile.assignments.length, true);
+    view.setUint16(offset, profile.width, true);
+    view.setUint16(offset + 2, profile.height, true);
+    view.setUint16(offset + 4, schedule.marginPixels, true);
+    bytes[offset + 6] = schedule.dilationFrames;
+    bytes[offset + 7] = 0;
+    view.setUint16(offset + 8, profile.frameCount, true);
+    view.setUint16(offset + 10, profile.leafCount, true);
+    view.setUint16(offset + 12, profile.initialVisibleIndices.length, true);
+    view.setUint32(offset + 14, profile.assignments.length, true);
     offset += PROFILE_HEADER_BYTES;
     offset = writeUint16Rows(bytes, offset, profile.initialVisibleIndices);
     for (const value of profile.changeOffsets) {
@@ -125,7 +144,7 @@ export function encodeGravityWellViewportVisibility(schedule) {
   return bytes;
 }
 
-function preparedQuadIntersectsSquareViewport(quad, size, marginPixels) {
+function preparedQuadIntersectsViewport(quad, width, height, marginPixels) {
   if (!Array.isArray(quad?.points) || quad.points.length !== 4) {
     throw new TypeError("Prepared Gravity Well line quad is incomplete");
   }
@@ -146,9 +165,10 @@ function preparedQuadIntersectsSquareViewport(quad, size, marginPixels) {
     minimumY = Math.min(minimumY, y);
     maximumY = Math.max(maximumY, y);
   }
-  const halfExtent = size / 2 + marginPixels;
-  return maximumX >= -halfExtent && minimumX <= halfExtent &&
-    maximumY >= -halfExtent && minimumY <= halfExtent;
+  const halfWidth = width / 2 + marginPixels;
+  const halfHeight = height / 2 + marginPixels;
+  return maximumX >= -halfWidth && minimumX <= halfWidth &&
+    maximumY >= -halfHeight && minimumY <= halfHeight;
 }
 
 function writeUint16Rows(target, offset, values) {

--- a/src/adapters/gravitywell/test/cssgravitywell-product-bank.asset-test.mjs
+++ b/src/adapters/gravitywell/test/cssgravitywell-product-bank.asset-test.mjs
@@ -13,7 +13,8 @@ test("generated Gravity Well product bank is exact and portable", async () => {
   assert.equal(summary.colorAssetCount, 24);
   assert.equal(summary.changeAssetCount, 24);
   assert.equal(summary.visibilityAssetCount, 24);
-  assert.equal(summary.visibilityEncodedBytes, 109_999);
+  assert.ok(summary.visibilityEncodedBytes >= 100_000);
+  assert.ok(summary.visibilityEncodedBytes <= 500_000);
   assert.equal(summary.transformAssetCount, 24 * CSSGRAVITYWELL_TRANSFORM_BLOCK_COUNT);
   assert.equal(summary.fileCount, 28 + summary.transformAssetCount);
   assert.ok(summary.maximumTransformBlockPreparedCssStringBytes < 4_000_000);

--- a/src/adapters/gravitywell/test/cssgravitywell-runtime-surface.test.mjs
+++ b/src/adapters/gravitywell/test/cssgravitywell-runtime-surface.test.mjs
@@ -33,6 +33,9 @@ test("proof tools use the canonical gravitywell route", async () => {
   const trace = await readFile(resolve(adapterRoot, "tools/trace-frame-work.mjs"), "utf8");
   const oracle = await readFile(resolve(adapterRoot, "tools/oracle/run-visual-oracle.mjs"), "utf8");
   assert.match(trace, /127\.0\.0\.1:5174\/gravitywell\//u);
+  assert.match(trace, /cssgravitywell-steady-playback-start/u);
+  assert.match(trace, /analyzeTrace/u);
+  assert.match(trace, /noScheduledTransformBlockWait/u);
   assert.match(oracle, /127\.0\.0\.1:\$\{port\}\/gravitywell\//u);
 });
 
@@ -56,6 +59,7 @@ test("product runtime has one retained DOM renderer and no forbidden geometry ro
     assert.doesNotMatch(source, forbidden);
   }
   assert.match(source, /createPolyMorphPreparedDomTarget/u);
+  assert.match(source, /setViewportSize/u);
   assert.match(source, /leafStyles\[leafIndex\]\.transform\s*=/u);
   assert.match(source, /changes\.transformIndices/u);
   assert.match(source, /changes\.colorIndices/u);
@@ -73,7 +77,7 @@ test("product frame loop publishes only separately prepared writes", async () =>
     playback.indexOf("function schedule"),
   );
   const schedule = playback.slice(
-    playback.indexOf("function schedule"),
+    playback.indexOf("function requestPaintAlignedPublication"),
     playback.indexOf("function pause"),
   );
   const activate = assets.slice(
@@ -82,19 +86,31 @@ test("product frame loop publishes only separately prepared writes", async () =>
   );
   assert.doesNotMatch(publishFrame, /assertStableDomIdentity/u);
   assert.doesNotMatch(publishFrame, /selectedColorRows/u);
-  assert.doesNotMatch(playback, /requestAnimationFrame/u);
+  assert.match(schedule, /requestPaintAlignedPublication/u);
+  assert.match(schedule, /nextFrameAt - readNow\(\) - schedulerLeadMilliseconds/u);
+  assert.match(schedule, /requestFrame\(loop\)/u);
+  assert.match(schedule, /nextFrameAt \+= frameMilliseconds/u);
   assert.doesNotMatch(activate, /new Set/u);
   assert.doesNotMatch(assets, /verifyBytes\(decoded/u);
   assert.doesNotMatch(assets, /transforms\.some/u);
   assert.doesNotMatch(preparer, /decodedSha256/u);
-  assert.match(schedule, /setDelay\(loop, delay\)/u);
+  assert.match(schedule, /setDelay\(\(\) =>/u);
+  assert.match(playback, /deadline-setTimeout-requestAnimationFrame-prepared-publication/u);
   assert.match(assets, /frame-major-reset-delta-varint-transform-indices-then-color-indices/u);
   assert.match(assets, /decoded\.byteLength !== descriptor\.decodedByteLength/u);
   assert.match(assets, /transforms\.length !== descriptor\.transformCount/u);
   assert.match(assets, /gzip-field-major-delta-varint-fixed2-matrix-and-bank-schedule@2/u);
   assert.match(assets, /decodePreparedTransformBlock\(decoded, descriptor, playback, transformIndices\)/u);
+  assert.match(assets, /decodePreparedTransformBlockIncrementally/u);
+  assert.match(assets, /requestIdle/u);
+  assert.match(assets, /setDelay\(resolveDelay, playback\.frameMilliseconds\)/u);
+  assert.match(assets, /incrementalSliceBudgetMilliseconds/u);
+  assert.match(assets, /incrementalDecodeMaximumSliceMilliseconds/u);
   assert.match(assets, /preparedCssStringByteLength !== descriptor\.preparedCssStringByteLength/u);
   assert.match(assets, /frameView\.mode = "delta"/u);
+  assert.match(assets, /activationWaitCount/u);
+  assert.match(assets, /rectangular-profile/u);
+  assert.match(playback, /lookahead:\s*true[\s\S]*incremental:\s*true/u);
   assert.match(preparer, /content-addressed/u);
   assert.match(preparer, /field-major fixed-point varints/u);
   assert.match(preparer, /prepared-transform-block-0/u);

--- a/src/adapters/gravitywell/test/cssgravitywell-source-model.test.mjs
+++ b/src/adapters/gravitywell/test/cssgravitywell-source-model.test.mjs
@@ -15,7 +15,7 @@ import {
   SOURCE,
 } from "../src/prepare/cssgravitywell/sourceModel.mjs";
 import {
-  CSSGRAVITYWELL_VIEWPORT_PROFILE_SIZES,
+  CSSGRAVITYWELL_VIEWPORT_PROFILES,
   encodeGravityWellViewportVisibility,
   prepareGravityWellViewportVisibility,
 } from "../src/prepare/cssgravitywell/visibilitySchedule.mjs";
@@ -81,13 +81,16 @@ test("prepared palette is a green through red source-depth ramp", () => {
   assert.equal(fogged[31], "rgb(0 255 0 / 0.6)");
 });
 
-test("viewport visibility is prepared as sparse conservative square profiles", () => {
+test("viewport visibility is prepared as sparse conservative rectangular profiles", () => {
   const states = buildPreparedGravityWellBankStates({ seed: CSSGRAVITYWELL_SEEDS[0] });
   const timeline = buildPreparedGravityWellTimeline(states);
   const quadsByFrame = timeline.frames.map((frame) => preparedGridLineQuads(states, frame.depths));
   const schedule = prepareGravityWellViewportVisibility(quadsByFrame);
   const encoded = encodeGravityWellViewportVisibility(schedule);
-  assert.deepEqual(schedule.profiles.map((profile) => profile.size), CSSGRAVITYWELL_VIEWPORT_PROFILE_SIZES);
+  assert.deepEqual(
+    schedule.profiles.map(({ width, height }) => ({ width, height })),
+    CSSGRAVITYWELL_VIEWPORT_PROFILES,
+  );
   assert.equal(schedule.frameCount, timeline.frameCount);
   assert.equal(schedule.leafCount, 1_922);
   assert.ok(schedule.profiles.every((profile) =>
@@ -96,6 +99,6 @@ test("viewport visibility is prepared as sparse conservative square profiles", (
     profile.minimumVisibleCount > 500 &&
     profile.maximumVisibleCount < schedule.leafCount));
   assert.equal(String.fromCharCode(...encoded.subarray(0, 4)), "CGWV");
-  assert.equal(encoded[4], 1);
-  assert.equal(encoded[5], CSSGRAVITYWELL_VIEWPORT_PROFILE_SIZES.length);
+  assert.equal(encoded[4], 2);
+  assert.equal(encoded[5], CSSGRAVITYWELL_VIEWPORT_PROFILES.length);
 });

--- a/src/adapters/gravitywell/tools/prepare-cssgravitywell.mjs
+++ b/src/adapters/gravitywell/tools/prepare-cssgravitywell.mjs
@@ -463,9 +463,13 @@ async function prepareBank({ bankIndex, seed, fixedViewQuaternion }) {
         leafCount: viewportVisibility.leafCount,
         marginPixels: CSSGRAVITYWELL_VIEWPORT_MARGIN_PIXELS,
         dilationFrames: CSSGRAVITYWELL_VIEWPORT_DILATION_FRAMES,
-        profileSizes: Object.freeze(viewportVisibility.profiles.map((profile) => profile.size)),
+        profileDimensions: Object.freeze(viewportVisibility.profiles.map((profile) => Object.freeze({
+          width: profile.width,
+          height: profile.height,
+        }))),
         profiles: Object.freeze(viewportVisibility.profiles.map((profile) => Object.freeze({
-          size: profile.size,
+          width: profile.width,
+          height: profile.height,
           initialVisibleCount: profile.initialVisibleIndices.length,
           visibilityChangeCount: profile.assignments.length,
           meanVisibleCount: profile.meanVisibleCount,

--- a/src/adapters/gravitywell/tools/productBank.mjs
+++ b/src/adapters/gravitywell/tools/productBank.mjs
@@ -3,10 +3,18 @@ import { readFile, readdir, writeFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 import { brotliDecompressSync } from "node:zlib";
 import { CSSGRAVITYWELL_TRANSFORM_BLOCK_COUNT } from "../src/cssgravitywell/renderContract.mjs";
+import {
+  CSSGRAVITYWELL_VIEWPORT_PROFILES,
+  CSSGRAVITYWELL_VISIBILITY_ENCODING,
+  CSSGRAVITYWELL_VISIBILITY_SCHEMA,
+} from "../src/prepare/cssgravitywell/visibilitySchedule.mjs";
 
 export const CSSGRAVITYWELL_PRODUCT_BANK_SCHEMA = "cssgravitywell-product-bank@2";
 const RETAINED_LEAF_COUNT = 1_922;
 const PREPARED_COLOR_COUNT = 4_096;
+const LEGACY_VISIBILITY_SCHEMA = "cssgravitywell-prepared-viewport-visibility@1";
+const LEGACY_VISIBILITY_ENCODING = "gzip-cgwv1-square-profile-sparse-visibility-assignments";
+const LEGACY_VISIBILITY_PROFILE_SIZES = Object.freeze([1_024, 1_536, 1_920, 2_560, 3_840]);
 
 export async function inspectCssgravitywellProductBank(root, { verifyDescriptor = true } = {}) {
   const expectedFiles = new Set(["catalog.json", "model/catalog.json"]);
@@ -147,15 +155,22 @@ export async function inspectCssgravitywellProductBank(root, { verifyDescriptor 
     `bank ${bankIndex} changes`);
     changeAssetCount += 1;
     const visibility = scene.playback.visibilityAsset;
-    assert(visibility?.schema === "cssgravitywell-prepared-viewport-visibility@1" &&
+    const legacySquareVisibility = visibility?.schema === LEGACY_VISIBILITY_SCHEMA;
+    const preparedVisibilityContract = legacySquareVisibility
+      ? visibility.encoding === LEGACY_VISIBILITY_ENCODING &&
+        visibility.selection === "smallest-square-profile-covering-maximum-css-viewport-axis-or-disabled" &&
+        JSON.stringify(visibility.profileSizes) === JSON.stringify(LEGACY_VISIBILITY_PROFILE_SIZES) &&
+        visibility.profiles?.length === visibility.profileSizes.length
+      : visibility?.schema === CSSGRAVITYWELL_VISIBILITY_SCHEMA &&
+        visibility.encoding === CSSGRAVITYWELL_VISIBILITY_ENCODING &&
+        visibility.selection === "smallest-area-rectangular-profile-covering-css-viewport-or-disabled" &&
+        JSON.stringify(visibility.profileDimensions) === JSON.stringify(CSSGRAVITYWELL_VIEWPORT_PROFILES) &&
+        visibility.profiles?.length === visibility.profileDimensions.length;
+    assert(preparedVisibilityContract &&
       visibility.distribution === "embedded-prepared-bank-scene" &&
-      visibility.encoding === "gzip-cgwv1-square-profile-sparse-visibility-assignments" &&
-      visibility.selection === "smallest-square-profile-covering-maximum-css-viewport-axis-or-disabled" &&
       visibility.frameCount === scene.playback.frameCount &&
       visibility.leafCount === RETAINED_LEAF_COUNT &&
-      visibility.marginPixels === 8 && visibility.dilationFrames === 1 &&
-      JSON.stringify(visibility.profileSizes) === JSON.stringify([1024, 1536, 1920, 2560, 3840]) &&
-      visibility.profiles?.length === visibility.profileSizes.length,
+      visibility.marginPixels === 8 && visibility.dilationFrames === 1,
     `bank ${bankIndex} viewport visibility`);
     verifyEmbeddedAsset(visibility, `bank ${bankIndex} viewport visibility`);
     visibilityAssetCount += 1;
@@ -232,7 +247,7 @@ export async function writeCssgravitywellProductBankDescriptor(root, summary) {
       deployUnpacksStaticFiles: true,
       preparedTransformEncoding: "content-addressed-gzip-field-major-delta-varint-fixed2-matrix-color-and-index-schedules",
       preparedScheduleEncoding: "selected-bank-transform-block-zero-shared-gzip-container",
-      preparedVisibilityEncoding: "embedded-gzip-cgwv1-square-profile-sparse-visibility-assignments",
+      preparedVisibilityEncoding: "embedded-gzip-cgwv2-rectangular-profile-sparse-visibility-assignments",
       preparedModelEncoding: "content-addressed-brotli-json-expanded-by-http-content-encoding",
       startupFetch: "selected-bank-first-next-bank-prefetch",
     },

--- a/src/adapters/gravitywell/tools/trace-frame-work.mjs
+++ b/src/adapters/gravitywell/tools/trace-frame-work.mjs
@@ -2,6 +2,7 @@
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
+import { analyzeTrace, loadTrace, renderMarkdown } from "../../../../scripts/frame-sleuth.mjs";
 
 const repositoryRoot = resolve(import.meta.dirname, "..", "..", "..", "..");
 const generatedRoot = resolve(repositoryRoot, "build/generated/public/cssgravitywell");
@@ -15,9 +16,13 @@ const viewport = Object.freeze({
   height: positiveIntegerEnvironment("CSSGRAVITYWELL_TRACE_HEIGHT", 600),
   deviceScaleFactor: positiveNumberEnvironment("CSSGRAVITYWELL_TRACE_DPR", 1),
 });
-const outputRoot = resolve(repositoryRoot, "bench/results/cssgravitywell/performance");
+const outputRoot = resolve(
+  repositoryRoot,
+  process.env.CSSGRAVITYWELL_TRACE_OUTPUT_ROOT ?? "bench/results/cssgravitywell/performance",
+);
 const tracePath = resolve(outputRoot, "worst-frame-chrome-trace.json");
 const summaryPath = resolve(outputRoot, "worst-frame-summary.json");
+const frameSleuthReportPath = resolve(outputRoot, "frame-sleuth-report.md");
 await mkdir(outputRoot, { recursive: true });
 
 const browser = await chromium.launch({ channel: "chrome", headless: true });
@@ -179,8 +184,6 @@ try {
   });
   const afterMetrics = metricMap(await cdp.send("Performance.getMetrics"));
   await page.waitForTimeout(100);
-  await cdp.send("Tracing.end");
-  await tracingComplete;
   const schedulerBefore = await page.evaluate(() => {
     const debug = globalThis.__cssGravityWellDebug;
     const stats = debug.stats();
@@ -192,6 +195,7 @@ try {
       observer: null,
       startedAt: performance.now(),
     };
+    performance.mark("cssgravitywell-steady-playback-start");
     const sampleFrame = (timestamp) => {
       if (recorder.lastFrameAt !== null) recorder.intervals.push(timestamp - recorder.lastFrameAt);
       recorder.lastFrameAt = timestamp;
@@ -219,18 +223,30 @@ try {
     const recorder = globalThis.__cssGravityWellTraceRecorder;
     recorder.running = false;
     recorder.observer?.disconnect();
+    performance.mark("cssgravitywell-steady-playback-end");
     return { stats: debug.stats(), intervals: recorder.intervals, longTasks: recorder.longTasks };
   });
+  await cdp.send("Tracing.end");
+  await tracingComplete;
   const schedulerAfter = schedulerResult.stats;
   const schedulerTrial = {
     durationMilliseconds: 1_800,
     preparedFrameCount: schedulerAfter.preparedFramesApplied - schedulerBefore.preparedFramesApplied,
     callbackCount: schedulerAfter.schedulerCallbacks - schedulerBefore.schedulerCallbacks,
     transformBlockLoads: schedulerAfter.transformBlocks.loadCount - schedulerBefore.transformBlocks.loadCount,
+    activationWaits:
+      schedulerAfter.transformBlocks.activationWaitCount - schedulerBefore.transformBlocks.activationWaitCount,
+    visibilityProfile: {
+      viewportWidth: schedulerBefore.selectedViewportWidth,
+      viewportHeight: schedulerBefore.selectedViewportHeight,
+      profileWidth: schedulerBefore.selectedViewportProfileWidth,
+      profileHeight: schedulerBefore.selectedViewportProfileHeight,
+      visibleLeafCount: schedulerBefore.currentVisibleLeafCount,
+    },
     frameIntervals: summarizeNumbers(schedulerResult.intervals),
     longTasks: schedulerResult.longTasks,
   };
-  schedulerTrial.emptyCallbackCount = schedulerTrial.callbackCount - schedulerTrial.preparedFrameCount - 1;
+  schedulerTrial.emptyCallbackCount = schedulerTrial.callbackCount - schedulerTrial.preparedFrameCount;
   const marks = Object.fromEntries(events
     .filter((event) => event.cat?.includes("blink.user_timing") && event.name?.startsWith("cssgravitywell-"))
     .map((event) => [event.name, event.ts]));
@@ -275,6 +291,7 @@ try {
       noRedundantColorAttempts:
         publication.delta.leafColorAttempts === publication.delta.leafColorWrites,
       noEmptySchedulerCallbacks: schedulerTrial.emptyCallbackCount === 0,
+      noScheduledTransformBlockWait: schedulerTrial.activationWaits === 0,
       exactPreparedSelectedTransformPublication:
         worstTransitionPublication.actualTransformChanges === worstTransitionPublication.samples[0].transformWrites,
       exactPreparedSelectedColorPublication:
@@ -295,6 +312,24 @@ try {
   };
   await writeFile(tracePath, `${JSON.stringify({ traceEvents: events })}\n`);
   summary.trace.sizeBytes = (await stat(tracePath)).size;
+  const frameSleuthAnalysis = analyzeTrace(await loadTrace(tracePath), {
+    question: "what work did we do on the worst frame?",
+    top: 5,
+    url: "/gravitywell/",
+  });
+  await writeFile(frameSleuthReportPath, renderMarkdown(frameSleuthAnalysis));
+  summary.frameSleuth = {
+    reportPath: frameSleuthReportPath,
+    schema: frameSleuthAnalysis.schema,
+    window: frameSleuthAnalysis.window,
+    displayCadence: frameSleuthAnalysis.cadence.display,
+    drawFrame: frameSleuthAnalysis.cadence.drawFrame,
+    drawGapsAboveBaselineMultiples: frameSleuthAnalysis.cadence.drawGapsAboveBaselineMultiples,
+    worstFrame: frameSleuthAnalysis.worstFrames[0] ?? null,
+    longTasks: frameSleuthAnalysis.longTasks,
+    pipeline: frameSleuthAnalysis.pipeline,
+    evidenceWarnings: frameSleuthAnalysis.capabilities.warnings,
+  };
   await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
   if (errors.length || Object.values(summary.proof).some((value) => value !== true)) {
     throw new Error(`Gravity Well frame trace contract failed: ${JSON.stringify(summary)}`);


### PR DESCRIPTION
## Summary
- add FrameSleuth trace capture, analysis, reports, and frame-time charts
- reduce Gravity Well runtime work with rectangular prepared visibility profiles, bounded transform-block residency, and frame-paced incremental lookahead decoding
- align publication to paint with a deadline timer-to-rAF handoff while preserving exact-flat endless bank transitions

## Validation
- pnpm test:gravitywell
- pnpm test:gravitywell:assets
- pnpm test:gravitywell:browser
- pnpm test:framesleuth
- pnpm verify:gravitywell:bank
- pnpm verify:source-only
- pnpm typecheck
- pnpm build:gravitywell
- three fresh headless installed-Chrome candidate traces at 960x600; no candidate DrawFrame gap exceeded 40 ms