### PR TITLE
Prevent Gravity Well transform block stalls

### DIFF
--- a/src/adapters/gravitywell/index.html
+++ b/src/adapters/gravitywell/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <title>css.graphics/gravitywell</title>
   </head>
-  <body>
+  <body class="loading">
     <header class="site-header">
       <a class="site-wordmark" href="/" aria-label="css.graphics home">
         <svg class="site-wordmark-svg" viewBox="0 0 260 30" aria-hidden="true" focusable="false">

--- a/src/adapters/gravitywell/notes/provenance-bible.md
+++ b/src/adapters/gravitywell/notes/provenance-bible.md
@@ -57,17 +57,18 @@ native profile, not a claim about the default `grid-size = 1` raster.
 
 The browser loads the verified static Morph package and bank catalog, chooses
 the initial bank with `crypto.getRandomValues`, adopts its 1,922 retained
-solid-quad line leaves with `createPolyMorphPreparedDomTarget`, and expands the
-initial bank's current and lookahead blocks beneath the loader. Later lookahead
-blocks are fetched, verified, decompressed, decoded, and formatted ahead of
-activation. Decoding and fixed-two-decimal `matrix3d` formatting run in bounded
-request-idle slices with a two-millisecond target budget, outside frame
-publication. As in cssElectroPaint's prepared horizon, successive slices are
-separated by one source frame so they cannot bunch inside one idle window. The
-next shuffled bank starts prefetching only after the active
-bank's 240-frame source-authority window and uses the same incremental path.
-The active bank retains only its current and one lookahead transform block. The
-shuffle visits the other 23 banks without replacement.
+solid-quad line leaves with `createPolyMorphPreparedDomTarget`, and fetches,
+verifies, decompresses, decodes, and formats all sixteen blocks of the selected
+bank beneath the loading cover before exposing the scene. The largest selected
+bank transfers 1,733,655 encoded block bytes and expands to 42,212,693 bytes of
+prepared CSS strings. Playback releases only blocks it has already passed.
+The next complete shuffled bank starts preparing at the first block's midpoint,
+well ahead of handoff. Its fixed-two-decimal `matrix3d` formatting runs in
+bounded two-millisecond timer slices outside frame publication, with successive
+slices separated by one source frame so they cannot bunch inside one task.
+Unlike the previous idle-callback request, timer slices are not starved by
+continuous style and compositor work. The shuffle visits the other 23 banks
+without replacement.
 Sequential frames visit only their independently prepared transform and color
 write indices. Twenty-five conservative rectangular viewport profiles prepare
 visible-leaf membership for every bank frame, including one-frame temporal
@@ -106,14 +107,33 @@ product. The 24-bank archive grows by 211,695 bytes. Browser compositor cadence
 does not materially change, so this is a page-owned work and headroom
 improvement rather than a claim that external compositor stalls are eliminated.
 
-At 960 by 600, a 5.5-second production/candidate streaming trace over the same
+An earlier 960 by 600, 5.5-second production/candidate streaming trace over the same
 bank reduces current-plus-lookahead prepared CSS string residency from
 25,746,023 to 4,816,407 bytes. The production trace records two 91–95 ms long
 tasks, a 129.719 ms maximum GC slice, and a 91.8 ms maximum display interval;
 the sixteen-block product records no long task, a 42.721 ms maximum GC slice,
 and a 33.6 ms maximum display interval. Both runs transfer approximately 1.5 MB
 of transform packets over the interval; the change bounds allocation size
-rather than shifting work onto the wire.
+rather than shifting work onto the wire. That two-block residency experiment
+was superseded by the complete selected-bank preload after it still permitted
+activation waits in a real production trace.
+
+A later 6.8-second real production trace exposed a release-blocking flaw that
+the earlier warmed 1.8-second trace did not cover: six repeated 283–776 ms
+DrawFrame gaps aligned with transform-block activation while idle-callback
+lookahead decoding was starved. A direct local boundary probe reproduced
+214–306 ms waits only when a transform block loaded. The repair retains the
+same blocks, matrices, colors, two-millisecond slice budget, and one-frame slice
+spacing, but fully prepares the selected bank beneath the loader and schedules
+future-bank slices with the source-frame timer instead of waiting for browser
+idle time. The release gate now begins with the real endless route in an
+untouched seven-second playback window before any pause, seek, or step. At 960
+by 600 it crosses 11 block boundaries and 234 prepared frames with zero runtime
+block loads, zero activation waits, zero long tasks, a 16.7 ms maximum rAF
+sample, and a 41.031 ms maximum FrameSleuth DrawFrame interval after excluding
+only the first 500 ms tracing-start seam. A separate 12.5-second run crosses an
+endless bank handoff with both banks completely prepared, no bank wait, no
+activation wait, stable DOM identity, and a 25 ms maximum sampled gap.
 
 ## Proof boundary
 

