### PR TITLE
fix(solitaire): simplify prepared card DOM

### DIFF
--- a/src/adapters/solitaire/index.html
+++ b/src/adapters/solitaire/index.html
@@ -37,8 +37,8 @@
   <body class="loading">
     <header class="site-header">
       <h1 class="site-wordmark-heading">
-        <a class="site-wordmark" href="/" aria-label="Solitaire Victory - css.graphics home">
-          <svg class="site-wordmark-svg" viewBox="0 0 218 30" aria-hidden="true" focusable="false">
+        <a class="site-wordmark" href="/">
+          <svg class="site-wordmark-svg" viewBox="0 0 218 30">
             <text x="0" y="23"><tspan class="site-wordmark-css">css.</tspan><tspan class="site-wordmark-graphics">graphics</tspan><tspan class="site-wordmark-path">/solitaire</tspan></text>
           </svg>
         </a>
@@ -59,7 +59,7 @@
         </svg>
       </a>
     </header>
-    <main id="scene" aria-label="Classic Solitaire victory card cascade" aria-busy="true"></main>
+    <main id="scene"></main>
     <script type="module" src="/src/main.mjs"></script>
   </body>
 </html>

--- a/src/adapters/solitaire/src/csssolitaire/client.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/client.mjs
@@ -25,7 +25,7 @@ export function mountCsssolitaireClient() {
       playback: prepared.playback,
       scene: state.mount.scene,
       leaves: state.mount.leaves,
-      layoutRulesByProfile: state.mount.layoutRulesByProfile,
+      portraitBreakpoints: prepared.manifest.renderer.portraitCardBreakpoints,
     });
     state.ready = true;
     setBodyState("ready");
@@ -46,7 +46,6 @@ export function mountCsssolitaireClient() {
   function setBodyState(kind) {
     document.body.classList.remove("loading", "ready", "error");
     document.body.classList.add(kind);
-    host?.setAttribute("aria-busy", kind === "loading" ? "true" : "false");
   }
 }
 

