### PR TITLE
Clean Gravity Well retained DOM

### DIFF
--- a/src/adapters/gravitywell/src/cssgravitywell/client.mjs
+++ b/src/adapters/gravitywell/src/cssgravitywell/client.mjs
@@ -78,15 +78,14 @@ export function mountGravityWellClient(host) {
       initialBankIndex: selection.bankIndex,
       loadBank,
       cycleBanks: new URLSearchParams(location.search).get("cycle") !== "0",
-      onBankChange(bankIndex, nextScene) {
+      onBankChange(_bankIndex, nextScene) {
         state.scene = nextScene;
-        document.body.dataset.activeBank = String(bankIndex);
-        document.body.dataset.activeSeed = String(nextScene.seed);
       },
       onError(error) {
         recordError(error instanceof Error ? error.stack || error.message : String(error));
       },
     });
+    removeEmptyWrapperStyles(mounted);
     state.catalog = catalog;
     state.selection = selection;
     state.scene = scene;
@@ -94,11 +93,6 @@ export function mountGravityWellClient(host) {
     state.player = player;
     state.ready = true;
     setStatus("ready");
-    document.body.dataset.productView = "1";
-    document.body.dataset.gameView = "polycss";
-    document.body.dataset.portSlug = "cssgravitywell";
-    document.body.dataset.activeBank = String(selection.bankIndex);
-    document.body.dataset.activeSeed = String(scene.seed);
     requestAnimationFrame(() => player.resume());
   }
 