--- a/src/adapters/gravitywell/src/cssgravitywell/client.mjs
+++ b/src/adapters/gravitywell/src/cssgravitywell/client.mjs
@@ -32,20 +32,28 @@ export function mountGravityWellClient(host) {
 
   async function main() {
     if (!(host instanceof HTMLElement)) throw new Error("Missing Gravity Well host");
-    document.body.dataset.portStatus = "loading";
+    setStatus("loading");
     const [loaded, catalog] = await Promise.all([
       loadPolyMorphPackage("/cssgravitywell/model/"),
       loadPreparedGravityWellCatalog(),
     ]);
     const selection = selectInitialGravityWellBank(catalog);
-    const loadBank = async (bankIndex, { lookahead = false, incremental = lookahead } = {}) => {
+    const loadBank = async (bankIndex, {
+      lookahead = false,
+      incremental = lookahead,
+      complete = false,
+    } = {}) => {
       const scene = await loadPreparedGravityWellBankScene(catalog, bankIndex);
       const transformBlocks = createTransformBlockLoader(scene.playback);
-      await transformBlocks.prime(0, { lookahead, incremental });
+      await transformBlocks.prime(0, { lookahead, incremental, complete });
       const { changeSchedule } = transformBlocks.bankData();
       return Object.freeze({ scene, playback: scene.playback, transformBlocks, changeSchedule });
     };
-    const initialBank = await loadBank(selection.bankIndex, { lookahead: true, incremental: false });
+    const initialBank = await loadBank(selection.bankIndex, {
+      lookahead: true,
+      incremental: false,
+      complete: true,
+    });
     const scene = initialBank.scene;
     if (loaded.model.identity.id !== "gravitywell" ||
         loaded.model.render.leaves.length !== scene.metrics.preparedLeafCount) {
@@ -85,7 +93,7 @@ export function mountGravityWellClient(host) {
     state.mounted = mounted;
     state.player = player;
     state.ready = true;
-    document.body.dataset.portStatus = "ready";
+    setStatus("ready");
     document.body.dataset.productView = "1";
     document.body.dataset.gameView = "polycss";
     document.body.dataset.portSlug = "cssgravitywell";
@@ -96,7 +104,7 @@ export function mountGravityWellClient(host) {
 
   function recordError(message) {
     state.errors.push(message);
-    document.body.dataset.portStatus = "error";
+    setStatus("error");
     if (document.querySelector(".cssgravitywell-error-message")) return;
     const output = document.createElement("p");
     output.className = "cssgravitywell-error-message";
@@ -104,6 +112,12 @@ export function mountGravityWellClient(host) {
     output.textContent = message;
     host.append(output);
   }
+}
+
+function setStatus(kind) {
+  document.body.classList.remove("loading", "ready", "error");
+  document.body.classList.add(kind);
+  document.body.dataset.portStatus = kind;
 }
 
 function cleanPreparedDom(mounted) {

--- a/src/adapters/gravitywell/src/cssgravitywell/preparedAssets.mjs
+++ b/src/adapters/gravitywell/src/cssgravitywell/preparedAssets.mjs
@@ -136,6 +136,7 @@ export function createTransformBlockLoader(playback, scheduling = {}) {
   }
   let desiredCurrent = -1;
   let desiredNext = -1;
+  let preparedCompleteBank = false;
   let activeBlockIndex = -1;
   let activeRecord = null;
   let loadCount = 0;
@@ -152,12 +153,10 @@ export function createTransformBlockLoader(playback, scheduling = {}) {
   let incrementalDecodeOperationCount = 0;
   let incrementalDecodeMaximumSliceMilliseconds = 0;
   let destroyed = false;
-  const requestIdle = scheduling.requestIdle ?? defaultRequestIdle;
   const setDelay = scheduling.setDelay ?? globalThis.setTimeout.bind(globalThis);
   const readNow = scheduling.readNow ?? defaultReadNow;
   const incrementalSliceBudgetMilliseconds = scheduling.incrementalSliceBudgetMilliseconds ?? 2;
-  if (typeof requestIdle !== "function" || typeof setDelay !== "function" ||
-      typeof readNow !== "function" ||
+  if (typeof setDelay !== "function" || typeof readNow !== "function" ||
       !Number.isFinite(incrementalSliceBudgetMilliseconds) ||
       incrementalSliceBudgetMilliseconds <= 0 || incrementalSliceBudgetMilliseconds > 4) {
     throw new TypeError("Gravity Well incremental transform decoder scheduling is invalid");
@@ -188,11 +187,11 @@ export function createTransformBlockLoader(playback, scheduling = {}) {
           playback,
           transformIndices,
           {
-            requestIdle,
             setDelay,
             readNow,
             sliceBudgetMilliseconds: incrementalSliceBudgetMilliseconds,
-            isCurrent: () => !destroyed && (blockIndex === desiredCurrent || blockIndex === desiredNext),
+            isCurrent: () => !destroyed &&
+              (preparedCompleteBank || blockIndex === desiredCurrent || blockIndex === desiredNext),
             onSlice(operationCount, durationMilliseconds) {
               incrementalDecodeSliceCount += 1;
               incrementalDecodeOperationCount += operationCount;
@@ -227,7 +226,7 @@ export function createTransformBlockLoader(playback, scheduling = {}) {
       if (incremental) incrementalDecodeCompletedBlockCount += 1;
       residentDecodedBytes += descriptor.preparedCssStringByteLength;
       peakResidentDecodedBytes = Math.max(peakResidentDecodedBytes, residentDecodedBytes);
-      if (blockIndex !== desiredCurrent && blockIndex !== desiredNext) release(blockIndex);
+      if (!preparedCompleteBank && blockIndex !== desiredCurrent && blockIndex !== desiredNext) release(blockIndex);
       return record;
     })();
     records.set(blockIndex, { promise });
@@ -256,20 +255,36 @@ export function createTransformBlockLoader(playback, scheduling = {}) {
       incrementalDecodeRequestCount += 1;
       void ensure(next, { incremental: true }).catch(() => undefined);
     }
-    for (const blockIndex of records.keys()) {
-      if (blockIndex !== current && blockIndex !== next) release(blockIndex);
+    if (preparedCompleteBank) {
+      for (const blockIndex of records.keys()) {
+        if (blockIndex < current) release(blockIndex);
+      }
+    } else {
+      for (const blockIndex of records.keys()) {
+        if (blockIndex !== current && blockIndex !== next) release(blockIndex);
+      }
     }
   }
 
   return Object.freeze({
-    async prime(frameIndex = 0, { lookahead = false, incremental = false } = {}) {
+    async prime(frameIndex = 0, { lookahead = false, incremental = false, complete = false } = {}) {
       const current = Math.trunc(frameIndex / playback.blockFrameCount);
       if (current !== 0) throw new Error("Gravity Well prepared bank must prime from block zero");
       const next = lookahead ? nextBlockIndex(current) : -1;
       desiredCurrent = current;
       desiredNext = next;
+      preparedCompleteBank = complete;
       const record = await ensure(current, { incremental });
-      if (next >= 0) await ensure(next, { incremental });
+      if (complete) {
+        const remaining = playback.blocks.slice(1).map((block) => block.index);
+        if (incremental) {
+          for (const blockIndex of remaining) await ensure(blockIndex, { incremental: true });
+        } else {
+          await Promise.all(remaining.map((blockIndex) => ensure(blockIndex)));
+        }
+      } else if (next >= 0) {
+        await ensure(next, { incremental });
+      }
       activeBlockIndex = current;
       activeRecord = record;
     },
@@ -394,6 +409,7 @@ export function createTransformBlockLoader(playback, scheduling = {}) {
         releaseCount,
         activeBlockIndex,
         residentBlockCount: [...records.values()].filter((record) => record?.transforms).length,
+        preparedCompleteBank,
         residentDecodedBytes,
         peakResidentDecodedBytes,
         randomAccessReconstructionCount,
@@ -617,16 +633,6 @@ async function decompressGzip(encoded) {
   ).arrayBuffer());
 }
 
-function defaultRequestIdle(callback, options) {
-  if (typeof globalThis.requestIdleCallback === "function") {
-    return globalThis.requestIdleCallback(callback, options);
-  }
-  return globalThis.setTimeout(() => callback(Object.freeze({
-    didTimeout: true,
-    timeRemaining: () => 0,
-  })), 0);
-}
-
 function defaultReadNow() {
   return globalThis.performance.now();
 }
@@ -643,7 +649,6 @@ async function decodePreparedTransformBlockIncrementally(
   playback,
   loadedTransformIndices,
   {
-    requestIdle,
     setDelay,
     readNow,
     sliceBudgetMilliseconds,
@@ -659,15 +664,11 @@ async function decodePreparedTransformBlockIncrementally(
       if (!isCurrent()) return null;
     }
     firstSlice = false;
-    const deadline = await new Promise((resolveIdle) => requestIdle(resolveIdle, {
-      timeout: Math.max(50, Math.ceil(playback.frameMilliseconds * 4)),
-    }));
     if (!isCurrent()) return null;
     const startedAt = readNow();
     const operationCount = decoder.step(8_192, (processed) =>
       processed >= 64 && processed % 64 === 0 &&
-      ((typeof deadline?.timeRemaining === "function" && deadline.timeRemaining() <= 1) ||
-        readNow() - startedAt >= sliceBudgetMilliseconds));
+      readNow() - startedAt >= sliceBudgetMilliseconds);
     onSlice(operationCount, readNow() - startedAt);
   }
   return decoder.result();

--- a/src/adapters/gravitywell/src/cssgravitywell/preparedPlayback.mjs
+++ b/src/adapters/gravitywell/src/cssgravitywell/preparedPlayback.mjs
@@ -246,6 +246,7 @@ export async function createGravityWellPreparedPlayer({
       firstBlockLookaheadFrameIndex = -1;
       const lookahead = transformBlocks.prefetchLookahead();
       if (lookahead) void lookahead.catch(onError);
+      queueNextBank();
     }
     if (nextFrameIndex === activeBank.scene.timeline.sourceFrameEndIndex) queueNextBank();
     return frameIndex;
@@ -275,6 +276,7 @@ export async function createGravityWellPreparedPlayer({
     pendingBankPromise = Promise.resolve(loadBank(pendingBankIndex, {
       lookahead: true,
       incremental: true,
+      complete: true,
     })).then((loaded) => {
       pendingBank = validateBank(loaded, pendingBankIndex, leaves.length);
       pendingBankPromise = null;

--- a/src/adapters/gravitywell/src/cssgravitywell/styles.css
+++ b/src/adapters/gravitywell/src/cssgravitywell/styles.css
@@ -21,6 +21,40 @@ body {
   background: linear-gradient(180deg, #0b1119 0%, #000 100%);
 }
 
+body.loading::after {
+  content: "";
+  position: fixed;
+  inset: 50% auto auto 50%;
+  z-index: 20;
+  width: 18px;
+  height: 18px;
+  margin: -9px 0 0 -9px;
+  border: 1px solid rgb(240 240 240 / 18%);
+  border-top-color: rgb(240 240 240 / 70%);
+  border-radius: 50%;
+  animation: cssgravitywell-loading 0.8s linear infinite;
+}
+
+body.loading::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 19;
+  background: rgb(0 0 0 / 99.999%);
+}
+
+@keyframes cssgravitywell-loading {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.loading::after {
+    animation: none;
+  }
+}
+
 .site-header {
   position: fixed;
   inset: 0 0 auto;

--- a/src/adapters/gravitywell/test/cssgravitywell-runtime-surface.test.mjs
+++ b/src/adapters/gravitywell/test/cssgravitywell-runtime-surface.test.mjs
@@ -14,6 +14,7 @@ test("public product slug is gravitywell everywhere", async () => {
     resolve(adapterRoot, "README.md"),
     resolve(adapterRoot, "vite.config.mjs"),
     resolve(adapterRoot, "src/cssgravitywell/client.mjs"),
+    resolve(adapterRoot, "src/cssgravitywell/styles.css"),
     resolve(adapterRoot, "tools/prepare-cssgravitywell.mjs"),
     resolve(adapterRoot, "tools/smoke-browser.mjs"),
   ];
@@ -24,6 +25,9 @@ test("public product slug is gravitywell everywhere", async () => {
   assert.match(source, /<link rel="icon" href="\/favicon\.ico" sizes="any" \/>/u);
   assert.match(source, /base:\s*deployBuild \? "\/gravitywell\/" : "\/"/u);
   assert.match(source, /identity\.id !== "gravitywell"/u);
+  assert.match(source, /<body class="loading">/u);
+  assert.match(source, /body\.loading::after/u);
+  assert.match(source, /setStatus\("ready"\)/u);
   assert.match(source, /"dev:gravitywell"/u);
   assert.match(source, /prepare:gravitywell:artifact/u);
   assert.match(source, /CSSGRAVITYWELL_DEPLOY_BUILD=1 pnpm build:gravitywell/u);
@@ -36,6 +40,10 @@ test("proof tools use the canonical gravitywell route", async () => {
   assert.match(trace, /cssgravitywell-steady-playback-start/u);
   assert.match(trace, /analyzeTrace/u);
   assert.match(trace, /noScheduledTransformBlockWait/u);
+  assert.match(trace, /untouchedBeforeMeasurement:\s*true/u);
+  assert.match(trace, /noUntouchedPlaybackActivationWait/u);
+  assert.match(trace, /noUntouchedPlaybackFreezeGap/u);
+  assert.match(trace, /noFrameSleuthFreezeGap/u);
   assert.match(oracle, /127\.0\.0\.1:\$\{port\}\/gravitywell\//u);
 });
 
@@ -102,15 +110,18 @@ test("product frame loop publishes only separately prepared writes", async () =>
   assert.match(assets, /gzip-field-major-delta-varint-fixed2-matrix-and-bank-schedule@2/u);
   assert.match(assets, /decodePreparedTransformBlock\(decoded, descriptor, playback, transformIndices\)/u);
   assert.match(assets, /decodePreparedTransformBlockIncrementally/u);
-  assert.match(assets, /requestIdle/u);
+  assert.doesNotMatch(assets, /requestIdle/u);
+  assert.doesNotMatch(assets, /timeRemaining/u);
   assert.match(assets, /setDelay\(resolveDelay, playback\.frameMilliseconds\)/u);
   assert.match(assets, /incrementalSliceBudgetMilliseconds/u);
   assert.match(assets, /incrementalDecodeMaximumSliceMilliseconds/u);
+  assert.match(assets, /preparedCompleteBank/u);
+  assert.match(assets, /Promise\.all\(remaining\.map/u);
   assert.match(assets, /preparedCssStringByteLength !== descriptor\.preparedCssStringByteLength/u);
   assert.match(assets, /frameView\.mode = "delta"/u);
   assert.match(assets, /activationWaitCount/u);
   assert.match(assets, /rectangular-profile/u);
-  assert.match(playback, /lookahead:\s*true[\s\S]*incremental:\s*true/u);
+  assert.match(playback, /lookahead:\s*true[\s\S]*incremental:\s*true[\s\S]*complete:\s*true/u);
   assert.match(preparer, /content-addressed/u);
   assert.match(preparer, /field-major fixed-point varints/u);
   assert.match(preparer, /prepared-transform-block-0/u);

--- a/src/adapters/gravitywell/tools/smoke-browser.mjs
+++ b/src/adapters/gravitywell/tools/smoke-browser.mjs
@@ -29,6 +29,40 @@ try {
   await mkdir(outputRoot, { recursive: true });
   if (server) await waitFor(() => serverOutput.includes("Local:"), 20_000);
   browser = await chromium.launch({ channel: "chrome", headless: true });
+  let loadingIndicator = null;
+  {
+    const loadingPage = await browser.newPage({ viewport: { width: 960, height: 600 }, deviceScaleFactor: 1 });
+    await loadingPage.route("**/favicon.ico", (faviconRoute) => faviconRoute.fulfill({ status: 204 }));
+    await loadingPage.route("**/cssgravitywell/catalog.json", async (catalogRoute) => {
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 500));
+      await catalogRoute.continue();
+    });
+    await loadingPage.goto(route, { waitUntil: "domcontentloaded" });
+    await loadingPage.waitForFunction(() => document.body.classList.contains("loading"));
+    loadingIndicator = await loadingPage.evaluate(() => {
+      const indicator = getComputedStyle(document.body, "::after");
+      const cover = getComputedStyle(document.body, "::before");
+      return {
+        bodyClassName: document.body.className,
+        content: indicator.content,
+        width: indicator.width,
+        height: indicator.height,
+        borderRadius: indicator.borderRadius,
+        animationName: indicator.animationName,
+        coverContent: cover.content,
+        coverPosition: cover.position,
+      };
+    });
+    await loadingPage.waitForFunction(() => document.body.classList.contains("ready"), null, { timeout: 30_000 });
+    await loadingPage.close();
+  }
+  if (loadingIndicator.bodyClassName !== "loading" || loadingIndicator.content !== '""' ||
+      loadingIndicator.width !== "18px" || loadingIndicator.height !== "18px" ||
+      loadingIndicator.borderRadius !== "50%" ||
+      loadingIndicator.animationName !== "cssgravitywell-loading" ||
+      loadingIndicator.coverContent !== '""' || loadingIndicator.coverPosition !== "fixed") {
+    throw new Error(`Gravity Well loading indicator failed: ${JSON.stringify(loadingIndicator)}`);
+  }
   const page = await browser.newPage({ viewport: { width: 960, height: 600 }, deviceScaleFactor: 1 });
   await page.route("**/favicon.ico", (faviconRoute) => faviconRoute.fulfill({ status: 204 }));
   const pageErrors = [];
@@ -36,6 +70,15 @@ try {
   page.on("console", (message) => { if (message.type() === "error") pageErrors.push(message.text()); });
   await page.goto(route, { waitUntil: "networkidle" });
   await page.waitForFunction(() => ["ready", "error"].includes(document.body.dataset.portStatus), null, { timeout: 30_000 });
+  const initialCompleteBankEvidence = await page.evaluate(() => {
+    const stats = globalThis.__cssGravityWellDebug.stats().transformBlocks;
+    return {
+      loadCount: stats.loadCount,
+      residentBlockCount: stats.residentBlockCount,
+      preparedCompleteBank: stats.preparedCompleteBank,
+      activationWaitCount: stats.activationWaitCount,
+    };
+  });
   await page.evaluate(async () => globalThis.__cssGravityWellDebug.seekSourceTick(120));
   await page.evaluate(() => new Promise((resolveFrame) => requestAnimationFrame(() => requestAnimationFrame(resolveFrame))));
   const evidence = await page.evaluate(() => {
@@ -69,6 +112,8 @@ try {
           rect.left < innerWidth && rect.top < innerHeight && getComputedStyle(leaf).visibility === "visible";
       }).length,
       shellPath: document.querySelector(".site-wordmark-path")?.textContent ?? "",
+      bodyClassName: document.body.className,
+      loadingIndicatorContent: getComputedStyle(document.body, "::after").content,
       activeBankDataset: Number(document.body.dataset.activeBank),
       activeSeedDataset: Number(document.body.dataset.activeSeed),
     };
@@ -84,10 +129,18 @@ try {
       evidence.dataAttributeCount !== 0 || evidence.preparedColorCount < 8 ||
       evidence.visibleBackfaceLeafCount !== evidence.retainedLeaves ||
       evidence.visibleLeafCount < 500 || evidence.shellPath !== "/gravitywell" ||
+      evidence.bodyClassName !== "ready" || evidence.loadingIndicatorContent !== "none" ||
       evidence.stats.runtimeGeometryConstructionCount !== 0 ||
       evidence.stats.runtimeTopologyConstructionCount !== 0 ||
       evidence.stats.runtimeAffineEvaluationCount !== 0 ||
       evidence.stats.runtimeColorCalculationCount !== 0 ||
+      evidence.stats.transformBlocks.loadCount !== 16 ||
+      evidence.stats.transformBlocks.preparedCompleteBank !== true ||
+      evidence.stats.transformBlocks.activationWaitCount !== 0 ||
+      initialCompleteBankEvidence.loadCount !== 16 ||
+      initialCompleteBankEvidence.residentBlockCount !== 16 ||
+      initialCompleteBankEvidence.preparedCompleteBank !== true ||
+      initialCompleteBankEvidence.activationWaitCount !== 0 ||
       evidence.stats.runtimeDomCreationCount !== 0 || evidence.stats.runtimeDomRemovalCount !== 0) {
     throw new Error(`Gravity Well browser smoke failed: ${JSON.stringify({ evidence, pageErrors })}`);
   }
@@ -195,6 +248,8 @@ try {
   }
   await writeFile(statePath, `${JSON.stringify({
     route,
+    loadingIndicator,
+    initialCompleteBankEvidence,
     evidence,
     sparseBlockEvidence,
     cycleEvidence,
@@ -204,6 +259,8 @@ try {
   console.log(JSON.stringify({
     status: "passed",
     route,
+    loadingIndicator,
+    initialCompleteBankEvidence,
     screenshotPath,
     statePath,
     sparseBlockEvidence,

--- a/src/adapters/gravitywell/tools/trace-frame-work.mjs
+++ b/src/adapters/gravitywell/tools/trace-frame-work.mjs
@@ -3,13 +3,13 @@ import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
 import { analyzeTrace, loadTrace, renderMarkdown } from "../../../../scripts/frame-sleuth.mjs";
+import { traceCategories } from "../../../../scripts/frame-sleuth-trace.mjs";
 
 const repositoryRoot = resolve(import.meta.dirname, "..", "..", "..", "..");
 const generatedRoot = resolve(repositoryRoot, "build/generated/public/cssgravitywell");
 const preparedWorstTransition = await findPreparedWorstTransition(generatedRoot);
 const routeUrl = new URL(process.env.CSSGRAVITYWELL_TRACE_URL ?? "http://127.0.0.1:5174/gravitywell/");
 routeUrl.searchParams.set("bank", String(preparedWorstTransition.bankIndex));
-routeUrl.searchParams.set("cycle", "0");
 const route = routeUrl.href;
 const viewport = Object.freeze({
   width: positiveIntegerEnvironment("CSSGRAVITYWELL_TRACE_WIDTH", 960),
@@ -20,7 +20,8 @@ const outputRoot = resolve(
   repositoryRoot,
   process.env.CSSGRAVITYWELL_TRACE_OUTPUT_ROOT ?? "bench/results/cssgravitywell/performance",
 );
-const tracePath = resolve(outputRoot, "worst-frame-chrome-trace.json");
+const tracePath = resolve(outputRoot, "continuous-playback-chrome-trace.json");
+const focusedTracePath = resolve(outputRoot, "worst-frame-chrome-trace.json");
 const summaryPath = resolve(outputRoot, "worst-frame-summary.json");
 const frameSleuthReportPath = resolve(outputRoot, "frame-sleuth-report.md");
 await mkdir(outputRoot, { recursive: true });
@@ -39,6 +40,82 @@ try {
   page.on("console", (message) => { if (message.type() === "error") errors.push(message.text()); });
   await page.goto(route, { waitUntil: "networkidle" });
   await page.waitForFunction(() => globalThis.__cssGravityWellDebug?.ready === true, null, { timeout: 30_000 });
+  const continuousEvents = [];
+  const collectContinuousEvents = ({ value }) => continuousEvents.push(...value);
+  cdp.on("Tracing.dataCollected", collectContinuousEvents);
+  const continuousTracingComplete = new Promise(
+    (resolveComplete) => cdp.once("Tracing.tracingComplete", resolveComplete),
+  );
+  await cdp.send("Tracing.start", {
+    categories: traceCategories().join(","),
+    options: "sampling-frequency=10000",
+    transferMode: "ReportEvents",
+  });
+  const continuousStart = await page.evaluate(() => {
+    const debug = globalThis.__cssGravityWellDebug;
+    const recorder = {
+      intervals: [],
+      longTasks: [],
+      lastFrameAt: null,
+      running: true,
+      observer: null,
+      startedAt: performance.now(),
+    };
+    const sampleFrame = (timestamp) => {
+      if (recorder.lastFrameAt !== null) recorder.intervals.push(timestamp - recorder.lastFrameAt);
+      recorder.lastFrameAt = timestamp;
+      if (recorder.running) requestAnimationFrame(sampleFrame);
+    };
+    requestAnimationFrame(sampleFrame);
+    if (globalThis.PerformanceObserver?.supportedEntryTypes?.includes("longtask")) {
+      recorder.observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          if (entry.startTime >= recorder.startedAt) {
+            recorder.longTasks.push({ startTime: entry.startTime, duration: entry.duration });
+          }
+        }
+      });
+      recorder.observer.observe({ type: "longtask" });
+    }
+    globalThis.__cssGravityWellContinuousRecorder = recorder;
+    return { stats: debug.stats(), blockFrameCount: debug.scene().playback.blockFrameCount };
+  });
+  const continuousBefore = continuousStart.stats;
+  await page.waitForTimeout(7_000);
+  const continuousResult = await page.evaluate(() => {
+    const debug = globalThis.__cssGravityWellDebug;
+    const recorder = globalThis.__cssGravityWellContinuousRecorder;
+    recorder.running = false;
+    recorder.observer?.disconnect();
+    return { stats: debug.stats(), intervals: recorder.intervals, longTasks: recorder.longTasks };
+  });
+  await cdp.send("Tracing.end");
+  await continuousTracingComplete;
+  cdp.off("Tracing.dataCollected", collectContinuousEvents);
+  const continuousAfter = continuousResult.stats;
+  const continuousPlayback = {
+    durationMilliseconds: 7_000,
+    untouchedBeforeMeasurement: true,
+    frameSleuthStartupTrimMilliseconds: 500,
+    preparedFrameCount: continuousAfter.preparedFramesApplied - continuousBefore.preparedFramesApplied,
+    callbackCount: continuousAfter.schedulerCallbacks - continuousBefore.schedulerCallbacks,
+    transformBlockLoads:
+      continuousAfter.transformBlocks.loadCount - continuousBefore.transformBlocks.loadCount,
+    activationWaits:
+      continuousAfter.transformBlocks.activationWaitCount - continuousBefore.transformBlocks.activationWaitCount,
+    frameIntervals: summarizeNumbers(continuousResult.intervals),
+    longTasks: continuousResult.longTasks,
+    crossedTransformBlockCount: Math.floor(
+      (continuousAfter.frameIndex - continuousBefore.frameIndex) / continuousStart.blockFrameCount,
+    ),
+  };
+  await writeFile(tracePath, `${JSON.stringify({ traceEvents: continuousEvents })}\n`);
+  const frameSleuthAnalysis = analyzeTrace(await loadTrace(tracePath), {
+    question: "why does untouched continuous playback freeze?",
+    top: 10,
+    url: "/gravitywell/",
+    startMs: 500,
+  });
   const steadyStatePublication = await page.evaluate(async () => {
     const debug = globalThis.__cssGravityWellDebug;
     debug.pause();
@@ -263,6 +340,7 @@ try {
     preparedWorstTransition,
     worstTransitionPublication,
     steadyStatePublication,
+    continuousPlayback,
     schedulerTrial,
     publication,
     traceWindowMilliseconds: (end - start) / 1000,
@@ -292,6 +370,12 @@ try {
         publication.delta.leafColorAttempts === publication.delta.leafColorWrites,
       noEmptySchedulerCallbacks: schedulerTrial.emptyCallbackCount === 0,
       noScheduledTransformBlockWait: schedulerTrial.activationWaits === 0,
+      continuousPlaybackCrossesMultipleBlocks: continuousPlayback.crossedTransformBlockCount >= 5,
+      noUntouchedPlaybackBlockLoad: continuousPlayback.transformBlockLoads === 0,
+      noUntouchedPlaybackActivationWait: continuousPlayback.activationWaits === 0,
+      noUntouchedPlaybackLongTask: continuousPlayback.longTasks.length === 0,
+      noUntouchedPlaybackFreezeGap: continuousPlayback.frameIntervals.over50Milliseconds === 0,
+      noFrameSleuthFreezeGap: frameSleuthAnalysis.cadence.drawGapsAboveMs["50"] === 0,
       exactPreparedSelectedTransformPublication:
         worstTransitionPublication.actualTransformChanges === worstTransitionPublication.samples[0].transformWrites,
       exactPreparedSelectedColorPublication:
@@ -308,15 +392,16 @@ try {
         publication.after.frameIndex === preparedWorstTransition.frameIndex,
     },
     errors,
-    trace: { path: tracePath, eventCount: events.length, marks },
+    trace: {
+      path: tracePath,
+      eventCount: continuousEvents.length,
+      sizeBytes: (await stat(tracePath)).size,
+      untouchedContinuousPlayback: true,
+    },
+    focusedTrace: { path: focusedTracePath, eventCount: events.length, marks },
   };
-  await writeFile(tracePath, `${JSON.stringify({ traceEvents: events })}\n`);
-  summary.trace.sizeBytes = (await stat(tracePath)).size;
-  const frameSleuthAnalysis = analyzeTrace(await loadTrace(tracePath), {
-    question: "what work did we do on the worst frame?",
-    top: 5,
-    url: "/gravitywell/",
-  });
+  await writeFile(focusedTracePath, `${JSON.stringify({ traceEvents: events })}\n`);
+  summary.focusedTrace.sizeBytes = (await stat(focusedTracePath)).size;
   await writeFile(frameSleuthReportPath, renderMarkdown(frameSleuthAnalysis));
   summary.frameSleuth = {
     reportPath: frameSleuthReportPath,


### PR DESCRIPTION
## What changed

- keep the established CSS Graphics loading cover visible until all 16 selected-bank transform blocks are fetched, verified, decompressed, decoded, and formatted
- replace starvable idle-callback decoding for future banks with bounded source-frame timer slices
- prepare each future complete bank early, release only consumed active-bank blocks, and keep activation free of preparation work
- make the Gravity Well FrameSleuth gate start with seven seconds of untouched endless playback before any pause, seek, or step
- fail the gate on runtime block loads, activation waits, long tasks, or frame gaps above 50 ms

## Evidence

The supplied production trace recorded six repeated 283–776 ms stalls. A direct local probe reproduced 214–306 ms waits exactly on transform-block loads.

The fixed endless-path gate at 960×600 recorded 234 prepared frames across 11 block boundaries with:

- 0 runtime block loads
- 0 activation waits
- 0 long tasks
- 0 sampled gaps above 50 ms
- 41.031 ms maximum FrameSleuth DrawFrame interval

A separate 12.5-second run crossed an actual bank handoff with no bank wait, no activation wait, stable DOM identity, and a 25 ms maximum sampled gap.

## Validation

- `pnpm test:gravitywell`
- `pnpm test:gravitywell:browser`
- `pnpm perf:gravitywell:frame-work` on the real endless route
- `pnpm test:framesleuth`
- `pnpm typecheck`
- `pnpm build:gravitywell`
- `pnpm verify:source-only`
- `git diff --check`