### PR TITLE
Restore ElectroPaint high composition

### DIFF
--- a/src/adapters/electropaint/src/cssselectropaint/client.mjs
+++ b/src/adapters/electropaint/src/cssselectropaint/client.mjs
@@ -5,8 +5,8 @@ import { createPreparedElectropaintPlayer } from "./preparedPlayback.mjs";
 
 const PRESENTATION_STATS = Object.freeze({
   sourceViewport: Object.freeze({ width: 960, height: 540 }),
-  policy: "stylesheet-responsive-contain-with-safe-frame",
-  verticalCenterOffsetSourcePixels: 0,
+  policy: "stylesheet-responsive-high-composition-with-top-safe-frame",
+  verticalCenterOffsetSourcePixels: -35,
   resizeCount: 0,
   runtimeStyleWriteCount: 0,
   semanticCameraCalculationCount: 0,

--- a/src/adapters/electropaint/src/cssselectropaint/styles.css
+++ b/src/adapters/electropaint/src/cssselectropaint/styles.css
@@ -133,10 +133,9 @@ body.loading::after {
 }
 
 #scene {
-  --cssselectropaint-safe-frame-y: 32px;
   --cssselectropaint-presentation-scale: min(
     calc(100dvw / 960px),
-    calc((100dvh - var(--cssselectropaint-safe-frame-y)) / 540px)
+    calc((50dvh - 2px) / 311px)
   );
   --cssselectropaint-inverse-presentation-scale: calc(
     1 / var(--cssselectropaint-presentation-scale)
@@ -152,7 +151,9 @@ body.loading::after {
 #scene > .polycss-camera {
   position: absolute !important;
   left: 50% !important;
-  top: 50% !important;
+  top: calc(
+    50% - calc(35px * var(--cssselectropaint-presentation-scale))
+  ) !important;
   width: 960px !important;
   height: 540px !important;
   translate: -50% -50%;

--- a/src/adapters/electropaint/test/cssselectropaint-shell.test.mjs
+++ b/src/adapters/electropaint/test/cssselectropaint-shell.test.mjs
@@ -21,10 +21,9 @@ test("product shell identifies the route and avoids alternate or paint-heavy ren
   assert.match(player, /shapes:\s*\[\],\s*\n\s*leaves:\s*quads\.map/u);
   assert.match(css, /--cssselectropaint-presentation-scale:\s*min\(/u);
   assert.match(css, /calc\(100dvw \/ 960px\)/u);
-  assert.match(css, /--cssselectropaint-safe-frame-y:\s*32px/u);
-  assert.match(css, /calc\(\(100dvh - var\(--cssselectropaint-safe-frame-y\)\) \/ 540px\)/u);
+  assert.match(css, /calc\(\(50dvh - 2px\) \/ 311px\)/u);
   assert.match(css, /--cssselectropaint-inverse-presentation-scale:\s*calc\(/u);
-  assert.match(css, /top:\s*50%\s*!important/u);
+  assert.match(css, /50% - calc\(35px \* var\(--cssselectropaint-presentation-scale\)\)/u);
   assert.match(css, /perspective:\s*1000px/u);
   assert.match(css, /transform:\s*translateY\(135px\) rotateX\(45deg\)/u);
   assert.doesNotMatch(css, /@media \(pointer:\s*coarse\)/u);
@@ -38,7 +37,7 @@ test("product shell identifies the route and avoids alternate or paint-heavy ren
   assert.match(css, /@keyframes cssselectropaint-loading \{\s*to \{\s*transform:\s*rotate\(1turn\);/u);
   assert.match(css, /@media \(prefers-reduced-motion:\s*reduce\) \{\s*body\.loading::after \{\s*animation:\s*none;/u);
   assert.doesNotMatch(client, /ResizeObserver|style\.setProperty|PRESENTATION_VERTICAL_OFFSET_SOURCE_PIXELS/u);
-  assert.match(client, /verticalCenterOffsetSourcePixels:\s*0/u);
+  assert.match(client, /verticalCenterOffsetSourcePixels:\s*-35/u);
   assert.match(client, /runtimeStyleWriteCount:\s*0/u);
   assert.match(snapshotMount, /removeProperty\("perspective"\)/u);
   assert.match(snapshotMount, /removeProperty\("transform"\)/u);

--- a/src/adapters/electropaint/tools/smoke-browser.mjs
+++ b/src/adapters/electropaint/tools/smoke-browser.mjs
@@ -159,7 +159,7 @@ try {
         evidence.visualBounds.top < 0 || evidence.visualBounds.bottom > 540 || !evidence.stable ||
         evidence.cameraInlineStyle !== null || evidence.sceneInlineStyle !== null ||
         evidence.cameraPerspective !== "1000px" ||
-        Math.abs(Number.parseFloat(evidence.cameraScale) - (508 / 540)) > 0.000_01 ||
+        Math.abs(Number.parseFloat(evidence.cameraScale) - (268 / 311)) > 0.000_01 ||
         desktopExtremeBounds.top < 0 || desktopExtremeBounds.bottom > 540 ||
         landscapeExtremeBounds.top < 0 || landscapeExtremeBounds.bottom > 390 ||
         evidence.stats.player.runtimeGeometryConstructionCount !== 0 ||
@@ -221,7 +221,7 @@ try {
         evidence.stats.scene.runtimeDomGrowth !== false ||
         evidence.stats.scene.retainedQuadCount !== 40 ||
         evidence.stats.scene.retainedPerQuadWrapperCount !== 0 ||
-        evidence.stats.presentation.verticalCenterOffsetSourcePixels !== 0 ||
+        evidence.stats.presentation.verticalCenterOffsetSourcePixels !== -35 ||
         evidence.stats.presentation.resizeCount !== 0 ||
         evidence.stats.presentation.runtimeStyleWriteCount !== 0) {
       throw new Error(`ElectroPaint browser smoke failed: ${JSON.stringify({ pageErrors, evidence }, null, 2)}`);


### PR DESCRIPTION
## What changed\n\n- restore ElectroPaint's intentionally high composition after the global safe-frame correction\n- keep the presentation entirely in the stylesheet with a -35 source-pixel visual offset\n- use the prepared top projection envelope to retain a 2px top guard on desktop and mobile\n- preserve zero runtime presentation writes and clean camera/scene DOM\n\n## Visual evidence\n\n- representative seed-01 state 359 moves from the regressed ~332px visual center to ~297px, within ~6px of the earlier high composition\n- seed-01 top extremum remains visible at 3.0px on 960x540 and 2.7px on 844x390\n- verified visually in Chromium and geometrically in Chromium and WebKit\n\n## Tests\n\n- 
> cssgraphics@0.0.1 test:electropaint /private/tmp/cssgraphics-electropaint-safe-frame.FzwZUr
> node --test src/adapters/electropaint/test/cssselectropaint-shell.test.mjs src/adapters/electropaint/test/cssselectropaint-source-profile.test.mjs

TAP version 13
# Subtest: product shell identifies the route and avoids alternate or paint-heavy renderers
ok 1 - product shell identifies the route and avoids alternate or paint-heavy renderers
  ---
  duration_ms: 3.237167
  ...
# Subtest: prepared Kent motion is one continuous forty-wing stream split into seamless chunks
ok 2 - prepared Kent motion is one continuous forty-wing stream split into seamless chunks
  ---
  duration_ms: 1.133916
  ...
# Subtest: every inner chunk boundary is an ordinary sparse state transition with no reset or no-op writes
ok 3 - every inner chunk boundary is an ordinary sparse state transition with no reset or no-op writes
  ---
  duration_ms: 1698.76975
  ...
1..3
# tests 3
# suites 0
# pass 3
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 6009.001542\n- 
> cssgraphics@0.0.1 build:electropaint /private/tmp/cssgraphics-electropaint-safe-frame.FzwZUr
> vite build --config src/adapters/electropaint/vite.config.mjs

vite v7.3.1 building client environment for production...
transforming...
✓ 13 modules transformed.
rendering chunks...
computing gzip size...
../../../dist/electropaint/index.html                  2.61 kB │ gzip:  0.95 kB
../../../dist/electropaint/assets/index-DiUyA-Y_.css   3.23 kB │ gzip:  1.25 kB
../../../dist/electropaint/assets/index-DDrdudKO.js   31.99 kB │ gzip: 10.14 kB
✓ built in 1.14s\n- 
> cssgraphics@0.0.1 test:electropaint:browser /private/tmp/cssgraphics-electropaint-safe-frame.FzwZUr
> node src/adapters/electropaint/tools/smoke-browser.mjs

{
  "status": "ready",
  "deploy": false,
  "pageErrors": [],
  "evidence": {
    "stateIndex": 359,
    "quadCount": 40,
    "perQuadWrapperCount": 0,
    "nestedQuadCount": 0,
    "canvasCount": 0,
    "svgInSceneCount": 0,
    "bodyBackgroundImage": "linear-gradient(rgb(11, 17, 25) 0%, rgb(0, 0, 0) 100%)",
    "sceneBackgroundImage": "linear-gradient(rgb(11, 17, 25) 0%, rgb(0, 0, 0) 100%)",
    "headerBackgroundColor": "rgba(0, 0, 0, 0)",
    "headerBackgroundImage": "none",
    "headerPointerEvents": "none",
    "transformChanged": true,
    "colorfulLeafCount": 40,
    "outlinedLeafCount": 40,
    "visibleLeafCount": 40,
    "visualBounds": {
      "left": 303.87982177734375,
      "top": 129.726318359375,
      "right": 625.762451171875,
      "bottom": 443.445068359375
    },
    "hostBounds": {
      "x": 0,
      "y": 0,
      "width": 960,
      "height": 540,
      "top": 0,
      "right": 960,
      "bottom": 540,
      "left": 0
    },
    "cameraInlineStyle": null,
    "sceneInlineStyle": null,
    "cameraPerspective": "1000px",
    "cameraScale": "0.861736",
    "sparseStepDelta": {
      "schema": "cssselectropaint-prepared-player-stats@4",
      "morphTarget": "@layoutit/polycss-morph#createPolyMorphPreparedDomTarget",
      "stateIndex": 1,
      "chunkIndex": 0,
      "localStateIndex": 1,
      "paused": true,
      "preparedTimelineStateCount": 0,
      "preparedTimelineChunkCount": 0,
      "preparedFramesPerChunk": 0,
      "preparedStatesApplied": 1,
      "preparedTransformAssignmentCount": 0,
      "preparedColorAssignmentCount": 0,
      "preparedMeanTransformAssignmentsPerSequentialState": 0,
      "preparedMeanColorAssignmentsPerSequentialState": 0,
      "preparedCadenceScheduleStateCount": 0,
      "preparedCadenceEffectiveMeanStatesPerSecond": 0,
      "preparedChunkRequestCount": 0,
      "preparedLoadedChunkCount": 0,
      "preparedDecodedChunkCount": 0,
      "preparedRetainedChunkRequestCount": 0,
      "runtimeRootTransformWrites": 0,
      "runtimeTransformWrites": 40,
      "runtimeColorWrites": 0,
      "runtimeColorClassWrites": 1,
      "runtimeOutlineWrites": 0,
      "runtimePreparedTransformAssignments": 40,
      "runtimePreparedColorAssignments": 1,
      "runtimeLeafWideComparisonCount": 0,
      "runtimeRingIndexCalculationCount": 0,
      "runtimeSchedulerCallbackCount": 0,
      "runtimeAnimationFrameCallbackCount": 0,
      "preparedInnerChunkBoundaryCount": 0,
      "runtimeInnerChunkBoundaryResetCount": 0,
      "deterministicBankLoopCount": 0,
      "debugAbsoluteSeekCount": 0,
      "debugLeafWideComparisonCount": 0,
      "debugTransformWrites": 0,
      "debugColorClassWrites": 0,
      "runtimeGeometryConstructionCount": 0,
      "runtimeMatrixCalculationCount": 0,
      "runtimeColorCalculationCount": 0,
      "runtimeRandomGenerationCount": 0,
      "runtimeCameraCalculationCount": 0,
      "runtimeCadenceCalculationCount": 0,
      "runtimeCadenceDelayLookupCount": 0,
      "runtimeHorizonMaintenanceRequestCount": 0,
      "runtimeHorizonMaintenanceCallbackCount": 0,
      "runtimeHorizonIncrementalDecodeSliceCount": 0,
      "runtimeHorizonIncrementalDecodeDelayCount": 0,
      "runtimeHorizonIncrementalDecodeDelayCallbackCount": 0,
      "runtimeHorizonIncrementalDecodedTransformCount": 0,
      "runtimeDomGrowth": false
    },
    "longRunStepDelta": {
      "schema": "cssselectropaint-prepared-player-stats@4",
      "morphTarget": "@layoutit/polycss-morph#createPolyMorphPreparedDomTarget",
      "stateIndex": 1,
      "chunkIndex": 0,
      "localStateIndex": 1,
      "paused": true,
      "preparedTimelineStateCount": 0,
      "preparedTimelineChunkCount": 0,
      "preparedFramesPerChunk": 0,
      "preparedStatesApplied": 1,
      "preparedTransformAssignmentCount": 0,
      "preparedColorAssignmentCount": 0,
      "preparedMeanTransformAssignmentsPerSequentialState": 0,
      "preparedMeanColorAssignmentsPerSequentialState": 0,
      "preparedCadenceScheduleStateCount": 0,
      "preparedCadenceEffectiveMeanStatesPerSecond": 0,
      "preparedChunkRequestCount": 0,
      "preparedLoadedChunkCount": 0,
      "preparedDecodedChunkCount": 0,
      "preparedRetainedChunkRequestCount": 0,
      "runtimeRootTransformWrites": 0,
      "runtimeTransformWrites": 40,
      "runtimeColorWrites": 0,
      "runtimeColorClassWrites": 1,
      "runtimeOutlineWrites": 0,
      "runtimePreparedTransformAssignments": 40,
      "runtimePreparedColorAssignments": 1,
      "runtimeLeafWideComparisonCount": 0,
      "runtimeRingIndexCalculationCount": 0,
      "runtimeSchedulerCallbackCount": 0,
      "runtimeAnimationFrameCallbackCount": 0,
      "preparedInnerChunkBoundaryCount": 0,
      "runtimeInnerChunkBoundaryResetCount": 0,
      "deterministicBankLoopCount": 0,
      "debugAbsoluteSeekCount": 0,
      "debugLeafWideComparisonCount": 0,
      "debugTransformWrites": 0,
      "debugColorClassWrites": 0,
      "runtimeGeometryConstructionCount": 0,
      "runtimeMatrixCalculationCount": 0,
      "runtimeColorCalculationCount": 0,
      "runtimeRandomGenerationCount": 0,
      "runtimeCameraCalculationCount": 0,
      "runtimeCadenceCalculationCount": 0,
      "runtimeCadenceDelayLookupCount": 0,
      "runtimeHorizonMaintenanceRequestCount": 1,
      "runtimeHorizonMaintenanceCallbackCount": 0,
      "runtimeHorizonIncrementalDecodeSliceCount": 0,
      "runtimeHorizonIncrementalDecodeDelayCount": 0,
      "runtimeHorizonIncrementalDecodeDelayCallbackCount": 0,
      "runtimeHorizonIncrementalDecodedTransformCount": 0,
      "runtimeDomGrowth": false
    },
    "middleStepDelta": {
      "schema": "cssselectropaint-prepared-player-stats@4",
      "morphTarget": "@layoutit/polycss-morph#createPolyMorphPreparedDomTarget",
      "stateIndex": 1,
      "chunkIndex": 0,
      "localStateIndex": 1,
      "paused": true,
      "preparedTimelineStateCount": 0,
      "preparedTimelineChunkCount": 0,
      "preparedFramesPerChunk": 0,
      "preparedStatesApplied": 1,
      "preparedTransformAssignmentCount": 0,
      "preparedColorAssignmentCount": 0,
      "preparedMeanTransformAssignmentsPerSequentialState": 0,
      "preparedMeanColorAssignmentsPerSequentialState": 0,
      "preparedCadenceScheduleStateCount": 0,
      "preparedCadenceEffectiveMeanStatesPerSecond": 0,
      "preparedChunkRequestCount": 0,
      "preparedLoadedChunkCount": 0,
      "preparedDecodedChunkCount": 0,
      "preparedRetainedChunkRequestCount": 0,
      "runtimeRootTransformWrites": 0,
      "runtimeTransformWrites": 40,
      "runtimeColorWrites": 0,
      "runtimeColorClassWrites": 1,
      "runtimeOutlineWrites": 0,
      "runtimePreparedTransformAssignments": 40,
      "runtimePreparedColorAssignments": 1,
      "runtimeLeafWideComparisonCount": 0,
      "runtimeRingIndexCalculationCount": 0,
      "runtimeSchedulerCallbackCount": 0,
      "runtimeAnimationFrameCallbackCount": 0,
      "preparedInnerChunkBoundaryCount": 0,
      "runtimeInnerChunkBoundaryResetCount": 0,
      "deterministicBankLoopCount": 0,
      "debugAbsoluteSeekCount": 0,
      "debugLeafWideComparisonCount": 0,
      "debugTransformWrites": 0,
      "debugColorClassWrites": 0,
      "runtimeGeometryConstructionCount": 0,
      "runtimeMatrixCalculationCount": 0,
      "runtimeColorCalculationCount": 0,
      "runtimeRandomGenerationCount": 0,
      "runtimeCameraCalculationCount": 0,
      "runtimeCadenceCalculationCount": 0,
      "runtimeCadenceDelayLookupCount": 0,
      "runtimeHorizonMaintenanceRequestCount": 0,
      "runtimeHorizonMaintenanceCallbackCount": 0,
      "runtimeHorizonIncrementalDecodeSliceCount": 0,
      "runtimeHorizonIncrementalDecodeDelayCount": 0,
      "runtimeHorizonIncrementalDecodeDelayCallbackCount": 0,
      "runtimeHorizonIncrementalDecodedTransformCount": 0,
      "runtimeDomGrowth": false
    },
    "innerChunkBoundaryStepDelta": {
      "schema": "cssselectropaint-prepared-player-stats@4",
      "morphTarget": "@layoutit/polycss-morph#createPolyMorphPreparedDomTarget",
      "stateIndex": 1,
      "chunkIndex": 1,
      "localStateIndex": -499,
      "paused": true,
      "preparedTimelineStateCount": 0,
      "preparedTimelineChunkCount": 0,
      "preparedFramesPerChunk": 0,
      "preparedStatesApplied": 1,
      "preparedTransformAssignmentCount": 0,
      "preparedColorAssignmentCount": 0,
      "preparedMeanTransformAssignmentsPerSequentialState": 0,
      "preparedMeanColorAssignmentsPerSequentialState": 0,
      "preparedCadenceScheduleStateCount": 0,
      "preparedCadenceEffectiveMeanStatesPerSecond": 0,
      "preparedChunkRequestCount": 0,
      "preparedLoadedChunkCount": 0,
      "preparedDecodedChunkCount": 0,
      "preparedRetainedChunkRequestCount": 0,
      "runtimeRootTransformWrites": 0,
      "runtimeTransformWrites": 40,
      "runtimeColorWrites": 0,
      "runtimeColorClassWrites": 1,
      "runtimeOutlineWrites": 0,
      "runtimePreparedTransformAssignments": 40,
      "runtimePreparedColorAssignments": 1,
      "runtimeLeafWideComparisonCount": 0,
      "runtimeRingIndexCalculationCount": 0,
      "runtimeSchedulerCallbackCount": 0,
      "runtimeAnimationFrameCallbackCount": 0,
      "preparedInnerChunkBoundaryCount": 1,
      "runtimeInnerChunkBoundaryResetCount": 0,
      "deterministicBankLoopCount": 0,
      "debugAbsoluteSeekCount": 0,
      "debugLeafWideComparisonCount": 0,
      "debugTransformWrites": 0,
      "debugColorClassWrites": 0,
      "runtimeGeometryConstructionCount": 0,
      "runtimeMatrixCalculationCount": 0,
      "runtimeColorCalculationCount": 0,
      "runtimeRandomGenerationCount": 0,
      "runtimeCameraCalculationCount": 0,
      "runtimeCadenceCalculationCount": 0,
      "runtimeCadenceDelayLookupCount": 0,
      "runtimeHorizonMaintenanceRequestCount": 0,
      "runtimeHorizonMaintenanceCallbackCount": 0,
      "runtimeHorizonIncrementalDecodeSliceCount": 0,
      "runtimeHorizonIncrementalDecodeDelayCount": 0,
      "runtimeHorizonIncrementalDecodeDelayCallbackCount": 0,
      "runtimeHorizonIncrementalDecodedTransformCount": 0,
      "runtimeDomGrowth": false
    },
    "wrapStepDelta": {
      "schema": "cssselectropaint-prepared-player-stats@4",
      "morphTarget": "@layoutit/polycss-morph#createPolyMorphPreparedDomTarget",
      "stateIndex": -63999,
      "chunkIndex": -127,
      "localStateIndex": -499,
      "paused": true,
      "preparedTimelineStateCount": 0,
      "preparedTimelineChunkCount": 0,
      "preparedFramesPerChunk": 0,
      "preparedStatesApplied": 1,
      "preparedTransformAssignmentCount": 0,
      "preparedColorAssignmentCount": 0,
      "preparedMeanTransformAssignmentsPerSequentialState": 0,
      "preparedMeanColorAssignmentsPerSequentialState": 0,
      "preparedCadenceScheduleStateCount": 0,
      "preparedCadenceEffectiveMeanStatesPerSecond": 0,
      "preparedChunkRequestCount": 0,
      "preparedLoadedChunkCount": 0,
      "preparedDecodedChunkCount": 0,
      "preparedRetainedChunkRequestCount": 0,
      "runtimeRootTransformWrites": 0,
      "runtimeTransformWrites": 40,
      "runtimeColorWrites": 0,
      "runtimeColorClassWrites": 40,
      "runtimeOutlineWrites": 0,
      "runtimePreparedTransformAssignments": 40,
      "runtimePreparedColorAssignments": 40,
      "runtimeLeafWideComparisonCount": 0,
      "runtimeRingIndexCalculationCount": 0,
      "runtimeSchedulerCallbackCount": 0,
      "runtimeAnimationFrameCallbackCount": 0,
      "preparedInnerChunkBoundaryCount": 0,
      "runtimeInnerChunkBoundaryResetCount": 0,
      "deterministicBankLoopCount": 1,
      "debugAbsoluteSeekCount": 0,
      "debugLeafWideComparisonCount": 0,
      "debugTransformWrites": 0,
      "debugColorClassWrites": 0,
      "runtimeGeometryConstructionCount": 0,
      "runtimeMatrixCalculationCount": 0,
      "runtimeColorCalculationCount": 0,
      "runtimeRandomGenerationCount": 0,
      "runtimeCameraCalculationCount": 0,
      "runtimeCadenceCalculationCount": 0,
      "runtimeCadenceDelayLookupCount": 0,
      "runtimeHorizonMaintenanceRequestCount": 0,
      "runtimeHorizonMaintenanceCallbackCount": 0,
      "runtimeHorizonIncrementalDecodeSliceCount": 0,
      "runtimeHorizonIncrementalDecodeDelayCount": 0,
      "runtimeHorizonIncrementalDecodeDelayCallbackCount": 0,
      "runtimeHorizonIncrementalDecodedTransformCount": 0,
      "runtimeDomGrowth": false
    },
    "stable": true,
    "stats": {
      "scene": {
        "mode": "prepared-polycss-snapshot",
        "retainedQuadCount": 40,
        "retainedPolygonLeafCount": 40,
        "retainedPerQuadWrapperCount": 0,
        "runtimeDomCreationCount": 0,
        "runtimeDomRemovalCount": 0,
        "runtimeDomGrowth": false
      },
      "player": {
        "schema": "cssselectropaint-prepared-player-stats@4",
        "morphTarget": "@layoutit/polycss-morph#createPolyMorphPreparedDomTarget",
        "stateIndex": 359,
        "chunkIndex": 0,
        "localStateIndex": 359,
        "paused": true,
        "preparedTimelineStateCount": 64000,
        "preparedTimelineChunkCount": 128,
        "preparedFramesPerChunk": 500,
        "preparedStatesApplied": 33,
        "preparedTransformAssignmentCount": 2559960,
        "preparedColorAssignmentCount": 59088,
        "preparedMeanTransformAssignmentsPerSequentialState": 40,
        "preparedMeanColorAssignmentsPerSequentialState": 0.9232644260066564,
        "preparedCadenceScheduleStateCount": 0,
        "preparedCadenceEffectiveMeanStatesPerSecond": 60,
        "preparedChunkRequestCount": 15,
        "preparedLoadedChunkCount": 4,
        "preparedDecodedChunkCount": 4,
        "preparedRetainedChunkRequestCount": 4,
        "runtimeRootTransformWrites": 0,
        "runtimeTransformWrites": 1280,
        "runtimeColorWrites": 0,
        "runtimeColorClassWrites": 305,
        "runtimeOutlineWrites": 0,
        "runtimePreparedTransformAssignments": 1040,
        "runtimePreparedColorAssignments": 65,
        "runtimeLeafWideComparisonCount": 0,
        "runtimeRingIndexCalculationCount": 0,
        "runtimeSchedulerCallbackCount": 21,
        "runtimeAnimationFrameCallbackCount": 0,
        "preparedInnerChunkBoundaryCount": 1,
        "runtimeInnerChunkBoundaryResetCount": 0,
        "deterministicBankLoopCount": 1,
        "debugAbsoluteSeekCount": 6,
        "debugLeafWideComparisonCount": 240,
        "debugTransformWrites": 240,
        "debugColorClassWrites": 240,
        "runtimeGeometryConstructionCount": 0,
        "runtimeMatrixCalculationCount": 0,
        "runtimeColorCalculationCount": 0,
        "runtimeRandomGenerationCount": 0,
        "runtimeCameraCalculationCount": 0,
        "runtimeCadenceCalculationCount": 0,
        "runtimeCadenceDelayLookupCount": 0,
        "runtimeHorizonMaintenanceRequestCount": 3,
        "runtimeHorizonMaintenanceCallbackCount": 0,
        "runtimeHorizonIncrementalDecodeSliceCount": 0,
        "runtimeHorizonIncrementalDecodeDelayCount": 0,
        "runtimeHorizonIncrementalDecodeDelayCallbackCount": 0,
        "runtimeHorizonIncrementalDecodedTransformCount": 0,
        "runtimeDomGrowth": false
      },
      "presentation": {
        "sourceViewport": {
          "width": 960,
          "height": 540
        },
        "policy": "stylesheet-responsive-high-composition-with-top-safe-frame",
        "verticalCenterOffsetSourcePixels": -35,
        "resizeCount": 0,
        "runtimeStyleWriteCount": 0,
        "semanticCameraCalculationCount": 0
      }
    }
  },
  "selectedVariantId": "kent-seed-08",
  "desktopExtremeBounds": {
    "top": 3.6652770042419434,
    "bottom": 480.5162658691406,
    "viewportHeight": 540
  },
  "landscapeExtremeBounds": {
    "top": 3.193131446838379,
    "bottom": 346.5970153808594,
    "viewportHeight": 390
  },
  "screenshotPath": null
}\n- 
> cssgraphics@0.0.1 test:electropaint:assets /private/tmp/cssgraphics-electropaint-safe-frame.FzwZUr
> node --test src/adapters/electropaint/test/cssselectropaint-assets.test.mjs

TAP version 13
# Subtest: prepared Kent variants are random-selectable, compact, hash-bound retained-DOM banks
ok 1 - prepared Kent variants are random-selectable, compact, hash-bound retained-DOM banks
  ---
  duration_ms: 2266.771833
  ...
1..1
# tests 1
# suites 0
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 2330.505333\n- 