### PR TITLE
Mount ElectroPaint directly on the body

### DIFF
--- a/src/adapters/electropaint/index.html
+++ b/src/adapters/electropaint/index.html
@@ -48,7 +48,6 @@
         </svg>
       </a>
     </header>
-    <main id="scene" aria-busy="true"></main>
     <script type="module" src="/src/main.mjs"></script>
   </body>
 </html>

--- a/src/adapters/electropaint/src/cssselectropaint/client.mjs
+++ b/src/adapters/electropaint/src/cssselectropaint/client.mjs
@@ -7,8 +7,8 @@ const SOURCE_VIEWPORT = Object.freeze({ width: 960, height: 540 });
 const PRESENTATION_RULE_MARKER = "--cssselectropaint-presentation-rule";
 
 export async function mountElectropaintClient(body = document.body) {
-  const host = body.querySelector("#scene");
-  if (!(host instanceof HTMLElement)) throw new Error("Missing ElectroPaint scene host");
+  const host = body;
+  if (!(host instanceof HTMLElement)) throw new Error("Missing ElectroPaint host");
   const debug = { status: "loading" };
   globalThis.__cssElectropaint = debug;
   const presentation = mountPresentation(host);
@@ -43,7 +43,6 @@ export async function mountElectropaintClient(body = document.body) {
       },
     });
     body.classList.remove("loading");
-    host.setAttribute("aria-busy", "false");
     player.resume();
     return debug;
   } catch (error) {
@@ -51,11 +50,13 @@ export async function mountElectropaintClient(body = document.body) {
     debug.status = "error";
     debug.error = error.stack || error.message || String(error);
     body.classList.remove("loading");
-    host.setAttribute("aria-busy", "false");
     const message = document.createElement("pre");
     message.className = "cssselectropaint-error-message";
     message.textContent = debug.error;
-    host.replaceChildren(message);
+    for (const mounted of host.querySelectorAll(
+      ":scope > .polycss-camera, :scope > .cssselectropaint-error-message",
+    )) mounted.remove();
+    host.append(message);
     throw error;
   }
 }

--- a/src/adapters/electropaint/src/cssselectropaint/polycssScene.mjs
+++ b/src/adapters/electropaint/src/cssselectropaint/polycssScene.mjs
@@ -27,7 +27,8 @@ export function mountPreparedElectropaintSnapshot({ host, sceneData, snapshotHtm
     mountedStyles.push(imported);
   }
   const mountedCamera = document.importNode(camera, true);
-  host.replaceChildren(mountedCamera);
+  for (const existing of host.querySelectorAll(":scope > .polycss-camera")) existing.remove();
+  host.append(mountedCamera);
   const mountedScene = mountedCamera.querySelector(":scope > .polycss-scene");
   const mountedQuads = [...(mountedScene?.querySelectorAll(":scope > b") ?? [])];
   if (!(mountedScene instanceof HTMLElement) || mountedQuads.length !== 40 ||
@@ -62,7 +63,7 @@ export function mountPreparedElectropaintSnapshot({ host, sceneData, snapshotHtm
       });
     },
     destroy() {
-      host.replaceChildren();
+      mountedCamera.remove();
       removePreparedSnapshotStyles();
     },
   });

--- a/src/adapters/electropaint/src/cssselectropaint/styles.css
+++ b/src/adapters/electropaint/src/cssselectropaint/styles.css
@@ -8,16 +8,22 @@
 * { box-sizing: border-box; }
 
 html,
