### PR TITLE
Fix Solitaire mobile playback continuity

### DIFF
--- a/src/adapters/solitaire/index.html
+++ b/src/adapters/solitaire/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" href="/favicon.ico" sizes="any">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="css.graphics">
-    <meta property="og:title" content="Solitaire Victory - Powered by PolyCSS">
+    <meta property="og:title" content="Solitaire - Powered by PolyCSS">
     <meta
       property="og:description"
       content="The classic Solitaire victory cascade rendered entirely with retained HTML and CSS using PolyCSS."
@@ -25,14 +25,14 @@
     <meta property="og:image:height" content="960">
     <meta property="og:image:alt" content="An upright playing-card victory cascade in the css.graphics shell">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Solitaire Victory - Powered by PolyCSS">
+    <meta name="twitter:title" content="Solitaire - Powered by PolyCSS">
     <meta
       name="twitter:description"
       content="The classic Solitaire victory cascade rendered entirely with retained HTML and CSS using PolyCSS."
     >
     <meta name="twitter:image" content="https://css.graphics/landing/solitaire.webp">
     <meta name="twitter:image:alt" content="An upright playing-card victory cascade in the css.graphics shell">
-    <title>Solitaire Victory - Powered by PolyCSS</title>
+    <title>Solitaire - Powered by PolyCSS</title>
   </head>
   <body class="loading">
     <header class="site-header">

--- a/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
@@ -64,7 +64,7 @@ function validateManifest(manifest) {
       JSON.stringify(manifest.renderer?.landscapePresentationBase) !== "[960,540]" ||
       manifest.renderer?.landscapePresentationBaseScale !== 1.40625 ||
       JSON.stringify(manifest.renderer?.portraitPresentationBase) !== "[384,720]" ||
-      manifest.renderer?.portraitMapping !== "progressive-card-count-prepared-wall-reflection" ||
+      manifest.renderer?.portraitMapping !== "progressive-card-count-prepared-source-lane-folding" ||
       JSON.stringify(manifest.renderer?.portraitReflectionReferenceWidths) !== "[384,600,800,960]" ||
       JSON.stringify(manifest.renderer?.portraitCardCounts) !== "[1,2,3,4]" ||
       JSON.stringify(manifest.renderer?.portraitCardBreakpoints) !== "[520,720,920]" ||

--- a/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
+++ b/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
@@ -167,13 +167,13 @@ function landscapeCardPosition(left, top, foundationIndex, horizontalDirection) 
 }
 
 function portraitCardPosition(left, top, foundationIndex, horizontalDirection, profile) {
-  if (foundationIndex >= profile.cardCount) return null;
   const [width, height] = profile.playfield;
   const presentationScale = Math.min(width / 384, height / 720);
   const cardWidth = CARD_WIDTH * presentationScale;
+  const displayFoundationIndex = foundationIndex % profile.cardCount;
   const startLeft = profile.cardCount === 1
     ? (width - cardWidth) / 2
-    : solitaireSlotLeft(width, STARTING_CARDS[foundationIndex].slot, cardWidth);
+    : solitaireSlotLeft(width, STARTING_CARDS[displayFoundationIndex].slot, cardWidth);
   const sourceStartLeft = STARTING_CARDS[foundationIndex].x;
   const unboundedLeft = startLeft +
     (left - sourceStartLeft) * PORTRAIT_HORIZONTAL_DISTANCE_SCALE * presentationScale;
@@ -523,9 +523,9 @@ function buildSnapshot(leaves, cardAssetUrl) {
     ".polycss-scene.solitaire-prepared-scene>s.v{visibility:visible}",
     faceRules,
     landscapeRules,
-    `@media (orientation:portrait) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[0] - 1}px){${portraitRules[0]}.solitaire-prepared-scene>s:is(.lane-1,.lane-2,.lane-3){display:none}}`,
-    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[0]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[1] - 1}px){${portraitRules[1]}.solitaire-prepared-scene>s:is(.lane-2,.lane-3){display:none}}`,
-    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[1]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[2] - 1}px){${portraitRules[2]}.solitaire-prepared-scene>s.lane-3{display:none}}`,
+    `@media (orientation:portrait) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[0] - 1}px){${portraitRules[0]}.solitaire-prepared-scene>s.foundation:is(.lane-1,.lane-2,.lane-3){display:none}}`,
+    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[0]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[1] - 1}px){${portraitRules[1]}.solitaire-prepared-scene>s.foundation:is(.lane-2,.lane-3){display:none}}`,
+    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[1]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[2] - 1}px){${portraitRules[2]}.solitaire-prepared-scene>s.foundation.lane-3{display:none}}`,
     `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[2]}px){${portraitRules[3]}}`,
   ].join("");
   return `<!doctype html><html><head><style>${css}</style></head><body><div class="polycss-camera solitaire-prepared-camera"><div class="polycss-scene solitaire-prepared-scene">${cardNodes}</div></div></body></html>\n`;
