### PR TITLE
Attribute ElectroPaint to David Tristram

### DIFF
--- a/site/public/projects.json
+++ b/site/public/projects.json
@@ -7,7 +7,7 @@
       "name": "ElectroPaint",
       "route": "/electropaint/",
       "preview": "/landing/electropaint.webp",
-      "source": "Kent Rosenkoetter",
+      "source": "David Tristram",
       "date": "2026-08-10"
     },
     {

--- a/site/public/projects.json
+++ b/site/public/projects.json
@@ -7,7 +7,7 @@
       "name": "ElectroPaint",
       "route": "/electropaint/",
       "preview": "/landing/electropaint.webp",
-      "source": "David A. Tristram / SGI",
+      "source": "Kent Rosenkoetter",
       "date": "2026-08-10"
     },
     {

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = resolve(siteRoot, "..");
 const expectedProjects = [
-  ["electropaint", 5, "Kent Rosenkoetter", "2026-08-10"],
+  ["electropaint", 5, "David Tristram", "2026-08-10"],
   ["menger", 4, "XScreenSaver", "2026-08-13"],
   ["maze", 3, "XScreenSaver", "2026-08-09"],
   ["gears", 2, "XScreenSaver", "2026-08-07"],

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = resolve(siteRoot, "..");
 const expectedProjects = [
-  ["electropaint", 5, "David A. Tristram / SGI", "2026-08-10"],
+  ["electropaint", 5, "Kent Rosenkoetter", "2026-08-10"],
   ["menger", 4, "XScreenSaver", "2026-08-13"],
   ["maze", 3, "XScreenSaver", "2026-08-09"],
   ["gears", 2, "XScreenSaver", "2026-08-07"],

--- a/src/adapters/electropaint/README.md
+++ b/src/adapters/electropaint/README.md
@@ -1,7 +1,9 @@
 # cssElectroPaint
 
-This adapter prepares the Kent Rosenkoetter ElectroPaint motion model into eight
-deterministic 64,000-state PolyCSS screensavers. One variant is selected
+This adapter prepares ElectroPaint, originally written by David Tristram, into
+eight deterministic 64,000-state PolyCSS screensavers. Its prepared motion
+model is source-bound through the Kent Rosenkoetter and Douglas McInnes macOS
+port and two browser ports. One variant is selected
 uniformly before any variant asset fetch. It keeps 40 stable retained CSS quads
 and publishes the source 60 Hz sequence. Each 17:46.7 timeline is stored as 128
 continuous 500-frame gzip chunks. Four chunks are fetched, parsed, and decoded


### PR DESCRIPTION
## Summary
- attribute the ElectroPaint landing entry to original author David Tristram
- distinguish original authorship from the bound Kent Rosenkoetter and Douglas McInnes macOS implementation source in the adapter README
- update the landing manifest contract

## Verification
- `pnpm test:site`
- `CSSGRAPHICS_DEPLOY_BUILD=1 pnpm build:site`
- `git diff --check`