-body,
-#scene {
+body {
   width: 100%;
   height: 100%;
   margin: 0;
 }
 
 body {
+  --cssselectropaint-presentation-scale: 1;
+  --cssselectropaint-inverse-presentation-scale: 1;
+  --cssselectropaint-presentation-y: 35px;
   overflow: hidden;
   background: linear-gradient(180deg, #0b1119 0%, #000 100%);
+}
+
+html body {
+  --cssselectropaint-presentation-rule: 1;
 }
 
 body.loading::after {
@@ -132,22 +138,7 @@ body.loading::after {
   outline-offset: -5px;
 }
 
-#scene {
-  --cssselectropaint-presentation-scale: 1;
-  --cssselectropaint-inverse-presentation-scale: 1;
-  --cssselectropaint-presentation-y: 35px;
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-  contain: layout paint size style;
-  background: linear-gradient(180deg, #0b1119 0%, #000 100%);
-}
-
-html #scene {
-  --cssselectropaint-presentation-rule: 1;
-}
-
-#scene > .polycss-camera {
+body > .polycss-camera {
   position: absolute !important;
   left: 50% !important;
   top: calc(50% - var(--cssselectropaint-presentation-y)) !important;
@@ -160,7 +151,7 @@ html #scene {
   perspective-origin: 50% 75%;
 }
 
-#scene > .polycss-camera > .polycss-scene {
+body > .polycss-camera > .polycss-scene {
   transform: translateY(135px) rotateX(45deg);
 }
 

--- a/src/adapters/electropaint/test/cssselectropaint-shell.test.mjs
+++ b/src/adapters/electropaint/test/cssselectropaint-shell.test.mjs
@@ -14,6 +14,7 @@ test("product shell identifies the route and avoids alternate or paint-heavy ren
     readFile(resolve(adapterRoot, "src/cssselectropaint/polycssScene.mjs"), "utf8"),
   ]);
   assert.match(html, /css\.graphics\/electropaint/u);
