### PR TITLE
Cap Solitaire desktop card width

### DIFF
--- a/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
@@ -63,6 +63,7 @@ function validateManifest(manifest) {
       JSON.stringify(manifest.renderer?.cardSourceSize) !== "[71,96]" ||
       JSON.stringify(manifest.renderer?.landscapePresentationBase) !== "[960,540]" ||
       manifest.renderer?.landscapePresentationBaseScale !== 1.40625 ||
+      manifest.renderer?.landscapeCardMaximumWidthCssPixels !== 200 ||
       JSON.stringify(manifest.renderer?.portraitPresentationBase) !== "[384,720]" ||
       manifest.renderer?.portraitMapping !== "progressive-card-count-prepared-source-lane-folding" ||
       JSON.stringify(manifest.renderer?.portraitReflectionReferenceWidths) !== "[384,600,800,960]" ||

--- a/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
@@ -45,9 +45,12 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
         width / manifest.renderer.portraitPresentationBase[0],
         height / manifest.renderer.portraitPresentationBase[1],
       )
-      : manifest.renderer.landscapePresentationBaseScale * Math.min(
-        width / manifest.renderer.landscapePresentationBase[0],
-        height / manifest.renderer.landscapePresentationBase[1],
+      : Math.min(
+        manifest.renderer.landscapeCardMaximumWidthCssPixels / manifest.renderer.cardSourceSize[0],
+        manifest.renderer.landscapePresentationBaseScale * Math.min(
+          width / manifest.renderer.landscapePresentationBase[0],
+          height / manifest.renderer.landscapePresentationBase[1],
+        ),
       );
     const serialized = String(Number(presentationScale.toFixed(8)));
     if (ruleBank.presentation.style.getPropertyValue("--csssolitaire-presentation-scale") !== serialized) {

--- a/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
+++ b/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
@@ -37,6 +37,7 @@ const CARD_RED_SOURCE = Object.freeze([255, 85, 85]);
 const CARD_RED_COLOR = Object.freeze([230, 24, 10]);
 const CARD_WIDTH = 71;
 const CARD_HEIGHT = 96;
+const LANDSCAPE_CARD_MAXIMUM_WIDTH = 200;
 const FLOOR_Y = SOURCE_HEIGHT - CARD_HEIGHT;
 const SOURCE_BOUNCE_BOTTOM = 299;
 const FOUNDATION_Y = 4;
@@ -650,6 +651,7 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       cardSourceSize: [CARD_WIDTH, CARD_HEIGHT],
       landscapePresentationBase: LANDSCAPE_PLAYFIELD,
       landscapePresentationBaseScale: LANDSCAPE_PRESENTATION_SCALE,
+      landscapeCardMaximumWidthCssPixels: LANDSCAPE_CARD_MAXIMUM_WIDTH,
       portraitPresentationBase: PORTRAIT_PROFILES[0].playfield,
       portraitMapping: "progressive-card-count-prepared-source-lane-folding",
       portraitReflectionReferenceWidths: PORTRAIT_PROFILES.map(({ playfield }) => playfield[0]),

--- a/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
@@ -58,6 +58,7 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.deepEqual(manifest.renderer.cardSourceSize, [71, 96]);
   assert.deepEqual(manifest.renderer.landscapePresentationBase, [960, 540]);
   assert.equal(manifest.renderer.landscapePresentationBaseScale, 1.40625);
+  assert.equal(manifest.renderer.landscapeCardMaximumWidthCssPixels, 200);
   assert.deepEqual(manifest.renderer.portraitPresentationBase, [384, 720]);
   assert.equal(manifest.renderer.portraitMapping,
     "progressive-card-count-prepared-source-lane-folding");

--- a/src/adapters/solitaire/tools/smoke-browser.mjs
+++ b/src/adapters/solitaire/tools/smoke-browser.mjs
@@ -378,6 +378,7 @@ try {
       { width: 960, height: 540, expectedSize: [99.84375, 135], expectedLefts: [430.078125, 562.558594, 695.039063, 827.519531] },
       { width: 1_280, height: 720, expectedSize: [133.125, 180], expectedLefts: [573.4375, 750.078125, 926.71875, 1_103.359375] },
       { width: 1_440, height: 900, expectedSize: [149.765625, 202.5], expectedLefts: [645.117188, 843.837891, 1_042.558594, 1_241.279297] },
+      { width: 2_560, height: 1_440, expectedSize: [200, 270.422535], expectedLefts: [1_180, 1_525, 1_870, 2_215] },
     ]) {
       await page.setViewportSize(viewport);
       await page.waitForTimeout(50);


### PR DESCRIPTION
## Summary

- cap landscape Solitaire cards at exactly 200 CSS pixels wide
- keep portrait and smaller landscape presentation sizes unchanged
- validate the cap in the prepared manifest and browser smoke at 2560x1440

## Validation

- `pnpm prepare:solitaire`
- `pnpm test:solitaire:assets`
- `pnpm test:solitaire`
- `pnpm typecheck`
- `CSSSOLITAIRE_DEPLOY_BUILD=1 pnpm build:solitaire`
- `CSSGRAPHICS_DEPLOY_BUILD=1 pnpm build:site`
- `pnpm test:solitaire:deploy`

The production-build browser smoke observes every foundation card at exactly 200 by 270.422535 CSS pixels on a 2560x1440 viewport. The existing 1440x900 presentation remains 149.765625 by 202.5 CSS pixels, and the responsive mobile contracts remain unchanged.
