### PR TITLE
fix: simplify Solitaire prepared DOM

### DIFF
--- a/site/public/projects.json
+++ b/site/public/projects.json
@@ -2,16 +2,6 @@
   "schema": "cssgraphics.projects@2",
   "projects": [
     {
-      "number": 6,
-      "id": "solitaire",
-      "name": "Solitaire Victory",
-      "route": "/solitaire/",
-      "preview": "/landing/solitaire.webp",
-      "source": "Classic Solitaire",
-      "description": "The classic Solitaire victory cascade rendered entirely with retained HTML and CSS using PolyCSS.",
-      "date": "2026-08-16"
-    },
-    {
       "number": 5,
       "id": "electropaint",
       "name": "ElectroPaint",

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -7,14 +7,13 @@ import { fileURLToPath } from "node:url";
 const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = resolve(siteRoot, "..");
 const expectedProjects = [
-  ["solitaire", 6, "Classic Solitaire", "2026-08-16", "The classic Solitaire victory cascade"],
   ["electropaint", 5, "David Tristram", "2026-08-10", "ElectroPaint, originally written by David Tristram"],
   ["menger", 4, "XScreenSaver", "2026-08-13", "XScreenSaver Menger"],
   ["maze", 3, "XScreenSaver", "2026-08-09", "XScreenSaver Maze3D"],
   ["gears", 2, "XScreenSaver", "2026-08-07", "XScreenSaver Gears"],
   ["pipes", 1, "Original", "2026-08-06", "CSS Pipes"],
 ];
-const projectsExcludedFromLanding = ["flowerbox", "gravitywell"];
+const projectsExcludedFromLanding = ["flowerbox", "gravitywell", "solitaire"];
 const projectAdapterDirectories = new Map([
   ["electropaint", "electropaint"],
   ["flowerbox", "flowerbox"],

--- a/src/adapters/solitaire/src/csssolitaire/client.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/client.mjs
@@ -23,8 +23,9 @@ export function mountCsssolitaireClient() {
     });
     state.player = createCsssolitairePreparedPlayer({
       playback: prepared.playback,
-      board: state.mount.board,
+      scene: state.mount.scene,
       leaves: state.mount.leaves,
+      layoutRulesByProfile: state.mount.layoutRulesByProfile,
     });
     state.ready = true;
     setBodyState("ready");

--- a/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
@@ -191,6 +191,11 @@ function validPattern(pattern, playback, manifest, index) {
     !Array.from({ length: pattern.trailLeafCount }, (_, leafIndex) => leafIndex).some((leafIndex) =>
       pattern.leafPortraitMatricesByCardCount.some((profile, profileIndex, profiles) =>
         profileIndex > 0 && profiles[profileIndex - 1][leafIndex] !== null && profile[leafIndex] === null)) &&
+    Array.isArray(pattern.leafFoundationIndices) &&
+    pattern.leafFoundationIndices.length === pattern.trailLeafCount &&
+    !pattern.leafFoundationIndices.some((foundationIndex) =>
+      !Number.isSafeInteger(foundationIndex) || foundationIndex < 0 ||
+      foundationIndex >= playback.foundationLeafCount) &&
     Array.isArray(pattern.leafAtlasIndices) && pattern.leafAtlasIndices.length === pattern.trailLeafCount &&
     !pattern.leafAtlasIndices.some((atlasIndex) =>
       !Number.isSafeInteger(atlasIndex) || atlasIndex < 0 || atlasIndex >= playback.atlasPositions.length);

--- a/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
@@ -4,35 +4,36 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
   if (!(host instanceof HTMLElement)) throw new Error("Missing cssSolitaire host");
   if (typeof snapshotHtml !== "string") throw new Error("Prepared cssSolitaire snapshot is required");
   const snapshot = new DOMParser().parseFromString(snapshotHtml, "text/html");
-  if (snapshot.querySelector("script,canvas,svg") || snapshot.querySelectorAll("style").length !== 1 ||
-      hasPreparedMetadata(snapshot)) {
+  if (snapshot.querySelector("script,canvas,svg,[style]") ||
+      snapshot.querySelectorAll("style").length !== 1 || hasPreparedMetadata(snapshot)) {
     throw new Error("Prepared cssSolitaire snapshot contains a forbidden or incomplete graph");
   }
   const style = snapshot.querySelector("style");
   const camera = snapshot.querySelector(".solitaire-prepared-camera");
   const scene = camera?.querySelector(":scope > .solitaire-prepared-scene");
-  const board = scene?.querySelector(":scope > .csssolitaire-board");
-  const leaves = [...(board?.querySelectorAll(":scope > s") ?? [])];
+  const leaves = [...(scene?.querySelectorAll(":scope > s") ?? [])];
   if (!(style instanceof HTMLStyleElement) || !(camera instanceof HTMLElement) ||
-      !(scene instanceof HTMLElement) || !(board instanceof HTMLElement) ||
+      !(scene instanceof HTMLElement) || scene.childElementCount !== manifest.metrics.retainedLeafCount ||
       leaves.length !== manifest.metrics.retainedLeafCount ||
-      leaves.some((leaf) => !(leaf instanceof HTMLElement) || leaf.localName !== "s")) {
+      leaves.some((leaf) => !(leaf instanceof HTMLElement) || leaf.localName !== "s" || leaf.style.length !== 0)) {
     throw new Error("Prepared cssSolitaire retained DOM census drifted");
   }
 
   mountedStyle?.remove();
   mountedStyle = document.importNode(style, true);
   document.head.append(mountedStyle);
+  const ruleBank = collectPreparedRuleBank(mountedStyle, manifest.metrics.retainedLeafCount);
   const mountedCamera = document.importNode(camera, true);
   host.replaceChildren(mountedCamera);
   const mountedScene = mountedCamera.querySelector(":scope > .solitaire-prepared-scene");
-  const mountedBoard = mountedScene?.querySelector(":scope > .csssolitaire-board");
-  const mountedLeaves = [...(mountedBoard?.querySelectorAll(":scope > s") ?? [])];
-  if (!(mountedScene instanceof HTMLElement) || !(mountedBoard instanceof HTMLElement) ||
-      mountedLeaves.length !== manifest.metrics.retainedLeafCount) {
+  const mountedLeaves = [...(mountedScene?.querySelectorAll(":scope > s") ?? [])];
+  if (!(mountedScene instanceof HTMLElement) ||
+      mountedScene.childElementCount !== manifest.metrics.retainedLeafCount ||
+      mountedLeaves.length !== manifest.metrics.retainedLeafCount ||
+      mountedLeaves.some((leaf) => leaf.style.length !== 0)) {
     throw new Error("Mounted cssSolitaire retained DOM census drifted");
   }
-  const stableNodes = Object.freeze([mountedCamera, mountedScene, mountedBoard, ...mountedLeaves]);
+  const stableNodes = Object.freeze([mountedCamera, mountedScene, ...mountedLeaves]);
   let presentationScale = 1;
   let presentationScaleWrites = 0;
 
@@ -49,8 +50,8 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
         height / manifest.renderer.landscapePresentationBase[1],
       );
     const serialized = String(Number(presentationScale.toFixed(8)));
-    if (host.style.getPropertyValue("--csssolitaire-presentation-scale") !== serialized) {
-      host.style.setProperty("--csssolitaire-presentation-scale", serialized);
+    if (ruleBank.presentation.style.getPropertyValue("--csssolitaire-presentation-scale") !== serialized) {
+      ruleBank.presentation.style.setProperty("--csssolitaire-presentation-scale", serialized);
       presentationScaleWrites += 1;
     }
   }
@@ -63,10 +64,10 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
     const current = [
       host.querySelector(":scope > .solitaire-prepared-camera"),
       host.querySelector(":scope > .solitaire-prepared-camera > .solitaire-prepared-scene"),
-      host.querySelector(":scope > .solitaire-prepared-camera > .solitaire-prepared-scene > .csssolitaire-board"),
-      ...host.querySelectorAll(".csssolitaire-board > s"),
+      ...host.querySelectorAll(":scope > .solitaire-prepared-camera > .solitaire-prepared-scene > s"),
     ];
-    if (current.length !== stableNodes.length || current.some((node, index) => node !== stableNodes[index])) {
+    if (current.length !== stableNodes.length || current.some((node, index) => node !== stableNodes[index]) ||
+        mountedLeaves.some((leaf) => leaf.style.length !== 0)) {
       throw new Error("Prepared cssSolitaire retained DOM identity changed");
     }
     return true;
@@ -75,8 +76,8 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
   return Object.freeze({
     camera: mountedCamera,
     scene: mountedScene,
-    board: mountedBoard,
     leaves: Object.freeze(mountedLeaves),
+    layoutRulesByProfile: ruleBank.layouts,
     assertStableDomIdentity,
     stats() {
       assertStableDomIdentity();
@@ -84,8 +85,10 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
         mode: "prepared-snapshot",
         retainedCameraRootCount: 1,
         retainedSceneRootCount: 1,
-        retainedBoardRootCount: 1,
+        retainedBoardRootCount: 0,
+        retainedRenderWrapperCount: 2,
         retainedPolygonLeafCount: mountedLeaves.length,
+        retainedLeafInlineStyleDeclarationCount: 0,
         retainedDataAttributeCount: 0,
         runtimeDomCreationCount: 0,
         runtimeDomRemovalCount: 0,
@@ -102,11 +105,44 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
       resizeObserver?.disconnect();
       globalThis.removeEventListener?.("resize", updatePresentation);
       host.replaceChildren();
-      host.style.removeProperty("--csssolitaire-presentation-scale");
       mountedStyle?.remove();
       mountedStyle = null;
     },
   });
+}
+
+function collectPreparedRuleBank(style, retainedLeafCount) {
+  const sheet = style.sheet;
+  if (!(sheet instanceof CSSStyleSheet)) throw new Error("Prepared cssSolitaire stylesheet did not mount");
+  const topLevelRules = [...sheet.cssRules];
+  const presentation = topLevelRules.find((rule) =>
+    rule.selectorText === ".polycss-camera.solitaire-prepared-camera");
+  const mediaRules = topLevelRules.filter((rule) => rule.type === CSSRule.MEDIA_RULE);
+  const layouts = [
+    collectLayoutRules(topLevelRules, retainedLeafCount),
+    ...mediaRules.map((rule) => collectLayoutRules([...rule.cssRules], retainedLeafCount)),
+  ];
+  if (!presentation || layouts.length !== 5 || layouts.some((rules) => rules.some((rule) => !rule))) {
+    throw new Error("Prepared cssSolitaire stylesheet rule bank drifted");
+  }
+  return Object.freeze({
+    presentation,
+    layouts: Object.freeze(layouts.map((rules) => Object.freeze(rules))),
+  });
+}
+
+function collectLayoutRules(rules, retainedLeafCount) {
+  const result = Array(retainedLeafCount).fill(null);
+  for (const rule of rules) {
+    const match = rule.selectorText?.match(/^\.solitaire-prepared-scene\s*>\s*s\.l([0-9a-z]+)$/u);
+    if (!match) continue;
+    const index = Number.parseInt(match[1], 36);
+    if (!Number.isSafeInteger(index) || index < 0 || index >= retainedLeafCount || result[index]) {
+      throw new Error("Prepared cssSolitaire leaf rule index drifted");
+    }
+    result[index] = rule;
+  }
+  return result;
 }
 
 function hasPreparedMetadata(doc) {

--- a/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
@@ -2,20 +2,23 @@ import { createPolyMorphPreparedDomTarget } from "@layoutit/polycss-morph";
 
 export function createCsssolitairePreparedPlayer({
   playback,
-  board,
+  scene,
   leaves,
+  layoutRulesByProfile,
   randomUint32 = cryptoRandomUint32,
 }) {
   if (playback?.schema !== "csssolitaire-prepared-playback@2" ||
-      !(board instanceof HTMLElement) || !Array.isArray(leaves) ||
-      leaves.length !== playback.retainedLeafCount) {
+      !(scene instanceof HTMLElement) || !Array.isArray(leaves) ||
+      leaves.length !== playback.retainedLeafCount || !Array.isArray(layoutRulesByProfile) ||
+      layoutRulesByProfile.length !== 5 ||
+      layoutRulesByProfile.some((rules) => !Array.isArray(rules) || rules.length !== leaves.length)) {
     throw new Error("Prepared cssSolitaire player input drifted");
   }
   const target = createPolyMorphPreparedDomTarget({
     model: {
-      element: board,
+      element: scene,
       writeTransform(transform) {
-        board.style.transform = transform;
+        scene.style.transform = transform;
         return true;
       },
     },
@@ -28,17 +31,21 @@ export function createCsssolitairePreparedPlayer({
   const foundationLeafCount = playback.foundationLeafCount;
   const foundationLeaves = leaves.slice(0, foundationLeafCount);
   const trailLeaves = leaves.slice(foundationLeafCount);
-  const initialFoundationPositions = foundationLeaves.map((leaf) => leaf.style.backgroundPosition);
-  const foundationPositions = [...initialFoundationPositions];
+  const initialFoundationFaceIndices = foundationLeaves.map(readFaceIndex);
+  const foundationFaceIndices = [...initialFoundationFaceIndices];
   const foundationVisibility = new Uint8Array(foundationLeafCount);
   foundationVisibility.fill(1);
   const trailVisibility = new Uint8Array(trailLeaves.length);
-  const trailLandscapeTransforms = trailLeaves.map((leaf) =>
-    leaf.style.getPropertyValue("--csssolitaire-landscape-transform"));
+  const trailLandscapeTransforms = layoutRulesByProfile[0]
+    .slice(foundationLeafCount)
+    .map((rule) => rule?.style.transform ?? "");
   const trailPortraitTransformsByCardCount = Array.from({ length: 4 }, (_, profileIndex) =>
-    trailLeaves.map((leaf) =>
-      leaf.style.getPropertyValue(`--csssolitaire-portrait-${profileIndex + 1}-transform`)));
-  const trailBackgroundPositions = trailLeaves.map((leaf) => leaf.style.backgroundPosition);
+    layoutRulesByProfile[profileIndex + 1]
+      .slice(foundationLeafCount)
+      .map((rule) => rule?.style.transform ?? ""));
+  const trailLaneIndices = trailLeaves.map(readLaneIndex);
+  const trailFaceIndices = trailLeaves.map(readFaceIndex);
+  const atlasFaceIndices = new Map(playback.atlasPositions.map((position, index) => [position, index]));
   let activePatternIndex = playback.initialPatternIndex;
   let pattern = patterns[activePatternIndex];
   let shuffleBag = [];
@@ -51,7 +58,7 @@ export function createCsssolitairePreparedPlayer({
   let visibleFoundationCards = foundationLeafCount;
   let visibilityWrites = 0;
   let visibilityOperationsApplied = 0;
-  let foundationStyleWrites = 0;
+  let foundationClassWrites = 0;
   let foundationOperationsApplied = 0;
   let patternLayoutWrites = 0;
   let patternLayoutLeavesVisited = 0;
@@ -76,7 +83,7 @@ export function createCsssolitairePreparedPlayer({
       visibilityOperationsApplied += 1;
       if (Boolean(trailVisibility[trailIndex]) === visible) continue;
       trailVisibility[trailIndex] = Number(visible);
-      leaves[leafIndex].style.visibility = visible ? "visible" : "hidden";
+      leaves[leafIndex].classList.toggle("v", visible);
       visibleTrailCards += visible ? 1 : -1;
       visibilityWrites += 1;
       writes += 1;
@@ -92,25 +99,27 @@ export function createCsssolitairePreparedPlayer({
       if (atlasX < 0) {
         if (foundationVisibility[foundationIndex] === 0) continue;
         foundationVisibility[foundationIndex] = 0;
-        leaf.style.visibility = "hidden";
+        leaf.classList.remove("v");
         visibleFoundationCards -= 1;
         writes += 1;
         continue;
       }
       const position = `${-atlasX}px ${-atlasY}px`;
-      if (foundationPositions[foundationIndex] !== position) {
-        foundationPositions[foundationIndex] = position;
-        leaf.style.backgroundPosition = position;
+      const faceIndex = atlasFaceIndices.get(position);
+      if (!Number.isInteger(faceIndex)) throw new Error("Prepared cssSolitaire atlas position drifted");
+      if (foundationFaceIndices[foundationIndex] !== faceIndex) {
+        setFaceClass(leaf, foundationFaceIndices[foundationIndex], faceIndex);
+        foundationFaceIndices[foundationIndex] = faceIndex;
         writes += 1;
       }
       if (foundationVisibility[foundationIndex] === 0) {
         foundationVisibility[foundationIndex] = 1;
-        leaf.style.visibility = "visible";
+        leaf.classList.add("v");
         visibleFoundationCards += 1;
         writes += 1;
       }
     }
-    foundationStyleWrites += writes;
+    foundationClassWrites += writes;
     return writes;
   }
 
@@ -118,28 +127,35 @@ export function createCsssolitairePreparedPlayer({
     let writes = 0;
     for (let index = 0; index < nextPattern.trailLeafCount; index += 1) {
       const leaf = trailLeaves[index];
+      const leafIndex = foundationLeafCount + index;
       const landscapeTransform = nextPattern.leafMatrices[index];
-      const backgroundPosition = playback.atlasPositions[nextPattern.leafAtlasIndices[index]];
+      const laneIndex = nextPattern.leafFoundationIndices[index];
+      const faceIndex = nextPattern.leafAtlasIndices[index];
       patternLayoutLeavesVisited += 1;
       if (trailLandscapeTransforms[index] !== landscapeTransform) {
         trailLandscapeTransforms[index] = landscapeTransform;
-        leaf.style.setProperty("--csssolitaire-landscape-transform", landscapeTransform);
+        layoutRulesByProfile[0][leafIndex].style.transform = landscapeTransform;
         writes += 1;
       }
       for (let profileIndex = 0; profileIndex < 4; profileIndex += 1) {
         const portraitTransform = nextPattern.leafPortraitMatricesByCardCount[profileIndex][index];
         if (portraitTransform === null ||
             trailPortraitTransformsByCardCount[profileIndex][index] === portraitTransform) continue;
+        const rule = layoutRulesByProfile[profileIndex + 1][leafIndex];
+        if (!rule) throw new Error("Prepared cssSolitaire portrait rule bank drifted");
         trailPortraitTransformsByCardCount[profileIndex][index] = portraitTransform;
-        leaf.style.setProperty(
-          `--csssolitaire-portrait-${profileIndex + 1}-transform`,
-          portraitTransform,
-        );
+        rule.style.transform = portraitTransform;
         writes += 1;
       }
-      if (trailBackgroundPositions[index] !== backgroundPosition) {
-        trailBackgroundPositions[index] = backgroundPosition;
-        leaf.style.backgroundPosition = backgroundPosition;
+      if (trailLaneIndices[index] !== laneIndex) {
+        leaf.classList.remove(`lane-${trailLaneIndices[index]}`);
+        leaf.classList.add(`lane-${laneIndex}`);
+        trailLaneIndices[index] = laneIndex;
+        writes += 1;
+      }
+      if (trailFaceIndices[index] !== faceIndex) {
+        setFaceClass(leaf, trailFaceIndices[index], faceIndex);
+        trailFaceIndices[index] = faceIndex;
         writes += 1;
       }
     }
@@ -152,21 +168,21 @@ export function createCsssolitairePreparedPlayer({
     for (let index = 0; index < trailVisibility.length; index += 1) {
       if (trailVisibility[index] === 0) continue;
       trailVisibility[index] = 0;
-      trailLeaves[index].style.visibility = "hidden";
+      trailLeaves[index].classList.remove("v");
       writes += 1;
     }
     let foundationWrites = 0;
     for (let index = 0; index < foundationLeafCount; index += 1) {
       const leaf = foundationLeaves[index];
-      const initialPosition = initialFoundationPositions[index];
-      if (foundationPositions[index] !== initialPosition) {
-        foundationPositions[index] = initialPosition;
-        leaf.style.backgroundPosition = initialPosition;
+      const initialFaceIndex = initialFoundationFaceIndices[index];
+      if (foundationFaceIndices[index] !== initialFaceIndex) {
+        setFaceClass(leaf, foundationFaceIndices[index], initialFaceIndex);
+        foundationFaceIndices[index] = initialFaceIndex;
         foundationWrites += 1;
       }
       if (foundationVisibility[index] === 0) {
         foundationVisibility[index] = 1;
-        leaf.style.visibility = "visible";
+        leaf.classList.add("v");
         foundationWrites += 1;
       }
     }
@@ -175,7 +191,7 @@ export function createCsssolitairePreparedPlayer({
     frameIndex = 0;
     playheadMs = 0;
     visibilityWrites += writes;
-    foundationStyleWrites += foundationWrites;
+    foundationClassWrites += foundationWrites;
     resetCount += 1;
     lastApply = Object.freeze({
       visibilityWrites: writes,
@@ -355,7 +371,7 @@ export function createCsssolitairePreparedPlayer({
         runtimeVisibilityOperationsApplied: visibilityOperationsApplied,
         runtimeFoundationOperationsApplied: foundationOperationsApplied,
         runtimeLeafVisibilityWrites: visibilityWrites,
-        runtimeFoundationStyleWrites: foundationStyleWrites,
+        runtimeFoundationClassWrites: foundationClassWrites,
         runtimePatternLayoutWrites: patternLayoutWrites,
         runtimePatternLayoutLeavesVisited: patternLayoutLeavesVisited,
         runtimePreparedPatternSwitchCount: patternSwitchCount,
@@ -377,6 +393,28 @@ export function createCsssolitairePreparedPlayer({
       target.destroy();
     },
   });
+}
+
+function readFaceIndex(leaf) {
+  for (const className of leaf.classList) {
+    if (!/^f[0-9a-z]+$/u.test(className)) continue;
+    const index = Number.parseInt(className.slice(1), 36);
+    if (Number.isSafeInteger(index) && index >= 0 && index < 52) return index;
+  }
+  throw new Error("Prepared cssSolitaire face class drifted");
+}
+
+function readLaneIndex(leaf) {
+  for (const className of leaf.classList) {
+    const match = className.match(/^lane-([0-3])$/u);
+    if (match) return Number(match[1]);
+  }
+  throw new Error("Prepared cssSolitaire lane class drifted");
+}
+
+function setFaceClass(leaf, previousIndex, nextIndex) {
+  leaf.classList.remove(`f${previousIndex.toString(36)}`);
+  leaf.classList.add(`f${nextIndex.toString(36)}`);
 }
 
 function cryptoRandomUint32() {

--- a/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
+++ b/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
@@ -381,6 +381,7 @@ function cardLeaf({ cardFace, foundationIndex, horizontalDirection, left, top })
     return portrait ? cardTransform(portrait) : null;
   });
   return Object.freeze({
+    faceIndex: cardFace - 1,
     foundationIndex,
     matrix: cardTransform(landscape),
     portraitMatrices: Object.freeze(portraitMatrices),
@@ -484,33 +485,50 @@ function buildPreparedPattern(seed, index) {
           const portraitMatrix = portraitMatrices[profileIndex];
           return portraitMatrix;
         })),
+      leafFoundationIndices: source.snapshots.map(({ foundationIndex }) => foundationIndex),
       leafAtlasIndices: source.snapshots.map(({ faceNumber: cardFace }) => cardFace - 1),
     }),
   });
 }
 
 function buildSnapshot(leaves, cardAssetUrl) {
+  const leafClass = (index) => `l${index.toString(36)}`;
+  const faceClass = (index) => `f${index.toString(36)}`;
+  const leafSelector = (index) => `.solitaire-prepared-scene>s.${leafClass(index)}`;
   const cardNodes = leaves.map((leaf, index) => {
-    const classes = [index < FOUNDATION_COUNT ? "foundation" : null, `lane-${leaf.foundationIndex}`]
+    const classes = [
+      index < FOUNDATION_COUNT ? "foundation" : null,
+      index < FOUNDATION_COUNT ? "v" : null,
+      `lane-${leaf.foundationIndex}`,
+      leafClass(index),
+      faceClass(leaf.faceIndex),
+    ]
       .filter(Boolean).join(" ");
-    const portraitProperties = leaf.portraitMatrices.map((portraitMatrix, profileIndex) =>
-      portraitMatrix
-        ? `--csssolitaire-portrait-${profileIndex + 1}-transform:${portraitMatrix};`
-        : "").join("");
-    return `<s class="${classes}" style="--csssolitaire-landscape-transform:${leaf.matrix};${portraitProperties}background-position:${-leaf.atlas.x}px ${-leaf.atlas.y}px"></s>`;
+    return `<s class="${classes}"></s>`;
   }).join("");
+  const faceRules = Array.from({ length: 52 }, (_, faceIndex) => {
+    const atlas = atlasPosition(faceIndex + 1);
+    return `.solitaire-prepared-scene>s.${faceClass(faceIndex)}{background-position:${-atlas.x}px ${-atlas.y}px}`;
+  }).join("");
+  const landscapeRules = leaves.map((leaf, index) =>
+    `${leafSelector(index)}{transform:${leaf.matrix}}`).join("");
+  const portraitRules = PORTRAIT_PROFILES.map((_, profileIndex) => leaves
+    .map((leaf, index) =>
+      `${leafSelector(index)}{transform:${leaf.portraitMatrices[profileIndex] ?? "none"}}`)
+    .join(""));
   const css = [
-    `.polycss-camera.solitaire-prepared-camera{position:relative;display:block;width:100%;height:100%;overflow:hidden;--csssolitaire-card-width:calc(${CARD_WIDTH}px * var(--csssolitaire-presentation-scale,${LANDSCAPE_PRESENTATION_SCALE}));--csssolitaire-card-height:calc(${CARD_HEIGHT}px * var(--csssolitaire-presentation-scale,${LANDSCAPE_PRESENTATION_SCALE}));--csssolitaire-card-transform-x:calc(${CARD_HEIGHT / CARD_SOURCE_WIDTH} * var(--csssolitaire-presentation-scale,${LANDSCAPE_PRESENTATION_SCALE}));--csssolitaire-card-transform-y:calc(${CARD_WIDTH / CARD_SOURCE_HEIGHT} * var(--csssolitaire-presentation-scale,${LANDSCAPE_PRESENTATION_SCALE}))}`,
+    `.polycss-camera.solitaire-prepared-camera{position:relative;display:block;width:100%;height:100%;overflow:hidden;--csssolitaire-presentation-scale:${LANDSCAPE_PRESENTATION_SCALE};--csssolitaire-card-width:calc(${CARD_WIDTH}px * var(--csssolitaire-presentation-scale));--csssolitaire-card-height:calc(${CARD_HEIGHT}px * var(--csssolitaire-presentation-scale));--csssolitaire-card-transform-x:calc(${CARD_HEIGHT / CARD_SOURCE_WIDTH} * var(--csssolitaire-presentation-scale));--csssolitaire-card-transform-y:calc(${CARD_WIDTH / CARD_SOURCE_HEIGHT} * var(--csssolitaire-presentation-scale))}`,
     ".polycss-scene.solitaire-prepared-scene{position:absolute;inset:0}",
-    ".csssolitaire-board{position:absolute;inset:0}",
-    `.csssolitaire-board>s{position:absolute;display:block;width:${CARD_SOURCE_WIDTH}px;height:${CARD_SOURCE_HEIGHT}px;margin:0;padding:0;overflow:hidden;border:0;border-radius:14px;background-image:url('${cardAssetUrl}');background-repeat:no-repeat;background-size:${CARD_ATLAS_WIDTH}px ${CARD_ATLAS_HEIGHT}px;transform:var(--csssolitaire-landscape-transform);transform-origin:0 0;visibility:hidden;pointer-events:none;text-decoration:none;font:normal normal normal 0/0 serif;image-rendering:auto}`,
-    ".csssolitaire-board>s.foundation{visibility:visible}",
-    `@media (orientation:portrait) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[0] - 1}px){.csssolitaire-board>s{transform:var(--csssolitaire-portrait-1-transform)}.csssolitaire-board>s:is(.lane-1,.lane-2,.lane-3){display:none}}`,
-    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[0]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[1] - 1}px){.csssolitaire-board>s{transform:var(--csssolitaire-portrait-2-transform)}.csssolitaire-board>s:is(.lane-2,.lane-3){display:none}}`,
-    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[1]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[2] - 1}px){.csssolitaire-board>s{transform:var(--csssolitaire-portrait-3-transform)}.csssolitaire-board>s.lane-3{display:none}}`,
-    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[2]}px){.csssolitaire-board>s{transform:var(--csssolitaire-portrait-4-transform)}}`,
+    `.polycss-scene.solitaire-prepared-scene>s{position:absolute;display:block;width:${CARD_SOURCE_WIDTH}px;height:${CARD_SOURCE_HEIGHT}px;margin:0;padding:0;overflow:hidden;border:0;border-radius:14px;background-image:url('${cardAssetUrl}');background-repeat:no-repeat;background-size:${CARD_ATLAS_WIDTH}px ${CARD_ATLAS_HEIGHT}px;transform-origin:0 0;visibility:hidden;pointer-events:none;text-decoration:none;font:normal normal normal 0/0 serif;image-rendering:auto}`,
+    ".polycss-scene.solitaire-prepared-scene>s.v{visibility:visible}",
+    faceRules,
+    landscapeRules,
+    `@media (orientation:portrait) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[0] - 1}px){${portraitRules[0]}.solitaire-prepared-scene>s:is(.lane-1,.lane-2,.lane-3){display:none}}`,
+    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[0]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[1] - 1}px){${portraitRules[1]}.solitaire-prepared-scene>s:is(.lane-2,.lane-3){display:none}}`,
+    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[1]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[2] - 1}px){${portraitRules[2]}.solitaire-prepared-scene>s.lane-3{display:none}}`,
+    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[2]}px){${portraitRules[3]}}`,
   ].join("");
-  return `<!doctype html><html><head><style>${css}</style></head><body><div class="polycss-camera solitaire-prepared-camera"><div class="polycss-scene solitaire-prepared-scene"><div class="csssolitaire-board">${cardNodes}</div></div></div></body></html>\n`;
+  return `<!doctype html><html><head><style>${css}</style></head><body><div class="polycss-camera solitaire-prepared-camera"><div class="polycss-scene solitaire-prepared-scene">${cardNodes}</div></div></body></html>\n`;
 }
 
 export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() } = {}) {

--- a/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
@@ -117,21 +117,24 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   const snapshot = await readFile(join(generated, "solitaire.polycss.txt"), "utf8");
   assert.match(snapshot, /class="polycss-camera solitaire-prepared-camera"/u);
   assert.match(snapshot, /class="polycss-scene solitaire-prepared-scene"/u);
-  assert.match(snapshot, /class="csssolitaire-board"/u);
-  assert.equal((snapshot.match(/<s class="[^"]+" style=/gu) ?? []).length, 1952);
-  assert.equal((snapshot.match(/--csssolitaire-landscape-transform:translate\(/gu) ?? []).length, 1952);
-  const portraitTransformCounts = [1, 2, 3, 4].map((cardCount) =>
-    (snapshot.match(new RegExp(`--csssolitaire-portrait-${cardCount}-transform:translate\\(`, "gu")) ?? []).length);
-  assert.ok(portraitTransformCounts.every((count, index) => index === 0 || count > portraitTransformCounts[index - 1]));
-  assert.equal(portraitTransformCounts[3], 1952);
-  assert.equal((snapshot.match(/transform:var\(--csssolitaire-landscape-transform\)/gu) ?? []).length, 1);
-  assert.equal((snapshot.match(/<s class="foundation lane-[0-3]"/gu) ?? []).length, 4);
+  assert.doesNotMatch(snapshot, /csssolitaire-board/u);
+  assert.equal((snapshot.match(/<s class="[^"]+"><\/s>/gu) ?? []).length, 1952);
+  assert.doesNotMatch(snapshot, /<s[^>]+\sstyle=/u);
+  assert.doesNotMatch(snapshot, /--csssolitaire-(?:landscape|portrait)-/u);
+  assert.equal((snapshot.match(/\.solitaire-prepared-scene>s\.l[0-9a-z]+\{transform:/gu) ?? []).length,
+    9760);
+  assert.equal((snapshot.match(/\.solitaire-prepared-scene>s\.l[0-9a-z]+\{transform:translate\(/gu) ?? []).length,
+    6223);
+  assert.equal((snapshot.match(/\{transform:none\}/gu) ?? []).length, 3537);
+  assert.equal((snapshot.match(/\.solitaire-prepared-scene>s\.f[0-9a-z]+\{background-position:/gu) ?? []).length,
+    52);
+  assert.equal((snapshot.match(/<s class="foundation v lane-[0-3] l[0-3] f[0-9a-z]+"><\/s>/gu) ?? []).length, 4);
   assert.match(snapshot, /\.polycss-scene\.solitaire-prepared-scene\{position:absolute;inset:0\}/u);
-  assert.match(snapshot, /\.csssolitaire-board\{position:absolute;inset:0\}/u);
+  assert.match(snapshot, /\.polycss-scene\.solitaire-prepared-scene>s\{position:absolute/u);
   assert.match(snapshot, /--csssolitaire-card-width:calc\(71px \* var\(--csssolitaire-presentation-scale/u);
-  assert.doesNotMatch(snapshot, /--csssolitaire-fit|\.csssolitaire-board\{[^}]*translate/u);
-  assert.match(snapshot, /max-width:519px\)\{\.csssolitaire-board>s\{transform:var\(--csssolitaire-portrait-1-transform\)\}/u);
-  assert.match(snapshot, /min-width:920px\)\{\.csssolitaire-board>s\{transform:var\(--csssolitaire-portrait-4-transform\)\}/u);
+  assert.doesNotMatch(snapshot, /--csssolitaire-fit/u);
+  assert.match(snapshot, /max-width:519px\)\{\.solitaire-prepared-scene>s\.l0\{transform:translate\(/u);
+  assert.match(snapshot, /min-width:920px\)\{\.solitaire-prepared-scene>s\.l0\{transform:translate\(/u);
   assert.match(snapshot, /border-radius:14px/u);
   assert.doesNotMatch(snapshot, /box-shadow/u);
   assert.match(snapshot, /image-rendering:auto/u);
@@ -175,6 +178,9 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.ok(playback.patterns.every((pattern) =>
     pattern.leafPortraitMatricesByCardCount.length === 4 &&
     pattern.leafPortraitMatricesByCardCount.every((profile) => profile.length === pattern.trailLeafCount)));
+  assert.ok(playback.patterns.every((pattern) =>
+    pattern.leafFoundationIndices.length === pattern.trailLeafCount &&
+    pattern.leafFoundationIndices.every((foundationIndex) => foundationIndex >= 0 && foundationIndex < 4)));
   const initialPattern = playback.patterns[0];
   const oneCardTransforms = initialPattern.leafPortraitMatricesByCardCount[0].filter(Boolean);
   assert.ok(oneCardTransforms.every((transform) => transform.includes("vw") && transform.includes("vh")));

--- a/src/adapters/solitaire/tools/smoke-browser.mjs
+++ b/src/adapters/solitaire/tools/smoke-browser.mjs
@@ -59,13 +59,27 @@ try {
           mutations.removed += record.removedNodes.length;
         }
       });
-      observer.observe(document.querySelector(".csssolitaire-board"), { childList: true, subtree: true });
+      observer.observe(document.querySelector(".solitaire-prepared-scene"), { childList: true, subtree: true });
       window.__cssSolitaireSmoke = { mutations, observer };
     });
 
     const sampled = await page.evaluate(() => [0, 1250, 3500, 6500, 10000, 13584, 13585, 14585, 26210, 27210]
       .map((timeMs) => window.__cssSolitaireDebug.seek(timeMs)));
     const [initial, firstArc, secondArc, middle, thirdArc, nearEnd, rewindStart, rewinding, rewound, wrapped] = sampled;
+    const visibleBounds = await page.evaluate(() => {
+      const durationMs = window.__cssSolitaireDebug.manifest.sourceProfile.patterns[0].durationMs;
+      window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
+      const rects = [...document.querySelectorAll(".solitaire-prepared-scene > s")]
+        .filter((leaf) => getComputedStyle(leaf).visibility === "visible")
+        .map((leaf) => leaf.getBoundingClientRect());
+      window.__cssSolitaireDebug.seek(0);
+      return {
+        left: Math.min(...rects.map((rect) => rect.left)),
+        top: Math.min(...rects.map((rect) => rect.top)),
+        right: Math.max(...rects.map((rect) => rect.right)),
+        bottom: Math.max(...rects.map((rect) => rect.bottom)),
+      };
+    });
     const autoplayLoop = await page.evaluate(async () => {
       window.__cssSolitaireDebug.seek(26787);
       window.__cssSolitaireDebug.resume();
@@ -85,7 +99,7 @@ try {
       return patternIds;
     }, initial.patternId);
     const evidence = await page.evaluate(() => {
-      const leaves = [...document.querySelectorAll(".csssolitaire-board > s")];
+      const leaves = [...document.querySelectorAll(".solitaire-prepared-scene > s")];
       const first = leaves[0];
       const rect = first.getBoundingClientRect();
       const foundationRects = leaves.slice(0, 4).map((leaf) => {
@@ -101,7 +115,6 @@ try {
       const scene = document.getElementById("scene");
       const camera = scene?.querySelector(":scope > .solitaire-prepared-camera");
       const preparedScene = camera?.querySelector(":scope > .solitaire-prepared-scene");
-      const board = preparedScene?.querySelector(":scope > .csssolitaire-board");
       const resources = performance.getEntriesByType("resource")
         .map((entry) => new URL(entry.name).pathname)
         .filter((path) => path.includes("csssolitaire"));
@@ -117,13 +130,14 @@ try {
           sceneChildCount: scene?.childElementCount,
           cameraChildCount: camera?.childElementCount,
           preparedSceneChildCount: preparedScene?.childElementCount,
-          boardChildCount: board?.childElementCount,
           sceneDescendantCount: scene?.querySelectorAll("*").length,
           unexpectedSceneElementCount: scene?.querySelectorAll(
             "button,canvas,nav,output,section,svg,style,[contenteditable]",
           ).length,
           dataAttributeCount: [...scene.querySelectorAll("*")].reduce((count, element) =>
             count + [...element.attributes].filter(({ name }) => name.startsWith("data-")).length, 0),
+          inlineStyleDeclarationCount: [...scene.querySelectorAll("*")].reduce((count, element) =>
+            count + element.style.length, 0),
         },
         radius: getComputedStyle(first).borderRadius,
         cardEdge: getComputedStyle(first).boxShadow,
@@ -138,15 +152,9 @@ try {
         },
         composition: {
           sceneTransformStyle: getComputedStyle(document.querySelector(".solitaire-prepared-scene")).transformStyle,
-          boardTransformStyle: getComputedStyle(document.querySelector(".csssolitaire-board")).transformStyle,
           matrix2dLeafCount: computedTransforms.filter((transform) => transform.startsWith("matrix(")).length,
           matrix3dLeafCount: computedTransforms.filter((transform) => transform.startsWith("matrix3d(")).length,
-          landscapePreparedTransformCount: leaves.filter((leaf) =>
-            leaf.style.getPropertyValue("--csssolitaire-landscape-transform").startsWith("translate(")).length,
-          portraitPreparedTransformCounts: [1, 2, 3, 4].map((cardCount) =>
-            leaves.filter((leaf) => leaf.style
-              .getPropertyValue(`--csssolitaire-portrait-${cardCount}-transform`)
-              .startsWith("translate(")).length),
+          leafInlineStyleDeclarationCount: leaves.reduce((count, leaf) => count + leaf.style.length, 0),
         },
       };
     });
@@ -173,9 +181,9 @@ try {
         JSON.stringify(evidence.structure.bodyChildren) !==
           JSON.stringify(deploy ? ["HEADER", "MAIN"] : ["HEADER", "MAIN", "SCRIPT"]) ||
         evidence.structure.sceneChildCount !== 1 || evidence.structure.cameraChildCount !== 1 ||
-        evidence.structure.preparedSceneChildCount !== 1 || evidence.structure.boardChildCount !== 1952 ||
-        evidence.structure.sceneDescendantCount !== 1955 ||
+        evidence.structure.preparedSceneChildCount !== 1952 || evidence.structure.sceneDescendantCount !== 1954 ||
         evidence.structure.unexpectedSceneElementCount !== 0 || evidence.structure.dataAttributeCount !== 0 ||
+        evidence.structure.inlineStyleDeclarationCount !== 0 ||
         evidence.radius !== "14px" ||
         evidence.cardEdge !== "none" ||
         evidence.imageRendering !== "auto" ||
@@ -188,12 +196,8 @@ try {
         evidence.shell.buttons !== 0 ||
         !evidence.shell.sceneBackground.startsWith("linear-gradient(rgb(0, 128, 0)") ||
         evidence.composition.sceneTransformStyle !== "flat" ||
-        evidence.composition.boardTransformStyle !== "flat" ||
         evidence.composition.matrix2dLeafCount !== 1952 || evidence.composition.matrix3dLeafCount !== 0 ||
-        evidence.composition.landscapePreparedTransformCount !== 1952 ||
-        evidence.composition.portraitPreparedTransformCounts[3] !== 1952 ||
-        evidence.composition.portraitPreparedTransformCounts.some((count, index, counts) =>
-          index > 0 && count <= counts[index - 1]) ||
+        evidence.composition.leafInlineStyleDeclarationCount !== 0 ||
         evidence.stats.runtimeAnimationFrameCallbackCount !== 0 ||
         evidence.stats.runtimeTimerCallbackCount < 1 || evidence.stats.loopCount < 1 ||
         evidence.stats.preparedPatternCount !== 24 ||
@@ -205,7 +209,7 @@ try {
         evidence.stats.runtimeGeometryBoundsCalculationCount !== 0 ||
         evidence.stats.runtimeFitCalculationPurpose !== "single-root-presentation-scale-only" ||
         Math.abs(evidence.stats.runtimePresentationScale - 1.40625) > 0.000001 ||
-        evidence.stats.runtimePresentationScaleWrites < 1 ||
+        evidence.stats.runtimePresentationScaleWrites !== 0 ||
         evidence.stats.runtimeTrajectoryCalculationCount !== 0 ||
         evidence.stats.runtimeAtlasRasterizationCount !== 0 ||
         evidence.stats.runtimeDomMutationCount !== 0 ||
@@ -215,28 +219,17 @@ try {
         evidence.resources.some((path) => path.endsWith("model.json"))) {
       throw new Error(`cssSolitaire smoke contract failed: ${JSON.stringify({ readyMs, sampled, evidence })}`);
     }
-    await page.evaluate(() => {
-      const state = window.__cssSolitaireDebug.snapshot();
-      const durationMs = window.__cssSolitaireDebug.manifest.sourceProfile.patterns[state.patternIndex].durationMs;
-      window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
-    });
-    const visibleBounds = await page.evaluate(() => {
-      const rects = [...document.querySelectorAll(".csssolitaire-board > s")]
-        .filter((leaf) => getComputedStyle(leaf).visibility === "visible")
-        .map((leaf) => leaf.getBoundingClientRect());
-      return {
-        left: Math.min(...rects.map((rect) => rect.left)),
-        top: Math.min(...rects.map((rect) => rect.top)),
-        right: Math.max(...rects.map((rect) => rect.right)),
-        bottom: Math.max(...rects.map((rect) => rect.bottom)),
-      };
-    });
     if (visibleBounds.left > -0.9 * evidence.cardRect.width ||
         visibleBounds.right < 960 + 0.9 * evidence.cardRect.width ||
         visibleBounds.top < 7.9 || visibleBounds.top > 80 ||
         Math.abs(visibleBounds.bottom - 540) > 0.2) {
       throw new Error(`cssSolitaire cards no longer exit the fixed playfield: ${JSON.stringify(visibleBounds)}`);
     }
+    await page.evaluate(() => {
+      const state = window.__cssSolitaireDebug.snapshot();
+      const durationMs = window.__cssSolitaireDebug.manifest.sourceProfile.patterns[state.patternIndex].durationMs;
+      window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
+    });
     await mkdir(dirname(screenshotPath), { recursive: true });
     const screenshot = await page.screenshot({ path: screenshotPath });
     const png = PNG.sync.read(screenshot);
@@ -252,7 +245,7 @@ try {
     await page.waitForTimeout(100);
     const mobileInitial = await page.evaluate(() => {
       window.__cssSolitaireDebug.seek(0);
-      const displayedFoundations = [...document.querySelectorAll(".csssolitaire-board > s.foundation")]
+      const displayedFoundations = [...document.querySelectorAll(".solitaire-prepared-scene > s.foundation")]
         .filter((foundation) => getComputedStyle(foundation).display !== "none");
       const leaf = displayedFoundations[0];
       const rect = leaf.getBoundingClientRect();
@@ -264,12 +257,11 @@ try {
       return {
         portraitMedia: matchMedia("(orientation: portrait)").matches,
         stable: window.__cssSolitaireDebug.assertStableDomIdentity(),
-        retainedLeaves: document.querySelectorAll(".csssolitaire-board > s").length,
+        retainedLeaves: document.querySelectorAll(".solitaire-prepared-scene > s").length,
         displayedFoundationCount: displayedFoundations.length,
         cardRect: { left: rect.left, top: rect.top, width: rect.width, height: rect.height },
         foundationRects,
         sceneTransform: getComputedStyle(document.querySelector(".solitaire-prepared-scene")).transform,
-        boardTransform: getComputedStyle(document.querySelector(".csssolitaire-board")).transform,
         mutations: { ...window.__cssSolitaireSmoke.mutations },
       };
     });
@@ -279,7 +271,7 @@ try {
       window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
     });
     const mobileEvidence = await page.evaluate(() => {
-      const visibleLeaves = [...document.querySelectorAll(".csssolitaire-board > s")]
+      const visibleLeaves = [...document.querySelectorAll(".solitaire-prepared-scene > s")]
         .filter((leaf) => {
           const style = getComputedStyle(leaf);
           return style.display !== "none" && style.visibility === "visible";
@@ -306,7 +298,7 @@ try {
         mobileInitial.cardRect.height <= mobileInitial.cardRect.width ||
         Math.abs(mobileInitial.cardRect.left - 158.9453125) > 0.1 ||
         Math.abs(mobileInitial.cardRect.top - 80) > 0.1 ||
-        mobileInitial.sceneTransform !== "none" || mobileInitial.boardTransform !== "none" ||
+        mobileInitial.sceneTransform !== "none" ||
         mobileInitial.mutations.added !== 0 || mobileInitial.mutations.removed !== 0 ||
         !mobileEvidence.stable || mobileEvidence.visibleLeaves <= 1 ||
         mobileEvidence.intersectingVisibleLeaves <= 4 ||
@@ -341,7 +333,7 @@ try {
       await page.waitForTimeout(50);
       const layout = await page.evaluate(() => {
         window.__cssSolitaireDebug.seek(0);
-        const cards = [...document.querySelectorAll(".csssolitaire-board > s.foundation")]
+        const cards = [...document.querySelectorAll(".solitaire-prepared-scene > s.foundation")]
           .filter((foundation) => getComputedStyle(foundation).display !== "none")
           .map((foundation) => {
             const rect = foundation.getBoundingClientRect();
@@ -350,7 +342,7 @@ try {
         const state = window.__cssSolitaireDebug.snapshot();
         const durationMs = window.__cssSolitaireDebug.manifest.sourceProfile.patterns[state.patternIndex].durationMs;
         window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
-        const visibleRects = [...document.querySelectorAll(".csssolitaire-board > s")]
+        const visibleRects = [...document.querySelectorAll(".solitaire-prepared-scene > s")]
           .filter((leaf) => {
             const style = getComputedStyle(leaf);
             return style.display !== "none" && style.visibility === "visible";
@@ -391,7 +383,7 @@ try {
       await page.waitForTimeout(50);
       const layout = await page.evaluate(() => {
         window.__cssSolitaireDebug.seek(0);
-        const cards = [...document.querySelectorAll(".csssolitaire-board > s.foundation")]
+        const cards = [...document.querySelectorAll(".solitaire-prepared-scene > s.foundation")]
           .map((foundation) => {
             const rect = foundation.getBoundingClientRect();
             return { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
@@ -399,7 +391,7 @@ try {
         const state = window.__cssSolitaireDebug.snapshot();
         const durationMs = window.__cssSolitaireDebug.manifest.sourceProfile.patterns[state.patternIndex].durationMs;
         window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
-        const visible = [...document.querySelectorAll(".csssolitaire-board > s")]
+        const visible = [...document.querySelectorAll(".solitaire-prepared-scene > s")]
           .filter((leaf) => getComputedStyle(leaf).visibility === "visible")
           .map((leaf) => leaf.getBoundingClientRect());
         return {


### PR DESCRIPTION
## Summary

- flatten the Solitaire prepared render graph to camera, scene, and direct card leaves
- remove per-card inline styles and custom-property transforms in favor of prepared stylesheet rules plus sparse class state
- keep all 1,952 leaves retained across the 24-pattern playback bank
- hide Solitaire from the landing catalog for now while preserving the direct `/solitaire/` deployment

## Validation

- `pnpm test:site`
- `pnpm test:solitaire`
- `pnpm test:solitaire:assets`
- `pnpm typecheck`
- `CSSSOLITAIRE_DEPLOY_BUILD=1 pnpm build:solitaire`
- `CSSGRAPHICS_DEPLOY_BUILD=1 pnpm build:site`
- `pnpm test:solitaire:deploy`
- `pnpm prepare:solitaire:check`
- exact local/current-production screenshots at 960x540 and 390x844: 0 changed pixels
- Chrome handoff trace: style work reduced 64.1%, compositor-main work reduced 47.0%, p99 frame interval reduced 37.4%

## Retained DOM contract

- 2 render wrappers
- 1,952 direct card leaves
- 0 board wrappers
- 0 leaf inline style declarations
- 0 runtime DOM additions or removals