--- a/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
@@ -40,9 +40,11 @@ function validateManifest(manifest) {
       manifest.renderer?.morphTarget !== "createPolyMorphPreparedDomTarget" ||
       manifest.renderer?.profile !== "prepared-playback" ||
       manifest.renderer?.retainedDom !== true ||
+      manifest.renderer?.leafTag !== "b" ||
       manifest.renderer?.textureBackend !== "atlas" ||
       manifest.renderer?.textureLeafSizing !== "raster" ||
       manifest.renderer?.composition !== "flat-2d-card-plane" ||
+      manifest.renderer?.transformPublication !== "prepared-inline-style" ||
       manifest.renderer?.seamBleed !== 0.2 ||
       manifest.renderer?.runtimeCanvasCount !== 0 ||
       manifest.renderer?.runtimeAtlasRasterization !== false ||
@@ -75,7 +77,8 @@ function validateManifest(manifest) {
       manifest.renderer?.preparedSlotLayout !== "source-seven-slot-presentation-scaled-card-size" ||
       manifest.renderer?.slotCount !== 7 || manifest.renderer?.minimumSlotGap !== 11 ||
       manifest.renderer?.presentationScaleMode !== "single-root-contain-scale-viewport-positioned" ||
-      manifest.renderer?.runtimeResizeCalculation !== "single-root-presentation-scale-only" ||
+      manifest.renderer?.runtimeResizeCalculation !==
+        "single-root-scale-and-responsive-inline-transform-publication" ||
       manifest.transport?.snapshotUrl !== "/csssolitaire/solitaire.polycss.txt" ||
       manifest.transport?.runtimeModelPayload !== false ||
       manifest.sourceProfile?.cards !== 12 ||
@@ -130,6 +133,14 @@ function validatePlayback(playback, manifest) {
       playback.foundationLeafCount !== manifest.metrics.foundationLeafCount ||
       playback.retainedLeafCount !== manifest.metrics.retainedLeafCount ||
       playback.retainedTrailLeafCount !== manifest.metrics.retainedTrailLeafCount ||
+      !Array.isArray(playback.foundationMatrices) ||
+      playback.foundationMatrices.length !== playback.foundationLeafCount ||
+      playback.foundationMatrices.some((transform) => !validPreparedTransform(transform)) ||
+      !Array.isArray(playback.foundationPortraitMatricesByCardCount) ||
+      playback.foundationPortraitMatricesByCardCount.length !== 4 ||
+      playback.foundationPortraitMatricesByCardCount.some((profile) =>
+        !Array.isArray(profile) || profile.length !== playback.foundationLeafCount ||
+        profile.some((transform) => !validPreparedTransform(transform))) ||
       !Array.isArray(playback.atlasPositions) || playback.atlasPositions.length !== 52 ||
       playback.atlasPositions.some((position) => !/^-?\d+px -?\d+px$/u.test(position)) ||
       !Array.isArray(playback.patterns) || playback.patterns.length !== playback.patternCount ||
@@ -192,11 +203,6 @@ function validPattern(pattern, playback, manifest, index) {
     !Array.from({ length: pattern.trailLeafCount }, (_, leafIndex) => leafIndex).some((leafIndex) =>
       pattern.leafPortraitMatricesByCardCount.some((profile, profileIndex, profiles) =>
         profileIndex > 0 && profiles[profileIndex - 1][leafIndex] !== null && profile[leafIndex] === null)) &&
-    Array.isArray(pattern.leafFoundationIndices) &&
-    pattern.leafFoundationIndices.length === pattern.trailLeafCount &&
-    !pattern.leafFoundationIndices.some((foundationIndex) =>
-      !Number.isSafeInteger(foundationIndex) || foundationIndex < 0 ||
-      foundationIndex >= playback.foundationLeafCount) &&
     Array.isArray(pattern.leafAtlasIndices) && pattern.leafAtlasIndices.length === pattern.trailLeafCount &&
     !pattern.leafAtlasIndices.some((atlasIndex) =>
       !Number.isSafeInteger(atlasIndex) || atlasIndex < 0 || atlasIndex >= playback.atlasPositions.length);

--- a/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
@@ -4,33 +4,35 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
   if (!(host instanceof HTMLElement)) throw new Error("Missing cssSolitaire host");
   if (typeof snapshotHtml !== "string") throw new Error("Prepared cssSolitaire snapshot is required");
   const snapshot = new DOMParser().parseFromString(snapshotHtml, "text/html");
-  if (snapshot.querySelector("script,canvas,svg,[style]") ||
+  if (snapshot.querySelector("script,canvas,svg") ||
       snapshot.querySelectorAll("style").length !== 1 || hasPreparedMetadata(snapshot)) {
     throw new Error("Prepared cssSolitaire snapshot contains a forbidden or incomplete graph");
   }
   const style = snapshot.querySelector("style");
-  const camera = snapshot.querySelector(".solitaire-prepared-camera");
-  const scene = camera?.querySelector(":scope > .solitaire-prepared-scene");
-  const leaves = [...(scene?.querySelectorAll(":scope > s") ?? [])];
+  const camera = snapshot.querySelector(".polycss-camera");
+  const scene = camera?.querySelector(":scope > .polycss-scene");
+  const leaves = [...(scene?.querySelectorAll(":scope > b") ?? [])];
   if (!(style instanceof HTMLStyleElement) || !(camera instanceof HTMLElement) ||
       !(scene instanceof HTMLElement) || scene.childElementCount !== manifest.metrics.retainedLeafCount ||
       leaves.length !== manifest.metrics.retainedLeafCount ||
-      leaves.some((leaf) => !(leaf instanceof HTMLElement) || leaf.localName !== "s" || leaf.style.length !== 0)) {
+      snapshot.querySelectorAll("[style]").length !== leaves.length ||
+      leaves.some((leaf) => !(leaf instanceof HTMLElement) || leaf.localName !== "b" ||
+        !hasInlineTransformOnly(leaf))) {
     throw new Error("Prepared cssSolitaire retained DOM census drifted");
   }
 
   mountedStyle?.remove();
   mountedStyle = document.importNode(style, true);
   document.head.append(mountedStyle);
-  const ruleBank = collectPreparedRuleBank(mountedStyle, manifest.metrics.retainedLeafCount);
+  const ruleBank = collectPreparedRuleBank(mountedStyle);
   const mountedCamera = document.importNode(camera, true);
   host.replaceChildren(mountedCamera);
-  const mountedScene = mountedCamera.querySelector(":scope > .solitaire-prepared-scene");
-  const mountedLeaves = [...(mountedScene?.querySelectorAll(":scope > s") ?? [])];
+  const mountedScene = mountedCamera.querySelector(":scope > .polycss-scene");
+  const mountedLeaves = [...(mountedScene?.querySelectorAll(":scope > b") ?? [])];
   if (!(mountedScene instanceof HTMLElement) ||
       mountedScene.childElementCount !== manifest.metrics.retainedLeafCount ||
       mountedLeaves.length !== manifest.metrics.retainedLeafCount ||
-      mountedLeaves.some((leaf) => leaf.style.length !== 0)) {
+      mountedLeaves.some((leaf) => !hasInlineTransformOnly(leaf))) {
     throw new Error("Mounted cssSolitaire retained DOM census drifted");
   }
   const stableNodes = Object.freeze([mountedCamera, mountedScene, ...mountedLeaves]);
@@ -65,12 +67,12 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
 
   function assertStableDomIdentity() {
     const current = [
-      host.querySelector(":scope > .solitaire-prepared-camera"),
-      host.querySelector(":scope > .solitaire-prepared-camera > .solitaire-prepared-scene"),
-      ...host.querySelectorAll(":scope > .solitaire-prepared-camera > .solitaire-prepared-scene > s"),
+      host.querySelector(":scope > .polycss-camera"),
+      host.querySelector(":scope > .polycss-camera > .polycss-scene"),
+      ...host.querySelectorAll(":scope > .polycss-camera > .polycss-scene > b"),
     ];
     if (current.length !== stableNodes.length || current.some((node, index) => node !== stableNodes[index]) ||
-        mountedLeaves.some((leaf) => leaf.style.length !== 0)) {
+        mountedLeaves.some((leaf) => !hasInlineTransformOnly(leaf))) {
       throw new Error("Prepared cssSolitaire retained DOM identity changed");
     }
     return true;
@@ -80,7 +82,6 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
     camera: mountedCamera,
     scene: mountedScene,
     leaves: Object.freeze(mountedLeaves),
-    layoutRulesByProfile: ruleBank.layouts,
     assertStableDomIdentity,
     stats() {
       assertStableDomIdentity();
@@ -91,7 +92,7 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
         retainedBoardRootCount: 0,
         retainedRenderWrapperCount: 2,
         retainedPolygonLeafCount: mountedLeaves.length,
-        retainedLeafInlineStyleDeclarationCount: 0,
+        retainedLeafInlineStyleDeclarationCount: mountedLeaves.length,
         retainedDataAttributeCount: 0,
         runtimeDomCreationCount: 0,
         runtimeDomRemovalCount: 0,
@@ -114,38 +115,20 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
   });
 }
 
-function collectPreparedRuleBank(style, retainedLeafCount) {
+function collectPreparedRuleBank(style) {
   const sheet = style.sheet;
   if (!(sheet instanceof CSSStyleSheet)) throw new Error("Prepared cssSolitaire stylesheet did not mount");
   const topLevelRules = [...sheet.cssRules];
   const presentation = topLevelRules.find((rule) =>
-    rule.selectorText === ".polycss-camera.solitaire-prepared-camera");
-  const mediaRules = topLevelRules.filter((rule) => rule.type === CSSRule.MEDIA_RULE);
-  const layouts = [
-    collectLayoutRules(topLevelRules, retainedLeafCount),
-    ...mediaRules.map((rule) => collectLayoutRules([...rule.cssRules], retainedLeafCount)),
-  ];
-  if (!presentation || layouts.length !== 5 || layouts.some((rules) => rules.some((rule) => !rule))) {
+    rule.selectorText === ".polycss-camera");
+  if (!presentation) {
     throw new Error("Prepared cssSolitaire stylesheet rule bank drifted");
   }
-  return Object.freeze({
-    presentation,
-    layouts: Object.freeze(layouts.map((rules) => Object.freeze(rules))),
-  });
+  return Object.freeze({ presentation });
 }
 
-function collectLayoutRules(rules, retainedLeafCount) {
-  const result = Array(retainedLeafCount).fill(null);
-  for (const rule of rules) {
-    const match = rule.selectorText?.match(/^\.solitaire-prepared-scene\s*>\s*s\.l([0-9a-z]+)$/u);
-    if (!match) continue;
-    const index = Number.parseInt(match[1], 36);
-    if (!Number.isSafeInteger(index) || index < 0 || index >= retainedLeafCount || result[index]) {
-      throw new Error("Prepared cssSolitaire leaf rule index drifted");
-    }
-    result[index] = rule;
-  }
-  return result;
+function hasInlineTransformOnly(leaf) {
+  return leaf.style.length === 1 && leaf.style[0] === "transform" && leaf.style.transform.length > 0;
 }
 
 function hasPreparedMetadata(doc) {

--- a/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
@@ -4,14 +4,13 @@ export function createCsssolitairePreparedPlayer({
   playback,
   scene,
   leaves,
-  layoutRulesByProfile,
+  portraitBreakpoints,
   randomUint32 = cryptoRandomUint32,
 }) {
   if (playback?.schema !== "csssolitaire-prepared-playback@2" ||
       !(scene instanceof HTMLElement) || !Array.isArray(leaves) ||
-      leaves.length !== playback.retainedLeafCount || !Array.isArray(layoutRulesByProfile) ||
-      layoutRulesByProfile.length !== 5 ||
-      layoutRulesByProfile.some((rules) => !Array.isArray(rules) || rules.length !== leaves.length)) {
+      leaves.length !== playback.retainedLeafCount ||
+      JSON.stringify(portraitBreakpoints) !== "[520,720,920]") {
     throw new Error("Prepared cssSolitaire player input drifted");
   }
   const target = createPolyMorphPreparedDomTarget({
@@ -36,18 +35,11 @@ export function createCsssolitairePreparedPlayer({
   const foundationVisibility = new Uint8Array(foundationLeafCount);
   foundationVisibility.fill(1);
   const trailVisibility = new Uint8Array(trailLeaves.length);
-  const trailLandscapeTransforms = layoutRulesByProfile[0]
-    .slice(foundationLeafCount)
-    .map((rule) => rule?.style.transform ?? "");
-  const trailPortraitTransformsByCardCount = Array.from({ length: 4 }, (_, profileIndex) =>
-    layoutRulesByProfile[profileIndex + 1]
-      .slice(foundationLeafCount)
-      .map((rule) => rule?.style.transform ?? ""));
-  const trailLaneIndices = trailLeaves.map(readLaneIndex);
   const trailFaceIndices = trailLeaves.map(readFaceIndex);
   const atlasFaceIndices = new Map(playback.atlasPositions.map((position, index) => [position, index]));
   let activePatternIndex = playback.initialPatternIndex;
   let pattern = patterns[activePatternIndex];
+  let activeProfileIndex = 0;
   let shuffleBag = [];
   let paused = true;
   let timer = null;
@@ -62,6 +54,8 @@ export function createCsssolitairePreparedPlayer({
   let foundationOperationsApplied = 0;
   let patternLayoutWrites = 0;
   let patternLayoutLeavesVisited = 0;
+  let responsiveTransformWrites = 0;
+  let responsiveProfileSwitchCount = 0;
   let patternSwitchCount = 0;
   let randomSelectionCount = 0;
   let timerCallbackCount = 0;
@@ -73,6 +67,38 @@ export function createCsssolitairePreparedPlayer({
     layoutWrites: 0,
     dirtyLeavesVisited: 0,
   });
+
+  function transformForPattern(nextPattern, index, profileIndex = activeProfileIndex) {
+    return profileIndex === 0
+      ? nextPattern.leafMatrices[index]
+      : nextPattern.leafPortraitMatricesByCardCount[profileIndex - 1][index];
+  }
+
+  function applyResponsiveProfile(nextProfileIndex) {
+    let writes = 0;
+    for (let index = 0; index < foundationLeafCount; index += 1) {
+      const transform = nextProfileIndex === 0
+        ? playback.foundationMatrices[index]
+        : playback.foundationPortraitMatricesByCardCount[nextProfileIndex - 1][index];
+      if (foundationLeaves[index].style.transform === transform) continue;
+      foundationLeaves[index].style.transform = transform;
+      writes += 1;
+    }
+    for (let index = 0; index < pattern.trailLeafCount; index += 1) {
+      const transform = transformForPattern(pattern, index, nextProfileIndex);
+      if (trailLeaves[index].style.transform === transform) continue;
+      trailLeaves[index].style.transform = transform;
+      writes += 1;
+    }
+    activeProfileIndex = nextProfileIndex;
+    responsiveTransformWrites += writes;
+    responsiveProfileSwitchCount += 1;
+  }
+
+  function syncResponsiveProfile() {
+    const nextProfileIndex = resolveResponsiveProfileIndex(portraitBreakpoints);
+    if (nextProfileIndex !== activeProfileIndex) applyResponsiveProfile(nextProfileIndex);
+  }
 
   function applyRow(row) {
     let writes = 0;
@@ -127,30 +153,11 @@ export function createCsssolitairePreparedPlayer({
     let writes = 0;
     for (let index = 0; index < nextPattern.trailLeafCount; index += 1) {
       const leaf = trailLeaves[index];
-      const leafIndex = foundationLeafCount + index;
-      const landscapeTransform = nextPattern.leafMatrices[index];
-      const laneIndex = nextPattern.leafFoundationIndices[index];
+      const transform = transformForPattern(nextPattern, index);
       const faceIndex = nextPattern.leafAtlasIndices[index];
       patternLayoutLeavesVisited += 1;
-      if (trailLandscapeTransforms[index] !== landscapeTransform) {
-        trailLandscapeTransforms[index] = landscapeTransform;
-        layoutRulesByProfile[0][leafIndex].style.transform = landscapeTransform;
-        writes += 1;
-      }
-      for (let profileIndex = 0; profileIndex < 4; profileIndex += 1) {
-        const portraitTransform = nextPattern.leafPortraitMatricesByCardCount[profileIndex][index];
-        if (portraitTransform === null ||
-            trailPortraitTransformsByCardCount[profileIndex][index] === portraitTransform) continue;
-        const rule = layoutRulesByProfile[profileIndex + 1][leafIndex];
-        if (!rule) throw new Error("Prepared cssSolitaire portrait rule bank drifted");
-        trailPortraitTransformsByCardCount[profileIndex][index] = portraitTransform;
-        rule.style.transform = portraitTransform;
-        writes += 1;
-      }
-      if (trailLaneIndices[index] !== laneIndex) {
-        leaf.classList.remove(`lane-${trailLaneIndices[index]}`);
-        leaf.classList.add(`lane-${laneIndex}`);
-        trailLaneIndices[index] = laneIndex;
+      if (leaf.style.transform !== transform) {
+        leaf.style.transform = transform;
         writes += 1;
       }
       if (trailFaceIndices[index] !== faceIndex) {
@@ -301,6 +308,7 @@ export function createCsssolitairePreparedPlayer({
       patternIndex: activePatternIndex,
       patternId: pattern.id,
       patternCount: patterns.length,
+      responsiveProfileIndex: activeProfileIndex,
       playheadMs,
       frameIndex,
       rewinding: playheadMs >= pattern.rewindStartMilliseconds && playheadMs <= pattern.rewindEndMilliseconds,
@@ -316,6 +324,9 @@ export function createCsssolitairePreparedPlayer({
       lastApply,
     });
   }
+
+  globalThis.addEventListener?.("resize", syncResponsiveProfile);
+  syncResponsiveProfile();
 
   return Object.freeze({
     get ready() { return true; },
@@ -374,6 +385,9 @@ export function createCsssolitairePreparedPlayer({
         runtimeFoundationClassWrites: foundationClassWrites,
         runtimePatternLayoutWrites: patternLayoutWrites,
         runtimePatternLayoutLeavesVisited: patternLayoutLeavesVisited,
+        runtimeResponsiveTransformWrites: responsiveTransformWrites,
+        runtimeResponsiveProfileSwitchCount: responsiveProfileSwitchCount,
+        responsiveProfileIndex: activeProfileIndex,
         runtimePreparedPatternSwitchCount: patternSwitchCount,
         runtimeRandomSelectionCount: randomSelectionCount,
         runtimeRandomSelectionPurpose: "prepared-pattern-shuffled-bag-index-only",
@@ -390,9 +404,19 @@ export function createCsssolitairePreparedPlayer({
     },
     destroy() {
       this.pause();
+      globalThis.removeEventListener?.("resize", syncResponsiveProfile);
       target.destroy();
     },
   });
+}
+
+function resolveResponsiveProfileIndex(portraitBreakpoints) {
+  if (!matchMedia("(orientation: portrait)").matches) return 0;
+  const width = document.documentElement.clientWidth || innerWidth;
+  if (width < portraitBreakpoints[0]) return 1;
+  if (width < portraitBreakpoints[1]) return 2;
+  if (width < portraitBreakpoints[2]) return 3;
+  return 4;
 }
 
 function readFaceIndex(leaf) {
@@ -402,14 +426,6 @@ function readFaceIndex(leaf) {
     if (Number.isSafeInteger(index) && index >= 0 && index < 52) return index;
   }
   throw new Error("Prepared cssSolitaire face class drifted");
-}
-
-function readLaneIndex(leaf) {
-  for (const className of leaf.classList) {
-    const match = className.match(/^lane-([0-3])$/u);
-    if (match) return Number(match[1]);
-  }
-  throw new Error("Prepared cssSolitaire lane class drifted");
 }
 
 function setFaceClass(leaf, previousIndex, nextIndex) {

--- a/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
+++ b/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
@@ -486,50 +486,36 @@ function buildPreparedPattern(seed, index) {
           const portraitMatrix = portraitMatrices[profileIndex];
           return portraitMatrix;
         })),
-      leafFoundationIndices: source.snapshots.map(({ foundationIndex }) => foundationIndex),
       leafAtlasIndices: source.snapshots.map(({ faceNumber: cardFace }) => cardFace - 1),
     }),
   });
 }
 
 function buildSnapshot(leaves, cardAssetUrl) {
-  const leafClass = (index) => `l${index.toString(36)}`;
   const faceClass = (index) => `f${index.toString(36)}`;
-  const leafSelector = (index) => `.solitaire-prepared-scene>s.${leafClass(index)}`;
   const cardNodes = leaves.map((leaf, index) => {
     const classes = [
-      index < FOUNDATION_COUNT ? "foundation" : null,
       index < FOUNDATION_COUNT ? "v" : null,
-      `lane-${leaf.foundationIndex}`,
-      leafClass(index),
       faceClass(leaf.faceIndex),
     ]
       .filter(Boolean).join(" ");
-    return `<s class="${classes}"></s>`;
+    return `<b class="${classes}" style="transform:${leaf.matrix}"></b>`;
   }).join("");
   const faceRules = Array.from({ length: 52 }, (_, faceIndex) => {
     const atlas = atlasPosition(faceIndex + 1);
-    return `.solitaire-prepared-scene>s.${faceClass(faceIndex)}{background-position:${-atlas.x}px ${-atlas.y}px}`;
+    return `.polycss-scene>b.${faceClass(faceIndex)}{background-position:${-atlas.x}px ${-atlas.y}px}`;
   }).join("");
-  const landscapeRules = leaves.map((leaf, index) =>
-    `${leafSelector(index)}{transform:${leaf.matrix}}`).join("");
-  const portraitRules = PORTRAIT_PROFILES.map((_, profileIndex) => leaves
-    .map((leaf, index) =>
-      `${leafSelector(index)}{transform:${leaf.portraitMatrices[profileIndex] ?? "none"}}`)
-    .join(""));
   const css = [
-    `.polycss-camera.solitaire-prepared-camera{position:relative;display:block;width:100%;height:100%;overflow:hidden;--csssolitaire-presentation-scale:${LANDSCAPE_PRESENTATION_SCALE};--csssolitaire-card-width:calc(${CARD_WIDTH}px * var(--csssolitaire-presentation-scale));--csssolitaire-card-height:calc(${CARD_HEIGHT}px * var(--csssolitaire-presentation-scale));--csssolitaire-card-transform-x:calc(${CARD_HEIGHT / CARD_SOURCE_WIDTH} * var(--csssolitaire-presentation-scale));--csssolitaire-card-transform-y:calc(${CARD_WIDTH / CARD_SOURCE_HEIGHT} * var(--csssolitaire-presentation-scale))}`,
-    ".polycss-scene.solitaire-prepared-scene{position:absolute;inset:0}",
-    `.polycss-scene.solitaire-prepared-scene>s{position:absolute;display:block;width:${CARD_SOURCE_WIDTH}px;height:${CARD_SOURCE_HEIGHT}px;margin:0;padding:0;overflow:hidden;border:0;border-radius:14px;background-image:url('${cardAssetUrl}');background-repeat:no-repeat;background-size:${CARD_ATLAS_WIDTH}px ${CARD_ATLAS_HEIGHT}px;transform-origin:0 0;visibility:hidden;pointer-events:none;text-decoration:none;font:normal normal normal 0/0 serif;image-rendering:auto}`,
-    ".polycss-scene.solitaire-prepared-scene>s.v{visibility:visible}",
+    `.polycss-camera{position:relative;display:block;width:100%;height:100%;overflow:hidden;--csssolitaire-presentation-scale:${LANDSCAPE_PRESENTATION_SCALE};--csssolitaire-card-width:calc(${CARD_WIDTH}px * var(--csssolitaire-presentation-scale));--csssolitaire-card-height:calc(${CARD_HEIGHT}px * var(--csssolitaire-presentation-scale));--csssolitaire-card-transform-x:calc(${CARD_HEIGHT / CARD_SOURCE_WIDTH} * var(--csssolitaire-presentation-scale));--csssolitaire-card-transform-y:calc(${CARD_WIDTH / CARD_SOURCE_HEIGHT} * var(--csssolitaire-presentation-scale))}`,
+    ".polycss-scene{position:absolute;inset:0}",
+    `.polycss-scene>b{position:absolute;display:block;width:${CARD_SOURCE_WIDTH}px;height:${CARD_SOURCE_HEIGHT}px;margin:0;padding:0;overflow:hidden;border:0;border-radius:14px;background-image:url('${cardAssetUrl}');background-repeat:no-repeat;background-size:${CARD_ATLAS_WIDTH}px ${CARD_ATLAS_HEIGHT}px;transform-origin:0 0;visibility:hidden;pointer-events:none;text-decoration:none;font:normal normal normal 0/0 serif;image-rendering:auto}`,
+    ".polycss-scene>b.v{visibility:visible}",
     faceRules,
-    landscapeRules,
-    `@media (orientation:portrait) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[0] - 1}px){${portraitRules[0]}.solitaire-prepared-scene>s.foundation:is(.lane-1,.lane-2,.lane-3){display:none}}`,
-    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[0]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[1] - 1}px){${portraitRules[1]}.solitaire-prepared-scene>s.foundation:is(.lane-2,.lane-3){display:none}}`,
-    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[1]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[2] - 1}px){${portraitRules[2]}.solitaire-prepared-scene>s.foundation.lane-3{display:none}}`,
-    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[2]}px){${portraitRules[3]}}`,
+    `@media (orientation:portrait) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[0] - 1}px){.polycss-scene>b:nth-child(2),.polycss-scene>b:nth-child(3),.polycss-scene>b:nth-child(4){display:none}}`,
+    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[0]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[1] - 1}px){.polycss-scene>b:nth-child(3),.polycss-scene>b:nth-child(4){display:none}}`,
+    `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[1]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[2] - 1}px){.polycss-scene>b:nth-child(4){display:none}}`,
   ].join("");
-  return `<!doctype html><html><head><style>${css}</style></head><body><div class="polycss-camera solitaire-prepared-camera"><div class="polycss-scene solitaire-prepared-scene">${cardNodes}</div></div></body></html>\n`;
+  return `<!doctype html><html><head><style>${css}</style></head><body><div class="polycss-camera"><div class="polycss-scene">${cardNodes}</div></div></body></html>\n`;
 }
 
 export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() } = {}) {
@@ -570,6 +556,9 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
     foundationLeafCount: FOUNDATION_COUNT,
     retainedLeafCount: leaves.length,
     retainedTrailLeafCount,
+    foundationMatrices: foundationLeaves.map(({ matrix: leafMatrix }) => leafMatrix),
+    foundationPortraitMatricesByCardCount: PORTRAIT_CARD_COUNTS.map((_, profileIndex) =>
+      foundationLeaves.map(({ portraitMatrices }) => portraitMatrices[profileIndex])),
     atlasPositions: Array.from({ length: 52 }, (_, index) => {
       const atlas = atlasPosition(index + 1);
       return `${-atlas.x}px ${-atlas.y}px`;
@@ -634,11 +623,12 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       morphTarget: "createPolyMorphPreparedDomTarget",
       profile: "prepared-playback",
       retainedDom: true,
-      leafTag: "s",
+      leafTag: "b",
       textureBackend: "atlas",
       textureLeafSizing: "raster",
       textureImageRendering: "auto",
       composition: "flat-2d-card-plane",
+      transformPublication: "prepared-inline-style",
       contentBounds: [contentBounds.left, contentBounds.top, contentBounds.right, contentBounds.bottom],
       responsiveProfiles: ["landscape", "portrait"],
       viewportPositioning: "prepared-css-vw-vh-no-letterbox",
@@ -670,7 +660,7 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       runtimeAtlasRasterization: false,
       runtimeGeometryCalculation: false,
       runtimeTrajectoryCalculation: false,
-      runtimeResizeCalculation: "single-root-presentation-scale-only",
+      runtimeResizeCalculation: "single-root-scale-and-responsive-inline-transform-publication",
       runtimeDomGrowth: false,
     },
     transport: {

--- a/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
@@ -42,9 +42,11 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.equal(manifest.sourceProfile.patterns.length, 24);
   assert.equal(manifest.renderer.morphTarget, "createPolyMorphPreparedDomTarget");
   assert.equal(manifest.renderer.profile, "prepared-playback");
+  assert.equal(manifest.renderer.leafTag, "b");
   assert.equal(manifest.renderer.textureBackend, "atlas");
   assert.equal(manifest.renderer.textureLeafSizing, "raster");
   assert.equal(manifest.renderer.composition, "flat-2d-card-plane");
+  assert.equal(manifest.renderer.transformPublication, "prepared-inline-style");
   assert.deepEqual(manifest.renderer.contentBounds, [-69, -71, 655, 395]);
   assert.deepEqual(manifest.renderer.responsiveProfiles, ["landscape", "portrait"]);
   assert.equal(manifest.renderer.viewportPositioning, "prepared-css-vw-vh-no-letterbox");
@@ -72,7 +74,8 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.equal(manifest.renderer.slotCount, 7);
   assert.equal(manifest.renderer.minimumSlotGap, 11);
   assert.equal(manifest.renderer.presentationScaleMode, "single-root-contain-scale-viewport-positioned");
-  assert.equal(manifest.renderer.runtimeResizeCalculation, "single-root-presentation-scale-only");
+  assert.equal(manifest.renderer.runtimeResizeCalculation,
+    "single-root-scale-and-responsive-inline-transform-publication");
   assert.equal(manifest.renderer.seamBleed, 0.2);
   assert.equal(manifest.renderer.runtimeAtlasRasterization, false);
   assert.equal(manifest.renderer.runtimeGeometryCalculation, false);
@@ -117,30 +120,27 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   }
 
   const snapshot = await readFile(join(generated, "solitaire.polycss.txt"), "utf8");
-  assert.match(snapshot, /class="polycss-camera solitaire-prepared-camera"/u);
-  assert.match(snapshot, /class="polycss-scene solitaire-prepared-scene"/u);
+  assert.match(snapshot, /class="polycss-camera"/u);
+  assert.match(snapshot, /class="polycss-scene"/u);
+  assert.doesNotMatch(snapshot, /solitaire-prepared-(?:camera|scene)/u);
   assert.doesNotMatch(snapshot, /csssolitaire-board/u);
-  assert.equal((snapshot.match(/<s class="[^"]+"><\/s>/gu) ?? []).length, 1952);
-  assert.doesNotMatch(snapshot, /<s[^>]+\sstyle=/u);
+  assert.equal((snapshot.match(/<b class="[^"]+" style="transform:[^"]+"><\/b>/gu) ?? []).length, 1952);
+  assert.doesNotMatch(snapshot, /<s\b/u);
   assert.doesNotMatch(snapshot, /--csssolitaire-(?:landscape|portrait)-/u);
-  assert.equal((snapshot.match(/\.solitaire-prepared-scene>s\.l[0-9a-z]+\{transform:/gu) ?? []).length,
-    9760);
-  assert.equal((snapshot.match(/\.solitaire-prepared-scene>s\.l[0-9a-z]+\{transform:translate\(/gu) ?? []).length,
-    9760);
+  assert.equal((snapshot.match(/\sstyle="transform:/gu) ?? []).length, 1952);
+  assert.doesNotMatch(snapshot, /class="[^"]*\bl[0-9a-z]+\b/u);
+  assert.doesNotMatch(snapshot, /\.polycss-scene>b\.[^{]+\{transform:/u);
   assert.equal((snapshot.match(/\{transform:none\}/gu) ?? []).length, 0);
-  assert.equal((snapshot.match(/\.solitaire-prepared-scene>s\.f[0-9a-z]+\{background-position:/gu) ?? []).length,
+  assert.equal((snapshot.match(/\.polycss-scene>b\.f[0-9a-z]+\{background-position:/gu) ?? []).length,
     52);
-  assert.equal((snapshot.match(/<s class="foundation v lane-[0-3] l[0-3] f[0-9a-z]+"><\/s>/gu) ?? []).length, 4);
-  assert.match(snapshot, /\.polycss-scene\.solitaire-prepared-scene\{position:absolute;inset:0\}/u);
-  assert.match(snapshot, /\.polycss-scene\.solitaire-prepared-scene>s\{position:absolute/u);
+  assert.equal((snapshot.match(/<b class="v f[0-9a-z]+" style="transform:[^"]+"><\/b>/gu) ?? []).length, 4);
+  assert.doesNotMatch(snapshot, /\bfoundation\b|\blane-[0-3]\b/u);
+  assert.match(snapshot, /\.polycss-scene\{position:absolute;inset:0\}/u);
+  assert.match(snapshot, /\.polycss-scene>b\{position:absolute/u);
   assert.match(snapshot, /--csssolitaire-card-width:calc\(71px \* var\(--csssolitaire-presentation-scale/u);
   assert.doesNotMatch(snapshot, /--csssolitaire-fit/u);
-  assert.match(snapshot, /max-width:519px\)\{\.solitaire-prepared-scene>s\.l0\{transform:translate\(/u);
-  assert.match(snapshot, /min-width:920px\)\{\.solitaire-prepared-scene>s\.l0\{transform:translate\(/u);
   assert.match(snapshot,
-    /max-width:519px\)\{.*\.solitaire-prepared-scene>s\.foundation:is\(\.lane-1,\.lane-2,\.lane-3\)\{display:none\}/u);
-  assert.doesNotMatch(snapshot,
-    /\.solitaire-prepared-scene>s:is\(\.lane-1,\.lane-2,\.lane-3\)\{display:none\}/u);
+    /max-width:519px\)\{\.polycss-scene>b:nth-child\(2\),\.polycss-scene>b:nth-child\(3\),\.polycss-scene>b:nth-child\(4\)\{display:none\}/u);
   assert.match(snapshot, /border-radius:14px/u);
   assert.doesNotMatch(snapshot, /box-shadow/u);
   assert.match(snapshot, /image-rendering:auto/u);
@@ -152,7 +152,7 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   const preparedTransforms = playback.patterns.flatMap((pattern) => [
     ...pattern.leafMatrices,
     ...pattern.leafPortraitMatricesByCardCount.flat().filter(Boolean),
-  ]);
+  ]).concat(playback.foundationMatrices, playback.foundationPortraitMatricesByCardCount.flat());
   const topAnchoredPixels = preparedTransforms
     .map((transform) => transform.match(/,calc\(0vh \+ ([\d.]+)px/u)?.[1])
     .filter(Boolean)
@@ -185,9 +185,7 @@ test("generated product is one complete retained snapshot plus sparse prepared p
     pattern.leafPortraitMatricesByCardCount.length === 4 &&
     pattern.leafPortraitMatricesByCardCount.every((profile) =>
       profile.length === pattern.trailLeafCount && profile.every(Boolean))));
-  assert.ok(playback.patterns.every((pattern) =>
-    pattern.leafFoundationIndices.length === pattern.trailLeafCount &&
-    pattern.leafFoundationIndices.every((foundationIndex) => foundationIndex >= 0 && foundationIndex < 4)));
+  assert.ok(playback.patterns.every((pattern) => !("leafFoundationIndices" in pattern)));
   const maximumPortraitUpdateGaps = [1, 2, 3, 4].map((cardCount) => Math.max(
     ...playback.patterns.map((pattern) => {
       const updateTimes = pattern.frameTimesMs.filter((_, frameIndex) =>

--- a/src/adapters/solitaire/test/csssolitaire-shell.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-shell.test.mjs
@@ -20,7 +20,9 @@ test("product shell is the standard css.graphics route without demo controls", a
   assert.match(html, /class="site-header"/u);
   assert.match(html, /class="site-wordmark-svg"/u);
   assert.match(html, /href="https:\/\/github\.com\/layoutit\/cssGraphics"/u);
-  assert.match(html, /<main id="scene"/u);
+  assert.match(html, /<main id="scene"><\/main>/u);
+  assert.equal((html.match(/\saria-label=/gu) ?? []).length, 1);
+  assert.doesNotMatch(html, /aria-busy/u);
   assert.doesNotMatch(html, /<button\b|<nav\b|<section\b|<output\b|<canvas\b/u);
   assert.match(css, /\.site-header \{[^}]*position: fixed;[^}]*pointer-events: none;/u);
   assert.match(css, /\.site-wordmark \{[^}]*pointer-events: auto;/u);
@@ -34,10 +36,12 @@ test("product shell is the standard css.graphics route without demo controls", a
   assert.doesNotMatch(css, /clip-path|mask(?:-image)?|filter|box-shadow|text-shadow|mix-blend-mode/iu);
   assert.match(client, /loadPreparedSolitaire/u);
   assert.match(client, /state\.player\.resume\(\)/u);
+  assert.doesNotMatch(client, /aria-busy/u);
   assert.doesNotMatch(client, /prefers-reduced-motion/u);
   assert.match(player, /createPolyMorphPreparedDomTarget/u);
   assert.match(player, /deadline-setTimeout-prepared-visibility-publication/u);
   assert.doesNotMatch(player, /Math\.random|requestAnimationFrame\s*\(|createElement|DOMMatrix/u);
+  assert.doesNotMatch(player, /lane-/u);
   assert.match(snapshotMount, /new ResizeObserver\(updatePresentation\)/u);
   assert.match(snapshotMount, /host\.clientWidth/u);
   assert.match(snapshotMount, /host\.clientHeight/u);

--- a/src/adapters/solitaire/tools/smoke-browser.mjs
+++ b/src/adapters/solitaire/tools/smoke-browser.mjs
@@ -59,7 +59,7 @@ try {
           mutations.removed += record.removedNodes.length;
         }
       });
-      observer.observe(document.querySelector(".solitaire-prepared-scene"), { childList: true, subtree: true });
+      observer.observe(document.querySelector(".polycss-scene"), { childList: true, subtree: true });
       window.__cssSolitaireSmoke = { mutations, observer };
     });
 
@@ -69,7 +69,7 @@ try {
     const visibleBounds = await page.evaluate(() => {
       const durationMs = window.__cssSolitaireDebug.manifest.sourceProfile.patterns[0].durationMs;
       window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
-      const rects = [...document.querySelectorAll(".solitaire-prepared-scene > s")]
+      const rects = [...document.querySelectorAll(".polycss-scene > b")]
         .filter((leaf) => getComputedStyle(leaf).visibility === "visible")
         .map((leaf) => leaf.getBoundingClientRect());
       window.__cssSolitaireDebug.seek(0);
@@ -99,7 +99,7 @@ try {
       return patternIds;
     }, initial.patternId);
     const evidence = await page.evaluate(() => {
-      const leaves = [...document.querySelectorAll(".solitaire-prepared-scene > s")];
+      const leaves = [...document.querySelectorAll(".polycss-scene > b")];
       const first = leaves[0];
       const rect = first.getBoundingClientRect();
       const foundationRects = leaves.slice(0, 4).map((leaf) => {
@@ -113,8 +113,8 @@ try {
       });
       const computedTransforms = leaves.map((leaf) => getComputedStyle(leaf).transform);
       const scene = document.getElementById("scene");
-      const camera = scene?.querySelector(":scope > .solitaire-prepared-camera");
-      const preparedScene = camera?.querySelector(":scope > .solitaire-prepared-scene");
+      const camera = scene?.querySelector(":scope > .polycss-camera");
+      const preparedScene = camera?.querySelector(":scope > .polycss-scene");
       const resources = performance.getEntriesByType("resource")
         .map((entry) => new URL(entry.name).pathname)
         .filter((path) => path.includes("csssolitaire"));
@@ -130,6 +130,8 @@ try {
           sceneChildCount: scene?.childElementCount,
           cameraChildCount: camera?.childElementCount,
           preparedSceneChildCount: preparedScene?.childElementCount,
+          cameraClassName: camera?.className,
+          preparedSceneClassName: preparedScene?.className,
           sceneDescendantCount: scene?.querySelectorAll("*").length,
           unexpectedSceneElementCount: scene?.querySelectorAll(
             "button,canvas,nav,output,section,svg,style,[contenteditable]",
@@ -138,6 +140,13 @@ try {
             count + [...element.attributes].filter(({ name }) => name.startsWith("data-")).length, 0),
           inlineStyleDeclarationCount: [...scene.querySelectorAll("*")].reduce((count, element) =>
             count + element.style.length, 0),
+          invalidLeafClassCount: leaves.filter((leaf) => {
+            const classes = [...leaf.classList];
+            return classes.length < 1 || classes.length > 2 ||
+              classes.filter((className) => className === "v").length > 1 ||
+              classes.filter((className) => /^f[0-9a-z]+$/u.test(className)).length !== 1 ||
+              classes.some((className) => className !== "v" && !/^f[0-9a-z]+$/u.test(className));
+          }).length,
         },
         radius: getComputedStyle(first).borderRadius,
         cardEdge: getComputedStyle(first).boxShadow,
@@ -148,10 +157,13 @@ try {
         shell: {
           path: document.querySelector(".site-wordmark-path")?.textContent,
           buttons: document.querySelectorAll("button, nav, section, output").length,
+          ariaLabels: [...document.querySelectorAll("[aria-label]")]
+            .map((element) => element.getAttribute("aria-label")),
+          ariaBusyCount: document.querySelectorAll("[aria-busy]").length,
           sceneBackground: getComputedStyle(document.getElementById("scene")).backgroundImage,
         },
         composition: {
-          sceneTransformStyle: getComputedStyle(document.querySelector(".solitaire-prepared-scene")).transformStyle,
+          sceneTransformStyle: getComputedStyle(document.querySelector(".polycss-scene")).transformStyle,
           matrix2dLeafCount: computedTransforms.filter((transform) => transform.startsWith("matrix(")).length,
           matrix3dLeafCount: computedTransforms.filter((transform) => transform.startsWith("matrix3d(")).length,
           leafInlineStyleDeclarationCount: leaves.reduce((count, leaf) => count + leaf.style.length, 0),
@@ -182,8 +194,10 @@ try {
           JSON.stringify(deploy ? ["HEADER", "MAIN"] : ["HEADER", "MAIN", "SCRIPT"]) ||
         evidence.structure.sceneChildCount !== 1 || evidence.structure.cameraChildCount !== 1 ||
         evidence.structure.preparedSceneChildCount !== 1952 || evidence.structure.sceneDescendantCount !== 1954 ||
+        evidence.structure.cameraClassName !== "polycss-camera" ||
+        evidence.structure.preparedSceneClassName !== "polycss-scene" ||
         evidence.structure.unexpectedSceneElementCount !== 0 || evidence.structure.dataAttributeCount !== 0 ||
-        evidence.structure.inlineStyleDeclarationCount !== 0 ||
+        evidence.structure.inlineStyleDeclarationCount !== 1952 || evidence.structure.invalidLeafClassCount !== 0 ||
         evidence.radius !== "14px" ||
         evidence.cardEdge !== "none" ||
         evidence.imageRendering !== "auto" ||
@@ -194,10 +208,12 @@ try {
           Math.abs(rect.height - 135) > 0.1) ||
         evidence.shell.path !== "/solitaire" ||
         evidence.shell.buttons !== 0 ||
+        JSON.stringify(evidence.shell.ariaLabels) !== JSON.stringify(["View cssGraphics on GitHub"]) ||
+        evidence.shell.ariaBusyCount !== 0 ||
         !evidence.shell.sceneBackground.startsWith("linear-gradient(rgb(0, 128, 0)") ||
         evidence.composition.sceneTransformStyle !== "flat" ||
         evidence.composition.matrix2dLeafCount !== 1952 || evidence.composition.matrix3dLeafCount !== 0 ||
-        evidence.composition.leafInlineStyleDeclarationCount !== 0 ||
+        evidence.composition.leafInlineStyleDeclarationCount !== 1952 ||
         evidence.stats.runtimeAnimationFrameCallbackCount !== 0 ||
         evidence.stats.runtimeTimerCallbackCount < 1 || evidence.stats.loopCount < 1 ||
         evidence.stats.preparedPatternCount !== 24 ||
@@ -245,7 +261,7 @@ try {
     await page.waitForTimeout(100);
     const mobileInitial = await page.evaluate(() => {
       window.__cssSolitaireDebug.seek(0);
-      const displayedFoundations = [...document.querySelectorAll(".solitaire-prepared-scene > s.foundation")]
+      const displayedFoundations = [...document.querySelectorAll(".polycss-scene > b")].slice(0, 4)
         .filter((foundation) => getComputedStyle(foundation).display !== "none");
       const leaf = displayedFoundations[0];
       const rect = leaf.getBoundingClientRect();
@@ -257,11 +273,11 @@ try {
       return {
         portraitMedia: matchMedia("(orientation: portrait)").matches,
         stable: window.__cssSolitaireDebug.assertStableDomIdentity(),
-        retainedLeaves: document.querySelectorAll(".solitaire-prepared-scene > s").length,
+        retainedLeaves: document.querySelectorAll(".polycss-scene > b").length,
         displayedFoundationCount: displayedFoundations.length,
         cardRect: { left: rect.left, top: rect.top, width: rect.width, height: rect.height },
         foundationRects,
-        sceneTransform: getComputedStyle(document.querySelector(".solitaire-prepared-scene")).transform,
+        sceneTransform: getComputedStyle(document.querySelector(".polycss-scene")).transform,
         mutations: { ...window.__cssSolitaireSmoke.mutations },
       };
     });
@@ -271,7 +287,7 @@ try {
       window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
     });
     const mobileEvidence = await page.evaluate(() => {
-      const visibleLeaves = [...document.querySelectorAll(".solitaire-prepared-scene > s")]
+      const visibleLeaves = [...document.querySelectorAll(".polycss-scene > b")]
         .filter((leaf) => {
           const style = getComputedStyle(leaf);
           return style.display !== "none" && style.visibility === "visible";
@@ -324,16 +340,16 @@ try {
     }
     const responsiveCardCounts = [];
     for (const viewport of [
-      { width: 390, height: 844, expected: 1, expectedSize: [72.109375, 97.5], expectedLefts: [158.9453125] },
-      { width: 600, height: 900, expected: 2, expectedSize: [88.75, 120], expectedLefts: [322.25, 425] },
-      { width: 800, height: 1_000, expected: 3, expectedSize: [98.611111, 133.333333], expectedLefts: [355.833333, 469.444444, 583.055556] },
-      { width: 960, height: 1_200, expected: 4, expectedSize: [118.333333, 160], expectedLefts: [423, 558.333333, 693.666667, 829] },
+      { width: 390, height: 844, expected: 1, expectedProfile: 1, expectedSize: [72.109375, 97.5], expectedLefts: [158.9453125] },
+      { width: 600, height: 900, expected: 2, expectedProfile: 2, expectedSize: [88.75, 120], expectedLefts: [322.25, 425] },
+      { width: 800, height: 1_000, expected: 3, expectedProfile: 3, expectedSize: [98.611111, 133.333333], expectedLefts: [355.833333, 469.444444, 583.055556] },
+      { width: 960, height: 1_200, expected: 4, expectedProfile: 4, expectedSize: [118.333333, 160], expectedLefts: [423, 558.333333, 693.666667, 829] },
     ]) {
       await page.setViewportSize(viewport);
       await page.waitForTimeout(50);
       const layout = await page.evaluate(() => {
         window.__cssSolitaireDebug.seek(0);
-        const cards = [...document.querySelectorAll(".solitaire-prepared-scene > s.foundation")]
+        const cards = [...document.querySelectorAll(".polycss-scene > b")].slice(0, 4)
           .filter((foundation) => getComputedStyle(foundation).display !== "none")
           .map((foundation) => {
             const rect = foundation.getBoundingClientRect();
@@ -342,7 +358,7 @@ try {
         const state = window.__cssSolitaireDebug.snapshot();
         const durationMs = window.__cssSolitaireDebug.manifest.sourceProfile.patterns[state.patternIndex].durationMs;
         window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
-        const visibleRects = [...document.querySelectorAll(".solitaire-prepared-scene > s")]
+        const visibleRects = [...document.querySelectorAll(".polycss-scene > b")]
           .filter((leaf) => {
             const style = getComputedStyle(leaf);
             return style.display !== "none" && style.visibility === "visible";
@@ -350,6 +366,7 @@ try {
           .map((leaf) => leaf.getBoundingClientRect());
         return {
           cards,
+          profileIndex: state.responsiveProfileIndex,
           visibleLeft: Math.min(...visibleRects.map((rect) => rect.left)),
           visibleRight: Math.max(...visibleRects.map((rect) => rect.right)),
         };
@@ -362,9 +379,10 @@ try {
       });
     }
     if (responsiveCardCounts.some(({
-      width, expected, expectedTop, expectedSize, displayed, expectedLefts, cards, visibleLeft, visibleRight,
+      width, expected, expectedProfile, expectedTop, expectedSize, displayed, expectedLefts, cards,
+      profileIndex, visibleLeft, visibleRight,
     }) =>
-      expected !== displayed || cards.some((card, index) =>
+      expected !== displayed || profileIndex !== expectedProfile || cards.some((card, index) =>
         Math.abs(card.left - expectedLefts[index]) > 0.1 ||
         Math.abs(card.top - expectedTop) > 0.1 ||
         Math.abs(card.width - expectedSize[0]) > 0.1 || Math.abs(card.height - expectedSize[1]) > 0.1) ||
@@ -384,7 +402,7 @@ try {
       await page.waitForTimeout(50);
       const layout = await page.evaluate(() => {
         window.__cssSolitaireDebug.seek(0);
-        const cards = [...document.querySelectorAll(".solitaire-prepared-scene > s.foundation")]
+        const cards = [...document.querySelectorAll(".polycss-scene > b")].slice(0, 4)
           .map((foundation) => {
             const rect = foundation.getBoundingClientRect();
             return { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
@@ -392,11 +410,12 @@ try {
         const state = window.__cssSolitaireDebug.snapshot();
         const durationMs = window.__cssSolitaireDebug.manifest.sourceProfile.patterns[state.patternIndex].durationMs;
         window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
-        const visible = [...document.querySelectorAll(".solitaire-prepared-scene > s")]
+        const visible = [...document.querySelectorAll(".polycss-scene > b")]
           .filter((leaf) => getComputedStyle(leaf).visibility === "visible")
           .map((leaf) => leaf.getBoundingClientRect());
         return {
           cards,
+          profileIndex: state.responsiveProfileIndex,
           visibleLeft: Math.min(...visible.map((rect) => rect.left)),
           visibleTop: Math.min(...visible.map((rect) => rect.top)),
           visibleBottom: Math.max(...visible.map((rect) => rect.bottom)),
@@ -405,9 +424,9 @@ try {
       landscapeViewports.push({ ...viewport, expectedTop: 80, ...layout });
     }
     if (landscapeViewports.some(({
-      height, expectedTop, expectedSize, expectedLefts, cards, visibleLeft, visibleTop, visibleBottom,
+      height, expectedTop, expectedSize, expectedLefts, cards, profileIndex, visibleLeft, visibleTop, visibleBottom,
     }) =>
-      cards.some((card, index) => Math.abs(card.left - expectedLefts[index]) > 0.1 ||
+      profileIndex !== 0 || cards.some((card, index) => Math.abs(card.left - expectedLefts[index]) > 0.1 ||
         Math.abs(card.top - expectedTop) > 0.1 || Math.abs(card.width - expectedSize[0]) > 0.1 ||
         Math.abs(card.height - expectedSize[1]) > 0.1) ||
       visibleLeft > -0.9 * expectedSize[0] ||
@@ -496,7 +515,7 @@ async function captureMobileContinuity(browser, port, route) {
       return {
         samples: [1_000, 2_000, 3_000, 4_000].map((timeMs) => {
           window.__cssSolitaireDebug.seek(timeMs);
-          const visiblePaintedLeaves = [...document.querySelectorAll(".solitaire-prepared-scene > s")]
+          const visiblePaintedLeaves = [...document.querySelectorAll(".polycss-scene > b")]
             .filter((leaf) => {
               const style = getComputedStyle(leaf);
               return style.display !== "none" && style.visibility === "visible";


### PR DESCRIPTION
## Summary
- render every prepared card leaf as a `<b>` with its prepared transform inline
- remove layout classes, lane/foundation semantics, and unnecessary ARIA state from the scene DOM
- preserve prepared playback and responsive foundation profiles without per-frame transform calculation

## Verification
- `pnpm prepare:solitaire`
- `pnpm test:solitaire`
- `pnpm test:solitaire:assets`
- `pnpm build:solitaire`
- `pnpm test:solitaire:browser`
- `pnpm prepare:solitaire:check`
- `pnpm verify:source-only`
- `pnpm build:solitaire:deploy && pnpm test:solitaire:deploy`