### PR TITLE
Remove ElectroPaint implementation aria label

### DIFF
--- a/src/adapters/electropaint/index.html
+++ b/src/adapters/electropaint/index.html
@@ -48,7 +48,7 @@
         </svg>
       </a>
     </header>
-    <main id="scene" aria-label="Kent ElectroPaint rendered with retained DOM PolyCSS" aria-busy="true"></main>
+    <main id="scene" aria-busy="true"></main>
     <script type="module" src="/src/main.mjs"></script>
   </body>
 </html>


### PR DESCRIPTION
Removes the incorrect internal implementation description from the ElectroPaint scene element. The scene retains its loading `aria-busy` state.