### PR TITLE
Fix Solitaire inline card matrices

### DIFF
--- a/src/adapters/solitaire/src/csssolitaire/client.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/client.mjs
@@ -23,6 +23,8 @@ export function mountCsssolitaireClient() {
     });
     state.player = createCsssolitairePreparedPlayer({
       playback: prepared.playback,
+      host,
+      renderer: prepared.manifest.renderer,
       scene: state.mount.scene,
       leaves: state.mount.leaves,
       portraitBreakpoints: prepared.manifest.renderer.portraitCardBreakpoints,

--- a/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
@@ -54,7 +54,7 @@ function validateManifest(manifest) {
       manifest.renderer?.preparedPatternBankCount !== 24 ||
       manifest.renderer?.runtimePatternSelectionOnly !== true ||
       JSON.stringify(manifest.renderer?.responsiveProfiles) !== '["landscape","portrait"]' ||
-      manifest.renderer?.viewportPositioning !== "prepared-css-vw-vh-no-letterbox" ||
+      manifest.renderer?.viewportPositioning !== "prepared-layout-resolved-inline-matrix-no-letterbox" ||
       manifest.renderer?.viewportFill !== true ||
       manifest.renderer?.verticalMapping !== "foundation-and-retained-bounce-bottom-anchored" ||
       manifest.renderer?.foundationTopCssPixels !== 80 ||
@@ -63,6 +63,7 @@ function validateManifest(manifest) {
       manifest.renderer?.upwardArchMapping !==
         "prepared-source-smooth-three-anchor-curve" ||
       JSON.stringify(manifest.renderer?.cardSourceSize) !== "[71,96]" ||
+      JSON.stringify(manifest.renderer?.cardPrimitiveSize) !== "[240,160]" ||
       JSON.stringify(manifest.renderer?.landscapePresentationBase) !== "[960,540]" ||
       manifest.renderer?.landscapePresentationBaseScale !== 1.40625 ||
       manifest.renderer?.landscapeCardMaximumWidthCssPixels !== 200 ||
@@ -77,8 +78,7 @@ function validateManifest(manifest) {
       manifest.renderer?.preparedSlotLayout !== "source-seven-slot-presentation-scaled-card-size" ||
       manifest.renderer?.slotCount !== 7 || manifest.renderer?.minimumSlotGap !== 11 ||
       manifest.renderer?.presentationScaleMode !== "single-root-contain-scale-viewport-positioned" ||
-      manifest.renderer?.runtimeResizeCalculation !==
-        "single-root-scale-and-responsive-inline-transform-publication" ||
+      manifest.renderer?.runtimeResizeCalculation !== "prepared-layout-inline-matrix-resolution" ||
       manifest.transport?.snapshotUrl !== "/csssolitaire/solitaire.polycss.txt" ||
       manifest.transport?.runtimeModelPayload !== false ||
       manifest.sourceProfile?.cards !== 12 ||
@@ -133,14 +133,16 @@ function validatePlayback(playback, manifest) {
       playback.foundationLeafCount !== manifest.metrics.foundationLeafCount ||
       playback.retainedLeafCount !== manifest.metrics.retainedLeafCount ||
       playback.retainedTrailLeafCount !== manifest.metrics.retainedTrailLeafCount ||
-      !Array.isArray(playback.foundationMatrices) ||
-      playback.foundationMatrices.length !== playback.foundationLeafCount ||
-      playback.foundationMatrices.some((transform) => !validPreparedTransform(transform)) ||
-      !Array.isArray(playback.foundationPortraitMatricesByCardCount) ||
-      playback.foundationPortraitMatricesByCardCount.length !== 4 ||
-      playback.foundationPortraitMatricesByCardCount.some((profile) =>
+      JSON.stringify(playback.layoutComponentOrder) !==
+        '["xViewportPercent","xCardWidthFactor","yViewportPercent","yPixels","yCardHeightFactor"]' ||
+      !Array.isArray(playback.foundationLayouts) ||
+      playback.foundationLayouts.length !== playback.foundationLeafCount ||
+      playback.foundationLayouts.some((layout) => !validPreparedLayout(layout)) ||
+      !Array.isArray(playback.foundationPortraitLayoutsByCardCount) ||
+      playback.foundationPortraitLayoutsByCardCount.length !== 4 ||
+      playback.foundationPortraitLayoutsByCardCount.some((profile) =>
         !Array.isArray(profile) || profile.length !== playback.foundationLeafCount ||
-        profile.some((transform) => !validPreparedTransform(transform))) ||
+        profile.some((layout) => !validPreparedLayout(layout))) ||
       !Array.isArray(playback.atlasPositions) || playback.atlasPositions.length !== 52 ||
       playback.atlasPositions.some((position) => !/^-?\d+px -?\d+px$/u.test(position)) ||
       !Array.isArray(playback.patterns) || playback.patterns.length !== playback.patternCount ||
@@ -192,28 +194,22 @@ function validPattern(pattern, playback, manifest, index) {
       !Number.isSafeInteger(operation[1]) || !Number.isSafeInteger(operation[2]) ||
       !((operation[1] === -1 && operation[2] === -1) ||
         (operation[1] >= 0 && operation[1] <= 720 && operation[2] >= 0 && operation[2] <= 1920)))) &&
-    Array.isArray(pattern.leafMatrices) && pattern.leafMatrices.length === pattern.trailLeafCount &&
-    !pattern.leafMatrices.some((transform) => !validPreparedTransform(transform)) &&
-    Array.isArray(pattern.leafPortraitMatricesByCardCount) &&
-    pattern.leafPortraitMatricesByCardCount.length === 4 &&
-    !pattern.leafPortraitMatricesByCardCount.some((profile) =>
+    Array.isArray(pattern.leafLayouts) && pattern.leafLayouts.length === pattern.trailLeafCount &&
+    !pattern.leafLayouts.some((layout) => !validPreparedLayout(layout)) &&
+    Array.isArray(pattern.leafPortraitLayoutsByCardCount) &&
+    pattern.leafPortraitLayoutsByCardCount.length === 4 &&
+    !pattern.leafPortraitLayoutsByCardCount.some((profile) =>
       !Array.isArray(profile) || profile.length !== pattern.trailLeafCount ||
-      profile.some((transform) => transform !== null && !validPreparedTransform(transform))) &&
-    !pattern.leafPortraitMatricesByCardCount[3].some((transform) => transform === null) &&
+      profile.some((layout) => layout !== null && !validPreparedLayout(layout))) &&
+    !pattern.leafPortraitLayoutsByCardCount[3].some((layout) => layout === null) &&
     !Array.from({ length: pattern.trailLeafCount }, (_, leafIndex) => leafIndex).some((leafIndex) =>
-      pattern.leafPortraitMatricesByCardCount.some((profile, profileIndex, profiles) =>
+      pattern.leafPortraitLayoutsByCardCount.some((profile, profileIndex, profiles) =>
         profileIndex > 0 && profiles[profileIndex - 1][leafIndex] !== null && profile[leafIndex] === null)) &&
     Array.isArray(pattern.leafAtlasIndices) && pattern.leafAtlasIndices.length === pattern.trailLeafCount &&
     !pattern.leafAtlasIndices.some((atlasIndex) =>
       !Number.isSafeInteger(atlasIndex) || atlasIndex < 0 || atlasIndex >= playback.atlasPositions.length);
 }
 
-function validPreparedTransform(transform) {
-  return typeof transform === "string" &&
-    transform.startsWith("translate(calc(") && transform.includes("vw") &&
-    transform.includes("--csssolitaire-card-width") && transform.includes("vh") &&
-    transform.includes("--csssolitaire-card-height") &&
-    transform.endsWith(
-      "rotate(90deg) scale(var(--csssolitaire-card-transform-x),var(--csssolitaire-card-transform-y))",
-    );
+function validPreparedLayout(layout) {
+  return Array.isArray(layout) && layout.length === 5 && layout.every(Number.isFinite);
 }

--- a/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
@@ -24,7 +24,6 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
   mountedStyle?.remove();
   mountedStyle = document.importNode(style, true);
   document.head.append(mountedStyle);
-  const ruleBank = collectPreparedRuleBank(mountedStyle);
   const mountedCamera = document.importNode(camera, true);
   host.replaceChildren(mountedCamera);
   const mountedScene = mountedCamera.querySelector(":scope > .polycss-scene");
@@ -36,34 +35,6 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
     throw new Error("Mounted cssSolitaire retained DOM census drifted");
   }
   const stableNodes = Object.freeze([mountedCamera, mountedScene, ...mountedLeaves]);
-  let presentationScale = 1;
-  let presentationScaleWrites = 0;
-
-  function updatePresentation() {
-    const width = host.clientWidth || manifest.renderer.landscapePresentationBase[0];
-    const height = host.clientHeight || manifest.renderer.landscapePresentationBase[1];
-    presentationScale = height >= width
-      ? Math.min(
-        width / manifest.renderer.portraitPresentationBase[0],
-        height / manifest.renderer.portraitPresentationBase[1],
-      )
-      : Math.min(
-        manifest.renderer.landscapeCardMaximumWidthCssPixels / manifest.renderer.cardSourceSize[0],
-        manifest.renderer.landscapePresentationBaseScale * Math.min(
-          width / manifest.renderer.landscapePresentationBase[0],
-          height / manifest.renderer.landscapePresentationBase[1],
-        ),
-      );
-    const serialized = String(Number(presentationScale.toFixed(8)));
-    if (ruleBank.presentation.style.getPropertyValue("--csssolitaire-presentation-scale") !== serialized) {
-      ruleBank.presentation.style.setProperty("--csssolitaire-presentation-scale", serialized);
-      presentationScaleWrites += 1;
-    }
-  }
-  const resizeObserver = typeof ResizeObserver === "function" ? new ResizeObserver(updatePresentation) : null;
-  resizeObserver?.observe(host);
-  globalThis.addEventListener?.("resize", updatePresentation);
-  updatePresentation();
 
   function assertStableDomIdentity() {
     const current = [
@@ -99,32 +70,15 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
         runtimeDomMutationCount: 0,
         runtimeDomMutationObserverInstalled: false,
         runtimeDomGrowth: false,
-        runtimeFitCalculationPurpose: "single-root-presentation-scale-only",
-        runtimePresentationScale: presentationScale,
-        runtimePresentationScaleWrites: presentationScaleWrites,
         runtimeGeometryBoundsCalculationCount: 0,
       });
     },
     destroy() {
-      resizeObserver?.disconnect();
-      globalThis.removeEventListener?.("resize", updatePresentation);
       host.replaceChildren();
       mountedStyle?.remove();
       mountedStyle = null;
     },
   });
-}
-
-function collectPreparedRuleBank(style) {
-  const sheet = style.sheet;
-  if (!(sheet instanceof CSSStyleSheet)) throw new Error("Prepared cssSolitaire stylesheet did not mount");
-  const topLevelRules = [...sheet.cssRules];
-  const presentation = topLevelRules.find((rule) =>
-    rule.selectorText === ".polycss-camera");
-  if (!presentation) {
-    throw new Error("Prepared cssSolitaire stylesheet rule bank drifted");
-  }
-  return Object.freeze({ presentation });
 }
 
 function hasInlineTransformOnly(leaf) {

--- a/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
@@ -2,12 +2,15 @@ import { createPolyMorphPreparedDomTarget } from "@layoutit/polycss-morph";
 
 export function createCsssolitairePreparedPlayer({
   playback,
+  host,
+  renderer,
   scene,
   leaves,
   portraitBreakpoints,
   randomUint32 = cryptoRandomUint32,
 }) {
   if (playback?.schema !== "csssolitaire-prepared-playback@2" ||
+      !(host instanceof HTMLElement) || !validRenderer(renderer) ||
       !(scene instanceof HTMLElement) || !Array.isArray(leaves) ||
       leaves.length !== playback.retainedLeafCount ||
       JSON.stringify(portraitBreakpoints) !== "[520,720,920]") {
@@ -56,11 +59,16 @@ export function createCsssolitairePreparedPlayer({
   let patternLayoutLeavesVisited = 0;
   let responsiveTransformWrites = 0;
   let responsiveProfileSwitchCount = 0;
+  let responsiveMatrixResolutionCount = 0;
+  let presentationUpdateCount = 0;
   let patternSwitchCount = 0;
   let randomSelectionCount = 0;
   let timerCallbackCount = 0;
   let loopCount = 0;
   let resetCount = 0;
+  let presentationWidth = renderer.landscapePresentationBase[0];
+  let presentationHeight = renderer.landscapePresentationBase[1];
+  let presentationScale = renderer.landscapePresentationBaseScale;
   let lastApply = Object.freeze({
     visibilityWrites: 0,
     foundationWrites: 0,
@@ -68,36 +76,52 @@ export function createCsssolitairePreparedPlayer({
     dirtyLeavesVisited: 0,
   });
 
-  function transformForPattern(nextPattern, index, profileIndex = activeProfileIndex) {
+  function layoutForPattern(nextPattern, index, profileIndex = activeProfileIndex) {
     return profileIndex === 0
-      ? nextPattern.leafMatrices[index]
-      : nextPattern.leafPortraitMatricesByCardCount[profileIndex - 1][index];
+      ? nextPattern.leafLayouts[index]
+      : nextPattern.leafPortraitLayoutsByCardCount[profileIndex - 1][index];
   }
 
-  function applyResponsiveProfile(nextProfileIndex) {
+  function matrixForLayout(layout, width = presentationWidth, height = presentationHeight,
+    scale = presentationScale) {
+    responsiveMatrixResolutionCount += 1;
+    return preparedMatrix(layout, width, height, scale, renderer);
+  }
+
+  function applyPresentation(nextProfileIndex, width, height, scale) {
     let writes = 0;
     for (let index = 0; index < foundationLeafCount; index += 1) {
-      const transform = nextProfileIndex === 0
-        ? playback.foundationMatrices[index]
-        : playback.foundationPortraitMatricesByCardCount[nextProfileIndex - 1][index];
+      const layout = nextProfileIndex === 0
+        ? playback.foundationLayouts[index]
+        : playback.foundationPortraitLayoutsByCardCount[nextProfileIndex - 1][index];
+      const transform = matrixForLayout(layout, width, height, scale);
       if (foundationLeaves[index].style.transform === transform) continue;
       foundationLeaves[index].style.transform = transform;
       writes += 1;
     }
     for (let index = 0; index < pattern.trailLeafCount; index += 1) {
-      const transform = transformForPattern(pattern, index, nextProfileIndex);
+      const transform = matrixForLayout(layoutForPattern(pattern, index, nextProfileIndex), width, height, scale);
       if (trailLeaves[index].style.transform === transform) continue;
       trailLeaves[index].style.transform = transform;
       writes += 1;
     }
+    if (nextProfileIndex !== activeProfileIndex) responsiveProfileSwitchCount += 1;
     activeProfileIndex = nextProfileIndex;
+    presentationWidth = width;
+    presentationHeight = height;
+    presentationScale = scale;
     responsiveTransformWrites += writes;
-    responsiveProfileSwitchCount += 1;
+    presentationUpdateCount += 1;
   }
 
-  function syncResponsiveProfile() {
-    const nextProfileIndex = resolveResponsiveProfileIndex(portraitBreakpoints);
-    if (nextProfileIndex !== activeProfileIndex) applyResponsiveProfile(nextProfileIndex);
+  function syncPresentation() {
+    const width = host.clientWidth || renderer.landscapePresentationBase[0];
+    const height = host.clientHeight || renderer.landscapePresentationBase[1];
+    const nextProfileIndex = resolveResponsiveProfileIndex(portraitBreakpoints, width, height);
+    const scale = resolvePresentationScale(renderer, width, height);
+    if (nextProfileIndex === activeProfileIndex && width === presentationWidth &&
+        height === presentationHeight && scale === presentationScale) return;
+    applyPresentation(nextProfileIndex, width, height, scale);
   }
 
   function applyRow(row) {
@@ -153,7 +177,7 @@ export function createCsssolitairePreparedPlayer({
     let writes = 0;
     for (let index = 0; index < nextPattern.trailLeafCount; index += 1) {
       const leaf = trailLeaves[index];
-      const transform = transformForPattern(nextPattern, index);
+      const transform = matrixForLayout(layoutForPattern(nextPattern, index));
       const faceIndex = nextPattern.leafAtlasIndices[index];
       patternLayoutLeavesVisited += 1;
       if (leaf.style.transform !== transform) {
@@ -325,8 +349,10 @@ export function createCsssolitairePreparedPlayer({
     });
   }
 
-  globalThis.addEventListener?.("resize", syncResponsiveProfile);
-  syncResponsiveProfile();
+  const resizeObserver = typeof ResizeObserver === "function" ? new ResizeObserver(syncPresentation) : null;
+  resizeObserver?.observe(host);
+  globalThis.addEventListener?.("resize", syncPresentation);
+  syncPresentation();
 
   return Object.freeze({
     get ready() { return true; },
@@ -387,6 +413,10 @@ export function createCsssolitairePreparedPlayer({
         runtimePatternLayoutLeavesVisited: patternLayoutLeavesVisited,
         runtimeResponsiveTransformWrites: responsiveTransformWrites,
         runtimeResponsiveProfileSwitchCount: responsiveProfileSwitchCount,
+        runtimeResponsiveMatrixResolutionCount: responsiveMatrixResolutionCount,
+        runtimeFitCalculationPurpose: "prepared-layout-inline-matrix-resolution",
+        runtimePresentationScale: presentationScale,
+        runtimePresentationUpdateCount: presentationUpdateCount,
         responsiveProfileIndex: activeProfileIndex,
         runtimePreparedPatternSwitchCount: patternSwitchCount,
         runtimeRandomSelectionCount: randomSelectionCount,
@@ -404,19 +434,60 @@ export function createCsssolitairePreparedPlayer({
     },
     destroy() {
       this.pause();
-      globalThis.removeEventListener?.("resize", syncResponsiveProfile);
+      resizeObserver?.disconnect();
+      globalThis.removeEventListener?.("resize", syncPresentation);
       target.destroy();
     },
   });
 }
 
-function resolveResponsiveProfileIndex(portraitBreakpoints) {
-  if (!matchMedia("(orientation: portrait)").matches) return 0;
-  const width = document.documentElement.clientWidth || innerWidth;
+function resolveResponsiveProfileIndex(portraitBreakpoints, width, height) {
+  if (height < width) return 0;
   if (width < portraitBreakpoints[0]) return 1;
   if (width < portraitBreakpoints[1]) return 2;
   if (width < portraitBreakpoints[2]) return 3;
   return 4;
+}
+
+function resolvePresentationScale(renderer, width, height) {
+  if (height >= width) {
+    return Math.min(
+      width / renderer.portraitPresentationBase[0],
+      height / renderer.portraitPresentationBase[1],
+    );
+  }
+  return Math.min(
+    renderer.landscapeCardMaximumWidthCssPixels / renderer.cardSourceSize[0],
+    renderer.landscapePresentationBaseScale * Math.min(
+      width / renderer.landscapePresentationBase[0],
+      height / renderer.landscapePresentationBase[1],
+    ),
+  );
+}
+
+function preparedMatrix(layout, width, height, presentationScale, renderer) {
+  const [xViewport, xCardWidthFactor, yViewport, yPixels, yCardHeightFactor] = layout;
+  const [cardWidth, cardHeight] = renderer.cardSourceSize;
+  const [primitiveWidth, primitiveHeight] = renderer.cardPrimitiveSize;
+  const scaleX = cardHeight / primitiveWidth * presentationScale;
+  const scaleY = cardWidth / primitiveHeight * presentationScale;
+  const x = xViewport / 100 * width + xCardWidthFactor * cardWidth * presentationScale;
+  const y = yViewport / 100 * height + yPixels + yCardHeightFactor * cardHeight * presentationScale;
+  return `matrix(0,${rounded(scaleX)},${rounded(-scaleY)},0,${rounded(x)},${rounded(y)})`;
+}
+
+function rounded(value) {
+  const next = Math.round(value * 1e6) / 1e6;
+  return Object.is(next, -0) ? 0 : next;
+}
+
+function validRenderer(renderer) {
+  return Array.isArray(renderer?.cardSourceSize) && renderer.cardSourceSize.length === 2 &&
+    Array.isArray(renderer.cardPrimitiveSize) && renderer.cardPrimitiveSize.length === 2 &&
+    Array.isArray(renderer.landscapePresentationBase) && renderer.landscapePresentationBase.length === 2 &&
+    Array.isArray(renderer.portraitPresentationBase) && renderer.portraitPresentationBase.length === 2 &&
+    Number.isFinite(renderer.landscapePresentationBaseScale) &&
+    Number.isFinite(renderer.landscapeCardMaximumWidthCssPixels);
 }
 
 function readFaceIndex(leaf) {

--- a/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
+++ b/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
@@ -98,25 +98,24 @@ function rounded(value) {
   return Object.is(next, -0) ? 0 : next;
 }
 
-function calcLength(viewportValue, viewportUnit, pixelValue, variableFactor, variableName) {
-  const terms = [`${rounded(viewportValue)}${viewportUnit}`];
-  for (const [value, suffix] of [
-    [pixelValue, "px"],
-    [variableFactor, ` * var(${variableName})`],
-  ]) {
-    const roundedValue = rounded(value);
-    terms.push(`${roundedValue < 0 ? "-" : "+"} ${rounded(Math.abs(roundedValue))}${suffix}`);
-  }
-  return `calc(${terms.join(" ")})`;
+function cardLayout({ xViewport, xCardWidthFactor, yViewport, yPixels, yCardHeightFactor }) {
+  return Object.freeze([
+    xViewport,
+    xCardWidthFactor,
+    yViewport,
+    yPixels,
+    yCardHeightFactor,
+  ].map(rounded));
 }
 
-function cardTransform({ xViewport, xCardWidthFactor, yViewport, yPixels, yCardHeightFactor }) {
-  return [
-    `translate(${calcLength(xViewport, "vw", 0, xCardWidthFactor, "--csssolitaire-card-width")},` +
-      `${calcLength(yViewport, "vh", yPixels, yCardHeightFactor, "--csssolitaire-card-height")})`,
-    "rotate(90deg)",
-    "scale(var(--csssolitaire-card-transform-x),var(--csssolitaire-card-transform-y))",
-  ].join(" ");
+function cardMatrix(layout, viewportWidth, viewportHeight, presentationScale) {
+  const [xViewport, xCardWidthFactor, yViewport, yPixels, yCardHeightFactor] = layout;
+  const scaleX = CARD_HEIGHT / CARD_SOURCE_WIDTH * presentationScale;
+  const scaleY = CARD_WIDTH / CARD_SOURCE_HEIGHT * presentationScale;
+  const x = xViewport / 100 * viewportWidth + xCardWidthFactor * CARD_WIDTH * presentationScale;
+  const y = yViewport / 100 * viewportHeight + yPixels +
+    yCardHeightFactor * CARD_HEIGHT * presentationScale;
+  return `matrix(0,${rounded(scaleX)},${rounded(-scaleY)},0,${rounded(x)},${rounded(y)})`;
 }
 
 function reflectBetween(value, minimum, maximum) {
@@ -376,16 +375,24 @@ function simulateSource(seed) {
 }
 
 function cardLeaf({ cardFace, foundationIndex, horizontalDirection, left, top }) {
-  const landscape = landscapeCardPosition(left, top, foundationIndex, horizontalDirection);
-  const portraitMatrices = PORTRAIT_PROFILES.map((profile) => {
+  const landscapeLayout = cardLayout(
+    landscapeCardPosition(left, top, foundationIndex, horizontalDirection),
+  );
+  const portraitLayouts = PORTRAIT_PROFILES.map((profile) => {
     const portrait = portraitCardPosition(left, top, foundationIndex, horizontalDirection, profile);
-    return portrait ? cardTransform(portrait) : null;
+    return portrait ? cardLayout(portrait) : null;
   });
   return Object.freeze({
     faceIndex: cardFace - 1,
     foundationIndex,
-    matrix: cardTransform(landscape),
-    portraitMatrices: Object.freeze(portraitMatrices),
+    matrix: cardMatrix(
+      landscapeLayout,
+      LANDSCAPE_PLAYFIELD[0],
+      LANDSCAPE_PLAYFIELD[1],
+      LANDSCAPE_PRESENTATION_SCALE,
+    ),
+    layout: landscapeLayout,
+    portraitLayouts: Object.freeze(portraitLayouts),
     atlas: atlasPosition(cardFace),
   });
 }
@@ -480,11 +487,11 @@ function buildPreparedPattern(seed, index) {
       frameTimesMs: timeline.frameTimesMs,
       visibilityRows: timeline.visibilityRows,
       foundationRows: timeline.foundationRows,
-      leafMatrices: trailLeaves.map(({ matrix: leafMatrix }) => leafMatrix),
-      leafPortraitMatricesByCardCount: PORTRAIT_CARD_COUNTS.map((_, profileIndex) =>
-        trailLeaves.map(({ portraitMatrices }) => {
-          const portraitMatrix = portraitMatrices[profileIndex];
-          return portraitMatrix;
+      leafLayouts: trailLeaves.map(({ layout }) => layout),
+      leafPortraitLayoutsByCardCount: PORTRAIT_CARD_COUNTS.map((_, profileIndex) =>
+        trailLeaves.map(({ portraitLayouts }) => {
+          const portraitLayout = portraitLayouts[profileIndex];
+          return portraitLayout;
         })),
       leafAtlasIndices: source.snapshots.map(({ faceNumber: cardFace }) => cardFace - 1),
     }),
@@ -506,7 +513,7 @@ function buildSnapshot(leaves, cardAssetUrl) {
     return `.polycss-scene>b.${faceClass(faceIndex)}{background-position:${-atlas.x}px ${-atlas.y}px}`;
   }).join("");
   const css = [
-    `.polycss-camera{position:relative;display:block;width:100%;height:100%;overflow:hidden;--csssolitaire-presentation-scale:${LANDSCAPE_PRESENTATION_SCALE};--csssolitaire-card-width:calc(${CARD_WIDTH}px * var(--csssolitaire-presentation-scale));--csssolitaire-card-height:calc(${CARD_HEIGHT}px * var(--csssolitaire-presentation-scale));--csssolitaire-card-transform-x:calc(${CARD_HEIGHT / CARD_SOURCE_WIDTH} * var(--csssolitaire-presentation-scale));--csssolitaire-card-transform-y:calc(${CARD_WIDTH / CARD_SOURCE_HEIGHT} * var(--csssolitaire-presentation-scale))}`,
+    ".polycss-camera{position:relative;display:block;width:100%;height:100%;overflow:hidden}",
     ".polycss-scene{position:absolute;inset:0}",
     `.polycss-scene>b{position:absolute;display:block;width:${CARD_SOURCE_WIDTH}px;height:${CARD_SOURCE_HEIGHT}px;margin:0;padding:0;overflow:hidden;border:0;border-radius:14px;background-image:url('${cardAssetUrl}');background-repeat:no-repeat;background-size:${CARD_ATLAS_WIDTH}px ${CARD_ATLAS_HEIGHT}px;transform-origin:0 0;visibility:hidden;pointer-events:none;text-decoration:none;font:normal normal normal 0/0 serif;image-rendering:auto}`,
     ".polycss-scene>b.v{visibility:visible}",
@@ -556,9 +563,16 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
     foundationLeafCount: FOUNDATION_COUNT,
     retainedLeafCount: leaves.length,
     retainedTrailLeafCount,
-    foundationMatrices: foundationLeaves.map(({ matrix: leafMatrix }) => leafMatrix),
-    foundationPortraitMatricesByCardCount: PORTRAIT_CARD_COUNTS.map((_, profileIndex) =>
-      foundationLeaves.map(({ portraitMatrices }) => portraitMatrices[profileIndex])),
+    layoutComponentOrder: [
+      "xViewportPercent",
+      "xCardWidthFactor",
+      "yViewportPercent",
+      "yPixels",
+      "yCardHeightFactor",
+    ],
+    foundationLayouts: foundationLeaves.map(({ layout }) => layout),
+    foundationPortraitLayoutsByCardCount: PORTRAIT_CARD_COUNTS.map((_, profileIndex) =>
+      foundationLeaves.map(({ portraitLayouts }) => portraitLayouts[profileIndex])),
     atlasPositions: Array.from({ length: 52 }, (_, index) => {
       const atlas = atlasPosition(index + 1);
       return `${-atlas.x}px ${-atlas.y}px`;
@@ -631,7 +645,7 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       transformPublication: "prepared-inline-style",
       contentBounds: [contentBounds.left, contentBounds.top, contentBounds.right, contentBounds.bottom],
       responsiveProfiles: ["landscape", "portrait"],
-      viewportPositioning: "prepared-css-vw-vh-no-letterbox",
+      viewportPositioning: "prepared-layout-resolved-inline-matrix-no-letterbox",
       viewportFill: true,
       verticalMapping: "foundation-and-retained-bounce-bottom-anchored",
       foundationTopCssPixels: FOUNDATION_PRESENTATION_TOP,
@@ -639,6 +653,7 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       sourceVerticalAnchors: [SOURCE_ARCH_TOP, FOUNDATION_Y, SOURCE_BOUNCE_BOTTOM],
       upwardArchMapping: "prepared-source-smooth-three-anchor-curve",
       cardSourceSize: [CARD_WIDTH, CARD_HEIGHT],
+      cardPrimitiveSize: [CARD_SOURCE_WIDTH, CARD_SOURCE_HEIGHT],
       landscapePresentationBase: LANDSCAPE_PLAYFIELD,
       landscapePresentationBaseScale: LANDSCAPE_PRESENTATION_SCALE,
       landscapeCardMaximumWidthCssPixels: LANDSCAPE_CARD_MAXIMUM_WIDTH,
@@ -660,7 +675,7 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       runtimeAtlasRasterization: false,
       runtimeGeometryCalculation: false,
       runtimeTrajectoryCalculation: false,
-      runtimeResizeCalculation: "single-root-scale-and-responsive-inline-transform-publication",
+      runtimeResizeCalculation: "prepared-layout-inline-matrix-resolution",
       runtimeDomGrowth: false,
     },
     transport: {

--- a/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
@@ -49,7 +49,8 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.equal(manifest.renderer.transformPublication, "prepared-inline-style");
   assert.deepEqual(manifest.renderer.contentBounds, [-69, -71, 655, 395]);
   assert.deepEqual(manifest.renderer.responsiveProfiles, ["landscape", "portrait"]);
-  assert.equal(manifest.renderer.viewportPositioning, "prepared-css-vw-vh-no-letterbox");
+  assert.equal(manifest.renderer.viewportPositioning,
+    "prepared-layout-resolved-inline-matrix-no-letterbox");
   assert.equal(manifest.renderer.viewportFill, true);
   assert.equal(manifest.renderer.verticalMapping, "foundation-and-retained-bounce-bottom-anchored");
   assert.equal(manifest.renderer.foundationTopCssPixels, 80);
@@ -58,6 +59,7 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.equal(manifest.renderer.upwardArchMapping,
     "prepared-source-smooth-three-anchor-curve");
   assert.deepEqual(manifest.renderer.cardSourceSize, [71, 96]);
+  assert.deepEqual(manifest.renderer.cardPrimitiveSize, [240, 160]);
   assert.deepEqual(manifest.renderer.landscapePresentationBase, [960, 540]);
   assert.equal(manifest.renderer.landscapePresentationBaseScale, 1.40625);
   assert.equal(manifest.renderer.landscapeCardMaximumWidthCssPixels, 200);
@@ -75,7 +77,7 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.equal(manifest.renderer.minimumSlotGap, 11);
   assert.equal(manifest.renderer.presentationScaleMode, "single-root-contain-scale-viewport-positioned");
   assert.equal(manifest.renderer.runtimeResizeCalculation,
-    "single-root-scale-and-responsive-inline-transform-publication");
+    "prepared-layout-inline-matrix-resolution");
   assert.equal(manifest.renderer.seamBleed, 0.2);
   assert.equal(manifest.renderer.runtimeAtlasRasterization, false);
   assert.equal(manifest.renderer.runtimeGeometryCalculation, false);
@@ -124,7 +126,8 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.match(snapshot, /class="polycss-scene"/u);
   assert.doesNotMatch(snapshot, /solitaire-prepared-(?:camera|scene)/u);
   assert.doesNotMatch(snapshot, /csssolitaire-board/u);
-  assert.equal((snapshot.match(/<b class="[^"]+" style="transform:[^"]+"><\/b>/gu) ?? []).length, 1952);
+  assert.equal((snapshot.match(/<b class="[^"]+" style="transform:matrix\([^)]+\)"><\/b>/gu) ?? []).length,
+    1952);
   assert.doesNotMatch(snapshot, /<s\b/u);
   assert.doesNotMatch(snapshot, /--csssolitaire-(?:landscape|portrait)-/u);
   assert.equal((snapshot.match(/\sstyle="transform:/gu) ?? []).length, 1952);
@@ -137,26 +140,25 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.doesNotMatch(snapshot, /\bfoundation\b|\blane-[0-3]\b/u);
   assert.match(snapshot, /\.polycss-scene\{position:absolute;inset:0\}/u);
   assert.match(snapshot, /\.polycss-scene>b\{position:absolute/u);
-  assert.match(snapshot, /--csssolitaire-card-width:calc\(71px \* var\(--csssolitaire-presentation-scale/u);
+  assert.doesNotMatch(snapshot, /--csssolitaire-/u);
   assert.doesNotMatch(snapshot, /--csssolitaire-fit/u);
   assert.match(snapshot,
     /max-width:519px\)\{\.polycss-scene>b:nth-child\(2\),\.polycss-scene>b:nth-child\(3\),\.polycss-scene>b:nth-child\(4\)\{display:none\}/u);
   assert.match(snapshot, /border-radius:14px/u);
   assert.doesNotMatch(snapshot, /box-shadow/u);
   assert.match(snapshot, /image-rendering:auto/u);
-  assert.doesNotMatch(snapshot, /matrix3d|preserve-3d|backface-visibility/u);
+  assert.doesNotMatch(snapshot, /matrix3d|translate\(calc|preserve-3d|backface-visibility/u);
   assert.doesNotMatch(snapshot, /<(?:script|canvas|svg)\b|\sdata-[a-z0-9-]+=/iu);
 
   const playback = JSON.parse(await readFile(join(generated, "solitaire-playback.json"), "utf8"));
   assert.equal(playback.schema, "csssolitaire-prepared-playback@2");
-  const preparedTransforms = playback.patterns.flatMap((pattern) => [
-    ...pattern.leafMatrices,
-    ...pattern.leafPortraitMatricesByCardCount.flat().filter(Boolean),
-  ]).concat(playback.foundationMatrices, playback.foundationPortraitMatricesByCardCount.flat());
-  const topAnchoredPixels = preparedTransforms
-    .map((transform) => transform.match(/,calc\(0vh \+ ([\d.]+)px/u)?.[1])
-    .filter(Boolean)
-    .map(Number);
+  const preparedLayouts = playback.patterns.flatMap((pattern) => [
+    ...pattern.leafLayouts,
+    ...pattern.leafPortraitLayoutsByCardCount.flat().filter(Boolean),
+  ]).concat(playback.foundationLayouts, playback.foundationPortraitLayoutsByCardCount.flat());
+  const topAnchoredPixels = preparedLayouts
+    .filter((layout) => layout[2] === 0)
+    .map((layout) => layout[3]);
   assert.ok(topAnchoredPixels.length > 0);
   assert.equal(Math.min(...topAnchoredPixels), 8);
   assert.ok(Math.max(...topAnchoredPixels) <= 80);
@@ -182,8 +184,8 @@ test("generated product is one complete retained snapshot plus sparse prepared p
     return new Set(velocities).size === velocities.length;
   })));
   assert.ok(playback.patterns.every((pattern) =>
-    pattern.leafPortraitMatricesByCardCount.length === 4 &&
-    pattern.leafPortraitMatricesByCardCount.every((profile) =>
+    pattern.leafPortraitLayoutsByCardCount.length === 4 &&
+    pattern.leafPortraitLayoutsByCardCount.every((profile) =>
       profile.length === pattern.trailLeafCount && profile.every(Boolean))));
   assert.ok(playback.patterns.every((pattern) => !("leafFoundationIndices" in pattern)));
   const maximumPortraitUpdateGaps = [1, 2, 3, 4].map((cardCount) => Math.max(
@@ -196,10 +198,10 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   ));
   assert.deepEqual(maximumPortraitUpdateGaps, [500, 500, 500, 500]);
   const initialPattern = playback.patterns[0];
-  const oneCardTransforms = initialPattern.leafPortraitMatricesByCardCount[0];
-  assert.equal(oneCardTransforms.length, initialPattern.trailLeafCount);
-  assert.ok(oneCardTransforms.every((transform) => transform.includes("vw") && transform.includes("vh")));
-  assert.ok(new Set(oneCardTransforms).size > 100);
+  const oneCardLayouts = initialPattern.leafPortraitLayoutsByCardCount[0];
+  assert.equal(oneCardLayouts.length, initialPattern.trailLeafCount);
+  assert.ok(oneCardLayouts.every((layout) => layout.length === 5 && layout.every(Number.isFinite)));
+  assert.ok(new Set(oneCardLayouts.map(JSON.stringify)).size > 100);
   assert.equal(initialPattern.sourceStepCount, 1679);
   assert.equal(initialPattern.frameTimesMs.length, 609);
   assert.equal(initialPattern.visibilityRows.length, 609);

--- a/src/adapters/solitaire/test/csssolitaire-shell.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-shell.test.mjs
@@ -42,11 +42,11 @@ test("product shell is the standard css.graphics route without demo controls", a
   assert.match(player, /deadline-setTimeout-prepared-visibility-publication/u);
   assert.doesNotMatch(player, /Math\.random|requestAnimationFrame\s*\(|createElement|DOMMatrix/u);
   assert.doesNotMatch(player, /lane-/u);
-  assert.match(snapshotMount, /new ResizeObserver\(updatePresentation\)/u);
-  assert.match(snapshotMount, /host\.clientWidth/u);
-  assert.match(snapshotMount, /host\.clientHeight/u);
-  assert.match(snapshotMount, /--csssolitaire-presentation-scale/u);
-  assert.match(snapshotMount, /single-root-presentation-scale-only/u);
+  assert.match(player, /new ResizeObserver\(syncPresentation\)/u);
+  assert.match(player, /host\.clientWidth/u);
+  assert.match(player, /host\.clientHeight/u);
+  assert.match(player, /prepared-layout-inline-matrix-resolution/u);
+  assert.match(player, /return `matrix\(0,/u);
   assert.match(snapshotMount, /runtimeGeometryBoundsCalculationCount: 0/u);
   assert.doesNotMatch(snapshotMount, /renderer\.contentBounds/u);
 });

--- a/src/adapters/solitaire/tools/smoke-browser.mjs
+++ b/src/adapters/solitaire/tools/smoke-browser.mjs
@@ -223,9 +223,10 @@ try {
         evidence.stats.runtimeRandomSelectionPurpose !== "prepared-pattern-shuffled-bag-index-only" ||
         evidence.stats.runtimeGeometryCalculationCount !== 0 ||
         evidence.stats.runtimeGeometryBoundsCalculationCount !== 0 ||
-        evidence.stats.runtimeFitCalculationPurpose !== "single-root-presentation-scale-only" ||
+        evidence.stats.runtimeFitCalculationPurpose !== "prepared-layout-inline-matrix-resolution" ||
         Math.abs(evidence.stats.runtimePresentationScale - 1.40625) > 0.000001 ||
-        evidence.stats.runtimePresentationScaleWrites !== 0 ||
+        evidence.stats.runtimePresentationUpdateCount !== 0 ||
+        evidence.stats.runtimeResponsiveMatrixResolutionCount < 1 ||
         evidence.stats.runtimeTrajectoryCalculationCount !== 0 ||
         evidence.stats.runtimeAtlasRasterizationCount !== 0 ||
         evidence.stats.runtimeDomMutationCount !== 0 ||


### PR DESCRIPTION
## Summary
- publish each retained card as a `<b>` with one compact inline `matrix(...)` transform
- keep responsive trajectory coefficients in the prepared playback payload instead of serializing expanded formulas into the DOM
- resolve the prepared layout only at mount, resize, and pattern handoff while preserving the existing desktop/mobile geometry

## Root cause
The previous DOM cleanup inlined the full responsive `translate(calc(...)) rotate() scale()` expression rather than the compact matrix requested.

## Verification
- `pnpm prepare:solitaire`
- `pnpm test:solitaire`
- `pnpm test:solitaire:assets`
- `pnpm build:solitaire`
- `pnpm test:solitaire:browser`
- `pnpm build:solitaire:deploy`
- `pnpm test:solitaire:deploy`
- `pnpm prepare:solitaire:check`
- `pnpm verify:source-only`