### PR TITLE
Add ElectroPaint to landing

### DIFF
--- a/site/public/projects.json
+++ b/site/public/projects.json
@@ -2,6 +2,15 @@
   "schema": "cssgraphics.projects@2",
   "projects": [
     {
+      "number": 5,
+      "id": "electropaint",
+      "name": "ElectroPaint",
+      "route": "/electropaint/",
+      "preview": "/landing/electropaint.webp",
+      "source": "David A. Tristram / SGI",
+      "date": "2026-08-10"
+    },
+    {
       "number": 4,
       "id": "menger",
       "name": "Menger",

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -7,12 +7,13 @@ import { fileURLToPath } from "node:url";
 const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = resolve(siteRoot, "..");
 const expectedProjects = [
+  ["electropaint", 5, "David A. Tristram / SGI", "2026-08-10"],
   ["menger", 4, "XScreenSaver", "2026-08-13"],
   ["maze", 3, "XScreenSaver", "2026-08-09"],
   ["gears", 2, "XScreenSaver", "2026-08-07"],
   ["pipes", 1, "Original", "2026-08-06"],
 ];
-const hiddenLandingProjects = ["electropaint", "flowerbox", "gravitywell"];
+const hiddenLandingProjects = ["flowerbox", "gravitywell"];
 const projectAdapterDirectories = new Map([
   ["electropaint", "electropaint"],
   ["flowerbox", "flowerbox"],


### PR DESCRIPTION
## Summary
- add ElectroPaint as landing project #005
- reuse the existing production route and prepared thumbnail
- update the landing manifest contract

## Verification
- `pnpm test:site`
- `CSSGRAPHICS_DEPLOY_BUILD=1 pnpm build:site`
- `git diff --check`