+  assert.doesNotMatch(html, /<main\b|id="scene"/iu);
   assert.doesNotMatch(html, /<canvas\b|<model-viewer\b/iu);
   assert.doesNotMatch(css, /clip-path|mask(?:-image)?|filter|box-shadow|text-shadow|mix-blend-mode/iu);
   assert.doesNotMatch(player, /Math\.random|requestAnimationFrame\s*\(|DOMMatrix|createElement/u);
@@ -29,7 +30,7 @@ test("product shell identifies the route and avoids alternate or paint-heavy ren
   assert.doesNotMatch(css, /\.site-header \{[^}]*background:/u);
   assert.match(css, /\.site-wordmark \{[^}]*pointer-events:\s*auto;/u);
   assert.match(css, /\.site-action-icon-only \{[^}]*pointer-events:\s*auto;/u);
-  assert.match(css, /#scene \{[^}]*position:\s*absolute;[^}]*inset:\s*0;/u);
+  assert.match(css, /body > \.polycss-camera \{/u);
   assert.match(css, /body\.loading::after \{[^}]*animation:\s*cssselectropaint-loading 0\.8s linear infinite;/u);
   assert.match(css, /@keyframes cssselectropaint-loading \{\s*to \{\s*transform:\s*rotate\(1turn\);/u);
   assert.match(css, /@media \(prefers-reduced-motion:\s*reduce\) \{\s*body\.loading::after \{\s*animation:\s*none;/u);
@@ -38,6 +39,9 @@ test("product shell identifies the route and avoids alternate or paint-heavy ren
   assert.doesNotMatch(client, /CSS\?\.supports|(?:host|camera|scene)\.style\.setProperty/u);
   assert.match(client, /verticalCenterOffsetSourcePixels:\s*-35/u);
   assert.match(client, /runtimeStyleWriteCount:\s*0/u);
+  assert.doesNotMatch(client, /querySelector\("#scene"\)|aria-busy/u);
+  assert.match(snapshotMount, /host\.append\(mountedCamera\)/u);
+  assert.doesNotMatch(snapshotMount, /host\.replaceChildren/u);
   assert.match(snapshotMount, /removeProperty\("perspective"\)/u);
   assert.match(snapshotMount, /removeProperty\("transform"\)/u);
 });

--- a/src/adapters/electropaint/tools/smoke-browser.mjs
+++ b/src/adapters/electropaint/tools/smoke-browser.mjs
@@ -93,7 +93,8 @@ try {
       const wrapStepDelta = statDelta(statsBeforeWrapStep, api.stats().player);
       await api.setState(359);
       const rectangles = quads.map((quad) => quad.getBoundingClientRect());
-      const hostRectangle = document.querySelector("#scene").getBoundingClientRect();
+      const host = document.body;
+      const hostRectangle = host.getBoundingClientRect();
       const camera = document.querySelector(".polycss-camera");
       const scene = document.querySelector(".polycss-scene");
       const visualBounds = {
@@ -108,9 +109,11 @@ try {
         perQuadWrapperCount: document.querySelectorAll(".polycss-scene > div").length,
         nestedQuadCount: document.querySelectorAll(".polycss-scene > * > b").length,
         canvasCount: document.querySelectorAll("canvas").length,
-        svgInSceneCount: document.querySelectorAll("#scene svg").length,
+        svgInSceneCount: camera.querySelectorAll("svg").length,
+        legacySceneHostCount: document.querySelectorAll("#scene").length,
+        directCameraCount: host.querySelectorAll(":scope > .polycss-camera").length,
         bodyBackgroundImage: getComputedStyle(document.body).backgroundImage,
-        sceneBackgroundImage: getComputedStyle(document.querySelector("#scene")).backgroundImage,
+        sceneBackgroundImage: getComputedStyle(host).backgroundImage,
         headerBackgroundColor: getComputedStyle(document.querySelector(".site-header")).backgroundColor,
         headerBackgroundImage: getComputedStyle(document.querySelector(".site-header")).backgroundImage,
         headerPointerEvents: getComputedStyle(document.querySelector(".site-header")).pointerEvents,
@@ -124,7 +127,7 @@ try {
           rectangle.left < innerWidth && rectangle.top < innerHeight).length,
         visualBounds,
         hostBounds: hostRectangle.toJSON(),
-        hostInlineStyle: document.querySelector("#scene").getAttribute("style"),
+        hostInlineStyle: host.getAttribute("style"),
         cameraInlineStyle: camera.getAttribute("style"),
         sceneInlineStyle: scene.getAttribute("style"),
         cameraPerspective: getComputedStyle(camera).perspective,
@@ -145,7 +148,8 @@ try {
     await page.setViewportSize({ width: 844, height: 390 });
     const landscapeExtremeBounds = await measureExtremeBounds(page, extremeStates);
     if (pageErrors.length > 0 || evidence.quadCount !== 40 || evidence.perQuadWrapperCount !== 0 ||
-        evidence.nestedQuadCount !== 0 ||
+        evidence.nestedQuadCount !== 0 || evidence.legacySceneHostCount !== 0 ||
+        evidence.directCameraCount !== 1 ||
         evidence.canvasCount !== 0 || evidence.svgInSceneCount !== 0 ||
         !evidence.bodyBackgroundImage.includes("linear-gradient") ||
         !evidence.sceneBackgroundImage.includes("linear-gradient") || !evidence.transformChanged ||

--- a/src/adapters/electropaint/tools/trace-performance.mjs
+++ b/src/adapters/electropaint/tools/trace-performance.mjs
@@ -197,7 +197,7 @@ async function measureMutationAudit(page, durationMilliseconds) {
         }
       }
     });
-    observer.observe(document.querySelector("#scene"), {
+    observer.observe(document.body, {
       subtree: true,
       attributes: true,
       attributeFilter: ["style", "class"],


### PR DESCRIPTION
## What changed
- remove the legacy `<main id="scene">` host
- mount the prepared camera directly under `<body>`, matching Menger, Gravity Well, 3D Pipes, and Flowerbox
- preserve the header and loader during mount, error, and destroy paths
- update CSS selectors and performance/browser probes for the body-root topology

## Verification
- `pnpm test:electropaint`
- `pnpm build:electropaint`
- `pnpm test:electropaint:browser`
- `pnpm test:electropaint:browser:firefox`
- `git diff --check`

Both browser smokes assert zero legacy `#scene` hosts and exactly one direct body camera.