### PR TITLE
Avoid repeated Gravity Well seed on refresh

### DIFF
--- a/src/adapters/gravitywell/src/cssgravitywell/client.mjs
+++ b/src/adapters/gravitywell/src/cssgravitywell/client.mjs
@@ -15,6 +15,8 @@ import {
   defaultGravityWellCarrierCoverageScale,
 } from "./preparedPlayback.mjs";
 
+const LAST_BANK_STORAGE_KEY = "cssgravitywell:last-bank-index";
+
 export function mountGravityWellClient(host) {
   const state = {
     ready: false,
@@ -41,7 +43,12 @@ export function mountGravityWellClient(host) {
       loadPolyMorphPackage("/cssgravitywell/model/"),
       loadPreparedGravityWellCatalog(),
     ]);
-    const selection = selectInitialGravityWellBank(catalog);
+    const search = location.search;
+    const previousBankIndex = readPreviousBankIndex(catalog.bankCount);
+    const selection = selectInitialGravityWellBank(catalog, { search, previousBankIndex });
+    const cycleBanks = new URLSearchParams(search).get("cycle") !== "0";
+    rememberBankIndex(selection.bankIndex);
+    clearConsumedRouteControls();
     const loadBank = async (bankIndex, {
       lookahead = false,
       incremental = lookahead,
@@ -81,7 +88,7 @@ export function mountGravityWellClient(host) {
       bankCount: catalog.bankCount,
       initialBankIndex: selection.bankIndex,
       loadBank,
-      cycleBanks: new URLSearchParams(location.search).get("cycle") !== "0",
+      cycleBanks,
       onBankChange(_bankIndex, nextScene) {
         state.scene = nextScene;
       },
@@ -110,6 +117,37 @@ export function mountGravityWellClient(host) {
     output.textContent = message;
     host.append(output);
   }
+}
+
+function readPreviousBankIndex(bankCount) {
+  try {
+    const stored = globalThis.sessionStorage?.getItem(LAST_BANK_STORAGE_KEY);
+    if (stored === null || stored === undefined) return null;
+    const bankIndex = Number(stored);
+    return Number.isSafeInteger(bankIndex) && bankIndex >= 0 && bankIndex < bankCount
+      ? bankIndex
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function rememberBankIndex(bankIndex) {
+  try {
+    globalThis.sessionStorage?.setItem(LAST_BANK_STORAGE_KEY, String(bankIndex));
+  } catch {
+    // Storage can be unavailable in hardened browsing modes; selection remains random.
+  }
+}
+
+function clearConsumedRouteControls() {
+  const url = new URL(location.href);
+  const hadBank = url.searchParams.has("bank");
+  const hadCycle = url.searchParams.has("cycle");
+  if (!hadBank && !hadCycle) return;
+  url.searchParams.delete("bank");
+  url.searchParams.delete("cycle");
+  history.replaceState(history.state, "", `${url.pathname}${url.search}${url.hash}`);
 }
 
 function setStatus(kind) {

--- a/src/adapters/gravitywell/src/cssgravitywell/preparedAssets.mjs
+++ b/src/adapters/gravitywell/src/cssgravitywell/preparedAssets.mjs
@@ -47,21 +47,34 @@ export async function loadPreparedGravityWellCatalog() {
 
 export function selectInitialGravityWellBank(catalog, {
   search = globalThis.location?.search ?? "",
+  previousBankIndex = null,
   randomUint32 = cryptoRandomUint32,
 } = {}) {
+  if (previousBankIndex !== null &&
+      (!Number.isSafeInteger(previousBankIndex) || previousBankIndex < 0 ||
+        previousBankIndex >= catalog.bankCount)) {
+    throw new RangeError("Gravity Well previous bank is invalid");
+  }
   const requested = new URLSearchParams(search).get("bank");
   if (requested !== null) {
     const bankIndex = Number(requested);
     if (!Number.isSafeInteger(bankIndex) || bankIndex < 0 || bankIndex >= catalog.bankCount) {
       throw new RangeError("Gravity Well requested bank is invalid");
     }
-    return Object.freeze({ bankIndex, mode: "explicit" });
+    if (bankIndex !== previousBankIndex || catalog.bankCount === 1) {
+      return Object.freeze({ bankIndex, mode: "explicit" });
+    }
   }
   const value = randomUint32();
   if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
     throw new RangeError("Gravity Well initial-bank random value must be uint32");
   }
-  return Object.freeze({ bankIndex: value % catalog.bankCount, mode: "crypto-random" });
+  if (previousBankIndex === null || catalog.bankCount === 1) {
+    return Object.freeze({ bankIndex: value % catalog.bankCount, mode: "crypto-random" });
+  }
+  const candidate = value % (catalog.bankCount - 1);
+  const bankIndex = candidate >= previousBankIndex ? candidate + 1 : candidate;
+  return Object.freeze({ bankIndex, mode: "crypto-random-no-repeat" });
 }
 
 export async function loadPreparedGravityWellBankScene(catalog, bankIndex) {

--- a/src/adapters/gravitywell/test/cssgravitywell-bank-selection.test.mjs
+++ b/src/adapters/gravitywell/test/cssgravitywell-bank-selection.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { selectInitialGravityWellBank } from "../src/cssgravitywell/preparedAssets.mjs";
+
+const catalog = Object.freeze({ bankCount: 24 });
+
+test("Gravity Well honors a fresh explicit bank selection", () => {
+  assert.deepEqual(
+    selectInitialGravityWellBank(catalog, {
+      search: "?bank=7",
+      previousBankIndex: 6,
+      randomUint32: () => 0,
+    }),
+    { bankIndex: 7, mode: "explicit" },
+  );
+});
+
+test("Gravity Well does not repeat an explicit bank after refresh", () => {
+  assert.deepEqual(
+    selectInitialGravityWellBank(catalog, {
+      search: "?bank=7",
+      previousBankIndex: 7,
+      randomUint32: () => 7,
+    }),
+    { bankIndex: 8, mode: "crypto-random-no-repeat" },
+  );
+});
+
+test("Gravity Well does not repeat a randomly selected bank after refresh", () => {
+  assert.deepEqual(
+    selectInitialGravityWellBank(catalog, {
+      previousBankIndex: 5,
+      randomUint32: () => 5,
+    }),
+    { bankIndex: 6, mode: "crypto-random-no-repeat" },
+  );
+});
+
+test("Gravity Well keeps the first load crypto-random", () => {
+  assert.deepEqual(
+    selectInitialGravityWellBank(catalog, { randomUint32: () => 29 }),
+    { bankIndex: 5, mode: "crypto-random" },
+  );
+});


### PR DESCRIPTION
## Summary
- consume and remove Gravity Well bank/cycle route controls after startup
- remember the active bank per tab and exclude it on the next load
- add selector regression coverage for explicit and random refreshes

## Verification
- `pnpm test:gravitywell`
- `pnpm build:gravitywell`
- `pnpm test:gravitywell:browser`
- 10 headless reloads from `?bank=0&cycle=0`, zero adjacent seed repeats