@@ -651,7 +651,7 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       landscapePresentationBase: LANDSCAPE_PLAYFIELD,
       landscapePresentationBaseScale: LANDSCAPE_PRESENTATION_SCALE,
       portraitPresentationBase: PORTRAIT_PROFILES[0].playfield,
-      portraitMapping: "progressive-card-count-prepared-wall-reflection",
+      portraitMapping: "progressive-card-count-prepared-source-lane-folding",
       portraitReflectionReferenceWidths: PORTRAIT_PROFILES.map(({ playfield }) => playfield[0]),
       portraitCardCounts: PORTRAIT_CARD_COUNTS,
       portraitCardBreakpoints: PORTRAIT_CARD_BREAKPOINTS,

--- a/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
@@ -59,7 +59,8 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.deepEqual(manifest.renderer.landscapePresentationBase, [960, 540]);
   assert.equal(manifest.renderer.landscapePresentationBaseScale, 1.40625);
   assert.deepEqual(manifest.renderer.portraitPresentationBase, [384, 720]);
-  assert.equal(manifest.renderer.portraitMapping, "progressive-card-count-prepared-wall-reflection");
+  assert.equal(manifest.renderer.portraitMapping,
+    "progressive-card-count-prepared-source-lane-folding");
   assert.deepEqual(manifest.renderer.portraitReflectionReferenceWidths, [384, 600, 800, 960]);
   assert.deepEqual(manifest.renderer.portraitCardCounts, [1, 2, 3, 4]);
   assert.deepEqual(manifest.renderer.portraitCardBreakpoints, [520, 720, 920]);