@@ -117,16 +111,59 @@ export function mountGravityWellClient(host) {
 function setStatus(kind) {
   document.body.classList.remove("loading", "ready", "error");
   document.body.classList.add(kind);
-  document.body.dataset.portStatus = kind;
 }
 
 function cleanPreparedDom(mounted) {
+  if (!isIdentityMatrix(mounted.model.render.modelMatrix) ||
+      mounted.model.render.shapes.some((shape) => !isIdentityMatrix(shape.matrix))) {
+    throw new Error("Gravity Well clean DOM requires identity model and shape roots");
+  }
+  for (const { plan } of mounted.leafHandles.values()) {
+    if (plan.strategy !== "solid-quad" || plan.width !== 1 || plan.height !== 1) {
+      throw new Error("Gravity Well clean DOM requires prepared 1px solid quads");
+    }
+  }
+  mounted.cameraElement.className = "polycss-camera";
   mounted.cameraElement.removeAttribute("data-polycss-camera-projection");
+  mounted.cameraElement.removeAttribute("style");
+  mounted.sceneElement.className = "polycss-scene";
+  mounted.sceneElement.removeAttribute("style");
+  mounted.modelElement.removeAttribute("class");
   mounted.modelElement.removeAttribute("data-poly-morph-model");
-  for (const element of mounted.shapeElements.values()) element.removeAttribute("data-poly-morph-shape");
+  mounted.modelElement.removeAttribute("style");
+  for (const element of mounted.shapeElements.values()) {
+    element.className = "polycss-mesh";
+    element.removeAttribute("data-poly-morph-shape");
+    element.removeAttribute("style");
+  }
   for (const { element } of mounted.leafHandles.values()) {
+    element.removeAttribute("class");
     element.removeAttribute("data-poly-morph-leaf");
     element.removeAttribute("data-poly-morph-strategy");
     element.removeAttribute("data-poly-morph-resolved-strategy");
+    element.style.removeProperty("backface-visibility");
+    element.style.removeProperty("background-repeat");
+    element.style.removeProperty("height");
+    element.style.removeProperty("opacity");
+    element.style.removeProperty("transform-origin");
+    element.style.removeProperty("visibility");
+    element.style.removeProperty("width");
+  }
+}
+
+function isIdentityMatrix(matrix) {
+  const identity = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+  return Array.isArray(matrix) && matrix.length === identity.length &&
+    matrix.every((value, index) => value === identity[index]);
+}
+
+function removeEmptyWrapperStyles(mounted) {
+  for (const element of [
+    mounted.cameraElement,
+    mounted.sceneElement,
+    mounted.modelElement,
+    ...mounted.shapeElements.values(),
+  ]) {
+    if (element.getAttribute("style") === "") element.removeAttribute("style");
   }
 }

--- a/src/adapters/gravitywell/src/cssgravitywell/styles.css
+++ b/src/adapters/gravitywell/src/cssgravitywell/styles.css
@@ -17,6 +17,7 @@ body {
 }
 
 body {
+  position: relative;
   overflow: hidden;
   background: linear-gradient(180deg, #0b1119 0%, #000 100%);
 }
@@ -138,6 +139,27 @@ body > .polycss-camera {
   height: 100%;
   overflow: hidden;
   background: transparent;
+  perspective: 824.2432258363864px;
+}
+
+body > .polycss-camera > .polycss-scene {
+  transform: translateZ(824.2432258363864px) scale(1) rotateX(0deg) rotate(0deg) translate3d(0, 0, 0);
+}
+
+body > .polycss-camera > .polycss-scene > div {
+  position: absolute;
+  transform-style: preserve-3d;
+  transform-origin: 0 0 0;
+}
+
+body > .polycss-camera > .polycss-scene > div > .polycss-mesh > b {
+  width: 1px;
+  height: 1px;
+  opacity: 1;
+  visibility: visible;
+  backface-visibility: visible;
+  background-repeat: no-repeat;
+  transform-origin: 0 0;
 }
 
 .cssgravitywell-error-message {

--- a/src/adapters/gravitywell/test/cssgravitywell-runtime-surface.test.mjs
+++ b/src/adapters/gravitywell/test/cssgravitywell-runtime-surface.test.mjs
@@ -72,6 +72,10 @@ test("product runtime has one retained DOM renderer and no forbidden geometry ro
   assert.match(source, /changes\.transformIndices/u);
   assert.match(source, /changes\.colorIndices/u);
   assert.doesNotMatch(source, /backface-visibility:\s*visible\s*!important/u);
+  assert.doesNotMatch(source, /document\.body\.dataset/u);
+  assert.match(source, /element\.removeAttribute\("class"\)/u);
+  assert.match(source, /element\.style\.removeProperty\("backface-visibility"\)/u);
+  assert.match(source, /body > \.polycss-camera > \.polycss-scene > div > \.polycss-mesh > b/u);
   assert.match(source, /runtimeGeometryConstructionCount:\s*0/u);
   assert.match(source, /runtimeAffineEvaluationCount:\s*0/u);
 });

--- a/src/adapters/gravitywell/tools/oracle/run-visual-oracle.mjs
+++ b/src/adapters/gravitywell/tools/oracle/run-visual-oracle.mjs
@@ -262,7 +262,7 @@ async function captureBrowserRun(browser, url, runRoot) {
     }
     const audit = await page.evaluate(() => ({
       elementCount: document.querySelectorAll(".polycss-camera *").length,
-      leafCount: document.querySelectorAll(".polycss-morph-leaf").length,
+      leafCount: document.querySelectorAll(".polycss-scene > div > .polycss-mesh > b").length,
       canvasCount: document.querySelectorAll("canvas").length,
       svgSceneCount: document.querySelectorAll(".polycss-camera svg").length,
       clipPathCount: [...document.querySelectorAll(".polycss-camera *")].filter((element) => getComputedStyle(element).clipPath !== "none").length,

--- a/src/adapters/gravitywell/tools/smoke-browser.mjs
+++ b/src/adapters/gravitywell/tools/smoke-browser.mjs
@@ -69,7 +69,8 @@ try {
   page.on("pageerror", (error) => pageErrors.push(error.stack || error.message));
   page.on("console", (message) => { if (message.type() === "error") pageErrors.push(message.text()); });
   await page.goto(route, { waitUntil: "networkidle" });
-  await page.waitForFunction(() => ["ready", "error"].includes(document.body.dataset.portStatus), null, { timeout: 30_000 });
+  await page.waitForFunction(() => document.body.classList.contains("ready") ||
+    document.body.classList.contains("error"), null, { timeout: 30_000 });
   const initialCompleteBankEvidence = await page.evaluate(() => {
     const stats = globalThis.__cssGravityWellDebug.stats().transformBlocks;
     return {
@@ -83,10 +84,13 @@ try {
   await page.evaluate(() => new Promise((resolveFrame) => requestAnimationFrame(() => requestAnimationFrame(resolveFrame))));
   const evidence = await page.evaluate(() => {
     const debug = globalThis.__cssGravityWellDebug;
-    const leaves = [...document.querySelectorAll(".polycss-morph-leaf")];
+    const leaves = [...document.querySelectorAll(".polycss-scene > div > .polycss-mesh > b")];
     const sceneElements = [...document.querySelectorAll(".polycss-camera, .polycss-camera *")];
+    const dynamicInlineProperties = new Set(["color", "transform", "visibility"]);
+    const dirtyInlineElements = sceneElements.filter((element) =>
+      [...element.style].some((property) => !dynamicInlineProperties.has(property)));
     return {
-      status: document.body.dataset.portStatus,
+      status: document.body.className,
       ready: debug.ready,
       errors: debug.errors(),
       state: debug.state(),
@@ -96,12 +100,17 @@ try {
       stable: debug.assertStableDomIdentity(),
       retainedLeaves: leaves.length,
       retainedSceneElements: sceneElements.length,
-      retainedShapeRoots: document.querySelectorAll(".polycss-morph-shape").length,
+      retainedShapeRoots: document.querySelectorAll(".polycss-scene > div > .polycss-mesh").length,
       forbiddenCanvasCount: document.querySelectorAll(".polycss-camera canvas").length,
       forbiddenSvgCount: document.querySelectorAll(".polycss-camera svg").length,
       clipPathCount: sceneElements.filter((element) => getComputedStyle(element).clipPath !== "none").length,
       dataAttributeCount: sceneElements.reduce((sum, element) => sum +
         element.getAttributeNames().filter((name) => name.startsWith("data-")).length, 0),
+      bodyAttributeNames: document.body.getAttributeNames(),
+      dirtyInlineElementCount: dirtyInlineElements.length,
+      namedLeafCount: leaves.filter((leaf) => leaf.hasAttribute("class") ||
+        leaf.getAttributeNames().some((name) => name.startsWith("data-"))).length,
+      wrapperInlineStyleCount: sceneElements.slice(0, 4).filter((element) => element.hasAttribute("style")).length,
       preparedColorCount: new Set(leaves.map((leaf) => getComputedStyle(leaf).color)).size,
       visibleBackfaceLeafCount: leaves.filter(
         (leaf) => getComputedStyle(leaf).backfaceVisibility === "visible",
@@ -114,19 +123,17 @@ try {
       shellPath: document.querySelector(".site-wordmark-path")?.textContent ?? "",
       bodyClassName: document.body.className,
       loadingIndicatorContent: getComputedStyle(document.body, "::after").content,
-      activeBankDataset: Number(document.body.dataset.activeBank),
-      activeSeedDataset: Number(document.body.dataset.activeSeed),
     };
   });
   if (pageErrors.length || evidence.errors.length || evidence.status !== "ready" || !evidence.ready ||
       !evidence.stable || evidence.state.sourceFrameIndex !== 120 || !evidence.state.paused ||
       evidence.catalogBankCount !== 24 || evidence.stats.preparedBankCount !== 24 ||
-      evidence.state.activeBankIndex !== evidence.activeBankDataset ||
-      evidence.stats.activeSeed !== evidence.activeSeedDataset ||
       evidence.retainedLeaves !== 1_922 || evidence.retainedSceneElements !== 1_926 ||
       evidence.retainedShapeRoots !== 1 || evidence.forbiddenCanvasCount !== 0 ||
       evidence.forbiddenSvgCount !== 0 || evidence.clipPathCount !== 0 ||
-      evidence.dataAttributeCount !== 0 || evidence.preparedColorCount < 8 ||
+      evidence.dataAttributeCount !== 0 || evidence.bodyAttributeNames.join(",") !== "class" ||
+      evidence.dirtyInlineElementCount !== 0 || evidence.namedLeafCount !== 0 ||
+      evidence.wrapperInlineStyleCount !== 0 || evidence.preparedColorCount < 8 ||
       evidence.visibleBackfaceLeafCount !== evidence.retainedLeaves ||
       evidence.visibleLeafCount < 500 || evidence.shellPath !== "/gravitywell" ||
       evidence.bodyClassName !== "ready" || evidence.loadingIndicatorContent !== "none" ||
@@ -147,7 +154,7 @@ try {
   await page.screenshot({ path: screenshotPath });
   const sparseBlockEvidence = await page.evaluate(async () => {
     const debug = globalThis.__cssGravityWellDebug;
-    const leaves = [...document.querySelectorAll(".polycss-morph-leaf")];
+    const leaves = [...document.querySelectorAll(".polycss-scene > div > .polycss-mesh > b")];
     const blockBoundary = debug.scene().playback.blockFrameCount;
     const targetFrame = blockBoundary + 7;
     const styles = () => leaves.map((leaf) => ({
@@ -197,7 +204,7 @@ try {
   );
   const cycleEvidence = await page.evaluate(async () => {
     const debug = globalThis.__cssGravityWellDebug;
-    const leaves = [...document.querySelectorAll(".polycss-morph-leaf")];
+    const leaves = [...document.querySelectorAll(".polycss-scene > div > .polycss-mesh > b")];
     const { allWellsCompleteFrameIndex, terminalFlatFrameIndex: terminalFrameIndex } = debug.scene().timeline;
     await debug.seek(allWellsCompleteFrameIndex);
     const completionBankIndex = debug.state().activeBankIndex;

--- a/src/adapters/gravitywell/tools/trace-frame-work.mjs
+++ b/src/adapters/gravitywell/tools/trace-frame-work.mjs
@@ -153,7 +153,7 @@ try {
   const worstTransitionPublication = await page.evaluate(async ({ previousFrameIndex, frameIndex }) => {
     const debug = globalThis.__cssGravityWellDebug;
     debug.pause();
-    const leaves = [...document.querySelectorAll(".polycss-morph-leaf")];
+    const leaves = [...document.querySelectorAll(".polycss-scene > div > .polycss-mesh > b")];
     const visibleBackfaceLeafCount = leaves.filter(
       (leaf) => getComputedStyle(leaf).backfaceVisibility === "visible",
     ).length;


### PR DESCRIPTION
## Summary
- remove body/debug metadata from the product DOM
- move fixed camera, wrapper, and quad presentation into the stylesheet
- leave only dynamic transform, color, and visibility on plain retained `<b>` leaves

## Verification
- `pnpm test:gravitywell`
- `pnpm test:gravitywell:browser`
- `pnpm build:gravitywell`
- `pnpm typecheck`
- `pnpm verify:source-only`
- `pnpm test:framesleuth`
- pixel-identical fixed-bank/source-frame camera capture
- 7-second FrameSleuth gate: 0 runtime transform loads, 0 activation waits, 0 long tasks