@@ -124,8 +125,8 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.equal((snapshot.match(/\.solitaire-prepared-scene>s\.l[0-9a-z]+\{transform:/gu) ?? []).length,
     9760);
   assert.equal((snapshot.match(/\.solitaire-prepared-scene>s\.l[0-9a-z]+\{transform:translate\(/gu) ?? []).length,
-    6223);
-  assert.equal((snapshot.match(/\{transform:none\}/gu) ?? []).length, 3537);
+    9760);
+  assert.equal((snapshot.match(/\{transform:none\}/gu) ?? []).length, 0);
   assert.equal((snapshot.match(/\.solitaire-prepared-scene>s\.f[0-9a-z]+\{background-position:/gu) ?? []).length,
     52);
   assert.equal((snapshot.match(/<s class="foundation v lane-[0-3] l[0-3] f[0-9a-z]+"><\/s>/gu) ?? []).length, 4);
@@ -135,6 +136,10 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.doesNotMatch(snapshot, /--csssolitaire-fit/u);
   assert.match(snapshot, /max-width:519px\)\{\.solitaire-prepared-scene>s\.l0\{transform:translate\(/u);
   assert.match(snapshot, /min-width:920px\)\{\.solitaire-prepared-scene>s\.l0\{transform:translate\(/u);
+  assert.match(snapshot,
+    /max-width:519px\)\{.*\.solitaire-prepared-scene>s\.foundation:is\(\.lane-1,\.lane-2,\.lane-3\)\{display:none\}/u);
+  assert.doesNotMatch(snapshot,
+    /\.solitaire-prepared-scene>s:is\(\.lane-1,\.lane-2,\.lane-3\)\{display:none\}/u);
   assert.match(snapshot, /border-radius:14px/u);
   assert.doesNotMatch(snapshot, /box-shadow/u);
   assert.match(snapshot, /image-rendering:auto/u);
@@ -177,12 +182,23 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   })));
   assert.ok(playback.patterns.every((pattern) =>
     pattern.leafPortraitMatricesByCardCount.length === 4 &&
-    pattern.leafPortraitMatricesByCardCount.every((profile) => profile.length === pattern.trailLeafCount)));
+    pattern.leafPortraitMatricesByCardCount.every((profile) =>
+      profile.length === pattern.trailLeafCount && profile.every(Boolean))));
   assert.ok(playback.patterns.every((pattern) =>
     pattern.leafFoundationIndices.length === pattern.trailLeafCount &&
     pattern.leafFoundationIndices.every((foundationIndex) => foundationIndex >= 0 && foundationIndex < 4)));
+  const maximumPortraitUpdateGaps = [1, 2, 3, 4].map((cardCount) => Math.max(
+    ...playback.patterns.map((pattern) => {
+      const updateTimes = pattern.frameTimesMs.filter((_, frameIndex) =>
+        pattern.visibilityRows[frameIndex].length > 0 ||
+        pattern.foundationRows[frameIndex].some(([foundationIndex]) => foundationIndex < cardCount));
+      return Math.max(...updateTimes.slice(1).map((time, index) => time - updateTimes[index]));
+    }),
+  ));
+  assert.deepEqual(maximumPortraitUpdateGaps, [500, 500, 500, 500]);
   const initialPattern = playback.patterns[0];
-  const oneCardTransforms = initialPattern.leafPortraitMatricesByCardCount[0].filter(Boolean);
+  const oneCardTransforms = initialPattern.leafPortraitMatricesByCardCount[0];
+  assert.equal(oneCardTransforms.length, initialPattern.trailLeafCount);
   assert.ok(oneCardTransforms.every((transform) => transform.includes("vw") && transform.includes("vh")));
   assert.ok(new Set(oneCardTransforms).size > 100);
   assert.equal(initialPattern.sourceStepCount, 1679);

--- a/src/adapters/solitaire/test/csssolitaire-shell.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-shell.test.mjs
@@ -14,6 +14,9 @@ test("product shell is the standard css.graphics route without demo controls", a
     readFile(resolve(adapterRoot, "src/csssolitaire/polycssScene.mjs"), "utf8"),
   ]);
   assert.match(html, /css\.graphics\/solitaire/u);
+  assert.match(html, /<title>Solitaire - Powered by PolyCSS<\/title>/u);
+  assert.match(html, /property="og:title" content="Solitaire - Powered by PolyCSS"/u);
+  assert.match(html, /name="twitter:title" content="Solitaire - Powered by PolyCSS"/u);
   assert.match(html, /class="site-header"/u);
   assert.match(html, /class="site-wordmark-svg"/u);
   assert.match(html, /href="https:\/\/github\.com\/layoutit\/cssGraphics"/u);

--- a/src/adapters/solitaire/tools/smoke-browser.mjs
+++ b/src/adapters/solitaire/tools/smoke-browser.mjs
@@ -414,12 +414,13 @@ try {
       throw new Error(`cssSolitaire viewport fill drifted: ${JSON.stringify(landscapeViewports)}`);
     }
     const reducedMotionMobileAutoplay = await captureReducedMotionMobileAutoplay(browser, port, route);
+    const mobileContinuity = await captureMobileContinuity(browser, port, route);
     await page.evaluate(() => window.__cssSolitaireSmoke.observer.disconnect());
     process.stdout.write(`${JSON.stringify({
       status: "passed", headless: true, browser: browser.version(), deploy, route,
       readyMs, sampled, autoplayLoop, bankSequence, evidence, visibleBounds, cardPixelRatio, screenshotPath,
       mobileInitial, mobileEvidence, mobileCardPixelRatio, mobileScreenshotPath,
-      responsiveCardCounts, landscapeViewports, reducedMotionMobileAutoplay,
+      responsiveCardCounts, landscapeViewports, reducedMotionMobileAutoplay, mobileContinuity,
     }, null, 2)}\n`);
   } finally {
     await browser.close();
@@ -470,6 +471,43 @@ async function captureReducedMotionMobileAutoplay(browser, port, route) {
         result.advanced.frameIndex <= result.initial.frameIndex ||
         result.timerCallbacks === 0 || result.visibilityWrites === 0) {
       throw new Error(`cssSolitaire reduced-motion mobile autoplay failed: ${JSON.stringify(result)}`);
+    }
+    return result;
+  } finally {
+    await page.close();
+  }
+}
+
+async function captureMobileContinuity(browser, port, route) {
+  const page = await browser.newPage({
+    viewport: { width: 390, height: 844 },
+    screen: { width: 390, height: 844 },
+    deviceScaleFactor: 3,
+    isMobile: true,
+    hasTouch: true,
+  });
+  try {
+    await page.goto(`http://127.0.0.1:${port}${route}`, { waitUntil: "networkidle" });
+    await page.waitForFunction(() => window.__cssSolitaireDebug?.ready === true ||
+      window.__cssSolitaireDebug?.errors().length > 0, null, { timeout: 30_000 });
+    const result = await page.evaluate(() => {
+      window.__cssSolitaireDebug.pause();
+      return {
+        samples: [1_000, 2_000, 3_000, 4_000].map((timeMs) => {
+          window.__cssSolitaireDebug.seek(timeMs);
+          const visiblePaintedLeaves = [...document.querySelectorAll(".solitaire-prepared-scene > s")]
+            .filter((leaf) => {
+              const style = getComputedStyle(leaf);
+              return style.display !== "none" && style.visibility === "visible";
+            }).length;
+          return { timeMs, visiblePaintedLeaves };
+        }),
+        errors: window.__cssSolitaireDebug.errors(),
+      };
+    });
+    if (result.errors.length || result.samples.some((sample, index) =>
+      index > 0 && sample.visiblePaintedLeaves <= result.samples[index - 1].visiblePaintedLeaves)) {
+      throw new Error(`cssSolitaire mobile continuity failed: ${JSON.stringify(result)}`);
     }
     return result;
   } finally {


### PR DESCRIPTION
## Summary

- fold every prepared Solitaire source lane into the available portrait card slots
- hide only surplus foundation cards instead of hiding active trail lanes
- remove "Victory" from the document and social titles
- add prepared-timeline and real mobile-browser continuity regressions

## Root cause

Portrait layouts displayed one to three foundation lanes but the prepared timeline continued advancing through all four source lanes. The CSS hid the complete surplus lanes, including their trail leaves, so playback kept running while the phone showed no visible updates for several seconds.

## Validation

- `pnpm prepare:solitaire`
- `pnpm prepare:solitaire:check`
- `pnpm test:solitaire`
- `pnpm test:solitaire:assets`
- `pnpm typecheck`
- `pnpm verify:source-only`
- `CSSSOLITAIRE_DEPLOY_BUILD=1 pnpm build:solitaire`
- `CSSGRAPHICS_DEPLOY_BUILD=1 pnpm build:site`
- `pnpm test:solitaire:browser`
- `pnpm test:solitaire:deploy`

The maximum prepared portrait update gap is now 500 ms for all four responsive profiles. The 390x844 mobile smoke observes visible painted leaves increasing 68 to 202 to 335 to 468 over the first four seconds, with 1,952 retained leaves and no DOM growth.
