### PR TITLE
Fix Solitaire card state and phone playback

### DIFF
--- a/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
@@ -73,8 +73,12 @@ function validateManifest(manifest) {
       JSON.stringify(manifest.renderer?.portraitCardCounts) !== "[1,2,3,4]" ||
       JSON.stringify(manifest.renderer?.portraitCardBreakpoints) !== "[520,720,920]" ||
       manifest.renderer?.portraitHorizontalMotion !==
-        "mobile-reflected-wall-bounce-multi-card-full-exit" ||
+        "phone-reflected-three-card-cycle-wider-multi-card-exit" ||
       JSON.stringify(manifest.renderer?.portraitWallBounceCardCounts) !== "[1]" ||
+      manifest.renderer?.phoneLaunchCardCount !== 3 ||
+      manifest.renderer?.phonePlaybackTimeScale !== 3 ||
+      manifest.renderer?.phoneHorizontalDistanceScale !== 8 ||
+      manifest.renderer?.phoneProfileIndex !== 1 ||
       manifest.renderer?.preparedSlotLayout !== "source-seven-slot-presentation-scaled-card-size" ||
       manifest.renderer?.slotCount !== 7 || manifest.renderer?.minimumSlotGap !== 11 ||
       manifest.renderer?.presentationScaleMode !== "single-root-contain-scale-viewport-positioned" ||
@@ -107,6 +111,8 @@ function validateManifest(manifest) {
       manifest.metrics?.preparedPatternCount !== 24 ||
       manifest.metrics?.preparedFoundationOperationCount !== 576 ||
       manifest.metrics?.preparedFrameCount !== 13774 ||
+      !Number.isSafeInteger(manifest.metrics?.preparedPhoneFrameCount) ||
+      manifest.metrics.preparedPhoneFrameCount <= 0 ||
       manifest.metrics?.preparedLeafLayoutCount !== 38014 ||
       manifest.metrics?.initialPatternDurationMs !== 27210 ||
       manifest.metrics?.minimumPatternDurationMs !== 20475 ||
@@ -129,6 +135,7 @@ function validatePlayback(playback, manifest) {
   if (playback?.schema !== "csssolitaire-prepared-playback@2" || playback.loop !== true ||
       playback.selection !== "crypto-random-shuffled-bag-no-immediate-repeat" ||
       playback.patternCount !== 24 || playback.initialPatternIndex !== 0 ||
+      playback.phoneProfileIndex !== 1 ||
       playback.sourceStepMilliseconds !== 7.5 || playback.initialHoldMilliseconds !== 500 ||
       playback.foundationLeafCount !== manifest.metrics.foundationLeafCount ||
       playback.retainedLeafCount !== manifest.metrics.retainedLeafCount ||
@@ -149,6 +156,8 @@ function validatePlayback(playback, manifest) {
       playback.patterns.some((pattern, index) => !validPattern(pattern, playback, manifest, index)) ||
       playback.patterns.reduce((sum, pattern) => sum + pattern.frameTimesMs.length, 0) !==
         manifest.metrics.preparedFrameCount ||
+      playback.patterns.reduce((sum, pattern) => sum + pattern.phoneTimeline.frameTimesMs.length, 0) !==
+        manifest.metrics.preparedPhoneFrameCount ||
       playback.patterns.reduce((sum, pattern) => sum + pattern.trailLeafCount, 0) !==
         manifest.metrics.preparedLeafLayoutCount ||
       playback.runtimeSelectionOnly !== true ||
@@ -169,9 +178,11 @@ function validPattern(pattern, playback, manifest, index) {
     pattern.seed === manifest.sourceProfile.patternSeeds[index] &&
     sourcePattern?.id === pattern.id && sourcePattern.seed === pattern.seed &&
     pattern.trailLeafCount === sourcePattern.trailLeafCount &&
+    pattern.launchCardCount === manifest.sourceProfile.cards &&
     pattern.trailLeafCount > 0 && pattern.trailLeafCount <= playback.retainedTrailLeafCount &&
     pattern.sourceDrawCount === sourcePattern.sourceDraws &&
     pattern.sourceStepCount === sourcePattern.sourceSteps &&
+    pattern.sourceStepMilliseconds === playback.sourceStepMilliseconds &&
     pattern.durationMs === sourcePattern.durationMs &&
     pattern.rewindStartMilliseconds > 0 &&
     pattern.rewindEndMilliseconds > pattern.rewindStartMilliseconds &&
@@ -207,7 +218,38 @@ function validPattern(pattern, playback, manifest, index) {
         profileIndex > 0 && profiles[profileIndex - 1][leafIndex] !== null && profile[leafIndex] === null)) &&
     Array.isArray(pattern.leafAtlasIndices) && pattern.leafAtlasIndices.length === pattern.trailLeafCount &&
     !pattern.leafAtlasIndices.some((atlasIndex) =>
-      !Number.isSafeInteger(atlasIndex) || atlasIndex < 0 || atlasIndex >= playback.atlasPositions.length);
+      !Number.isSafeInteger(atlasIndex) || atlasIndex < 0 || atlasIndex >= playback.atlasPositions.length) &&
+    validPhoneTimeline(pattern.phoneTimeline, playback, pattern.trailLeafCount);
+}
+
+function validPhoneTimeline(timeline, playback, patternTrailLeafCount) {
+  const frameTimes = timeline?.frameTimesMs;
+  const visibilityRows = timeline?.visibilityRows;
+  const foundationRows = timeline?.foundationRows;
+  return timeline?.launchCardCount === 3 && timeline.sourceStepMilliseconds === 22.5 &&
+    Number.isSafeInteger(timeline.sourceStepCount) && timeline.sourceStepCount > 0 &&
+    Number.isSafeInteger(timeline.trailLeafCount) && timeline.trailLeafCount > 0 &&
+    timeline.trailLeafCount <= patternTrailLeafCount &&
+    timeline.durationMs > timeline.rewindEndMilliseconds &&
+    timeline.rewindEndMilliseconds > timeline.rewindStartMilliseconds &&
+    timeline.rewindStartMilliseconds > 0 &&
+    Array.isArray(frameTimes) && frameTimes.length > 1 && frameTimes[0] === 0 &&
+    frameTimes.at(-1) === timeline.rewindEndMilliseconds &&
+    !frameTimes.some((time, frameIndex, times) =>
+      !Number.isFinite(time) || time < 0 || (frameIndex > 0 && time <= times[frameIndex - 1])) &&
+    Array.isArray(visibilityRows) && visibilityRows.length === frameTimes.length &&
+    visibilityRows[0].length === timeline.trailLeafCount &&
+    !visibilityRows.some((row) => !Array.isArray(row) || row.some((operation) =>
+      !Number.isSafeInteger(operation) || Math.abs(operation) <= playback.foundationLeafCount ||
+      Math.abs(operation) > playback.foundationLeafCount + timeline.trailLeafCount)) &&
+    Array.isArray(foundationRows) && foundationRows.length === frameTimes.length &&
+    !foundationRows.some((row) => !Array.isArray(row) || row.some((operation) =>
+      !Array.isArray(operation) || operation.length !== 3 ||
+      !Number.isSafeInteger(operation[0]) || operation[0] < 0 ||
+      operation[0] >= playback.foundationLeafCount ||
+      !Number.isSafeInteger(operation[1]) || !Number.isSafeInteger(operation[2]) ||
+      !((operation[1] === -1 && operation[2] === -1) ||
+        (operation[1] >= 0 && operation[1] <= 720 && operation[2] >= 0 && operation[2] <= 1920))));
 }
 
 function validPreparedLayout(layout) {

--- a/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
@@ -17,7 +17,7 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
       leaves.length !== manifest.metrics.retainedLeafCount ||
       snapshot.querySelectorAll("[style]").length !== leaves.length ||
       leaves.some((leaf) => !(leaf instanceof HTMLElement) || leaf.localName !== "b" ||
-        !hasInlineTransformOnly(leaf))) {
+        !hasInlinePreparedStyle(leaf))) {
     throw new Error("Prepared cssSolitaire retained DOM census drifted");
   }
 
@@ -31,7 +31,7 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
   if (!(mountedScene instanceof HTMLElement) ||
       mountedScene.childElementCount !== manifest.metrics.retainedLeafCount ||
       mountedLeaves.length !== manifest.metrics.retainedLeafCount ||
-      mountedLeaves.some((leaf) => !hasInlineTransformOnly(leaf))) {
+      mountedLeaves.some((leaf) => !hasInlinePreparedStyle(leaf))) {
     throw new Error("Mounted cssSolitaire retained DOM census drifted");
   }
   const stableNodes = Object.freeze([mountedCamera, mountedScene, ...mountedLeaves]);
@@ -43,7 +43,7 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
       ...host.querySelectorAll(":scope > .polycss-camera > .polycss-scene > b"),
     ];
     if (current.length !== stableNodes.length || current.some((node, index) => node !== stableNodes[index]) ||
-        mountedLeaves.some((leaf) => !hasInlineTransformOnly(leaf))) {
+        mountedLeaves.some((leaf) => !hasInlinePreparedStyle(leaf))) {
       throw new Error("Prepared cssSolitaire retained DOM identity changed");
     }
     return true;
@@ -63,7 +63,10 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
         retainedBoardRootCount: 0,
         retainedRenderWrapperCount: 2,
         retainedPolygonLeafCount: mountedLeaves.length,
-        retainedLeafInlineStyleDeclarationCount: mountedLeaves.length,
+        retainedLeafInlineStyleDeclarationCount: mountedLeaves.reduce(
+          (count, leaf) => count + leaf.style.length,
+          0,
+        ),
         retainedDataAttributeCount: 0,
         runtimeDomCreationCount: 0,
         runtimeDomRemovalCount: 0,
@@ -81,8 +84,17 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
   });
 }
 
-function hasInlineTransformOnly(leaf) {
-  return leaf.style.length === 1 && leaf.style[0] === "transform" && leaf.style.transform.length > 0;
+function hasInlinePreparedStyle(leaf) {
+  const properties = [...leaf.style];
+  return leaf.className === "" && properties.length >= 3 && properties.length <= 4 &&
+    properties.includes("transform") && properties.includes("background-position-x") &&
+    properties.includes("background-position-y") &&
+    properties.every((property) =>
+      property === "transform" || property === "background-position-x" ||
+      property === "background-position-y" || property === "visibility") &&
+    leaf.style.transform.startsWith("matrix(") &&
+    /^-?\d+px -?\d+px$/u.test(leaf.style.backgroundPosition) &&
+    (leaf.style.visibility === "" || leaf.style.visibility === "visible");
 }
 
 function hasPreparedMetadata(doc) {

--- a/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
@@ -33,13 +33,13 @@ export function createCsssolitairePreparedPlayer({
   const foundationLeafCount = playback.foundationLeafCount;
   const foundationLeaves = leaves.slice(0, foundationLeafCount);
   const trailLeaves = leaves.slice(foundationLeafCount);
-  const initialFoundationFaceIndices = foundationLeaves.map(readFaceIndex);
+  const atlasFaceIndices = new Map(playback.atlasPositions.map((position, index) => [position, index]));
+  const initialFoundationFaceIndices = foundationLeaves.map((leaf) => readFaceIndex(leaf, atlasFaceIndices));
   const foundationFaceIndices = [...initialFoundationFaceIndices];
   const foundationVisibility = new Uint8Array(foundationLeafCount);
   foundationVisibility.fill(1);
   const trailVisibility = new Uint8Array(trailLeaves.length);
-  const trailFaceIndices = trailLeaves.map(readFaceIndex);
-  const atlasFaceIndices = new Map(playback.atlasPositions.map((position, index) => [position, index]));
+  const trailFaceIndices = trailLeaves.map((leaf) => readFaceIndex(leaf, atlasFaceIndices));
   let activePatternIndex = playback.initialPatternIndex;
   let pattern = patterns[activePatternIndex];
   let activeProfileIndex = 0;
@@ -53,7 +53,7 @@ export function createCsssolitairePreparedPlayer({
   let visibleFoundationCards = foundationLeafCount;
   let visibilityWrites = 0;
   let visibilityOperationsApplied = 0;
-  let foundationClassWrites = 0;
+  let foundationStyleWrites = 0;
   let foundationOperationsApplied = 0;
   let patternLayoutWrites = 0;
   let patternLayoutLeavesVisited = 0;
@@ -133,7 +133,7 @@ export function createCsssolitairePreparedPlayer({
       visibilityOperationsApplied += 1;
       if (Boolean(trailVisibility[trailIndex]) === visible) continue;
       trailVisibility[trailIndex] = Number(visible);
-      leaves[leafIndex].classList.toggle("v", visible);
+      leaves[leafIndex].style.visibility = visible ? "visible" : "";
       visibleTrailCards += visible ? 1 : -1;
       visibilityWrites += 1;
       writes += 1;
@@ -149,7 +149,7 @@ export function createCsssolitairePreparedPlayer({
       if (atlasX < 0) {
         if (foundationVisibility[foundationIndex] === 0) continue;
         foundationVisibility[foundationIndex] = 0;
-        leaf.classList.remove("v");
+        leaf.style.visibility = "";
         visibleFoundationCards -= 1;
         writes += 1;
         continue;
@@ -158,18 +158,18 @@ export function createCsssolitairePreparedPlayer({
       const faceIndex = atlasFaceIndices.get(position);
       if (!Number.isInteger(faceIndex)) throw new Error("Prepared cssSolitaire atlas position drifted");
       if (foundationFaceIndices[foundationIndex] !== faceIndex) {
-        setFaceClass(leaf, foundationFaceIndices[foundationIndex], faceIndex);
+        leaf.style.backgroundPosition = position;
         foundationFaceIndices[foundationIndex] = faceIndex;
         writes += 1;
       }
       if (foundationVisibility[foundationIndex] === 0) {
         foundationVisibility[foundationIndex] = 1;
-        leaf.classList.add("v");
+        leaf.style.visibility = "visible";
         visibleFoundationCards += 1;
         writes += 1;
       }
     }
-    foundationClassWrites += writes;
+    foundationStyleWrites += writes;
     return writes;
   }
 
@@ -185,7 +185,7 @@ export function createCsssolitairePreparedPlayer({
         writes += 1;
       }
       if (trailFaceIndices[index] !== faceIndex) {
-        setFaceClass(leaf, trailFaceIndices[index], faceIndex);
+        leaf.style.backgroundPosition = playback.atlasPositions[faceIndex];
         trailFaceIndices[index] = faceIndex;
         writes += 1;
       }
@@ -199,7 +199,7 @@ export function createCsssolitairePreparedPlayer({
     for (let index = 0; index < trailVisibility.length; index += 1) {
       if (trailVisibility[index] === 0) continue;
       trailVisibility[index] = 0;
-      trailLeaves[index].classList.remove("v");
+      trailLeaves[index].style.visibility = "";
       writes += 1;
     }
     let foundationWrites = 0;
@@ -207,13 +207,13 @@ export function createCsssolitairePreparedPlayer({
       const leaf = foundationLeaves[index];
       const initialFaceIndex = initialFoundationFaceIndices[index];
       if (foundationFaceIndices[index] !== initialFaceIndex) {
-        setFaceClass(leaf, foundationFaceIndices[index], initialFaceIndex);
+        leaf.style.backgroundPosition = playback.atlasPositions[initialFaceIndex];
         foundationFaceIndices[index] = initialFaceIndex;
         foundationWrites += 1;
       }
       if (foundationVisibility[index] === 0) {
         foundationVisibility[index] = 1;
-        leaf.classList.add("v");
+        leaf.style.visibility = "visible";
         foundationWrites += 1;
       }
     }
@@ -222,7 +222,7 @@ export function createCsssolitairePreparedPlayer({
     frameIndex = 0;
     playheadMs = 0;
     visibilityWrites += writes;
-    foundationClassWrites += foundationWrites;
+    foundationStyleWrites += foundationWrites;
     resetCount += 1;
     lastApply = Object.freeze({
       visibilityWrites: writes,
@@ -408,7 +408,7 @@ export function createCsssolitairePreparedPlayer({
         runtimeVisibilityOperationsApplied: visibilityOperationsApplied,
         runtimeFoundationOperationsApplied: foundationOperationsApplied,
         runtimeLeafVisibilityWrites: visibilityWrites,
-        runtimeFoundationClassWrites: foundationClassWrites,
+        runtimeFoundationStyleWrites: foundationStyleWrites,
         runtimePatternLayoutWrites: patternLayoutWrites,
         runtimePatternLayoutLeavesVisited: patternLayoutLeavesVisited,
         runtimeResponsiveTransformWrites: responsiveTransformWrites,
@@ -490,18 +490,10 @@ function validRenderer(renderer) {
     Number.isFinite(renderer.landscapeCardMaximumWidthCssPixels);
 }
 
-function readFaceIndex(leaf) {
-  for (const className of leaf.classList) {
-    if (!/^f[0-9a-z]+$/u.test(className)) continue;
-    const index = Number.parseInt(className.slice(1), 36);
-    if (Number.isSafeInteger(index) && index >= 0 && index < 52) return index;
-  }
-  throw new Error("Prepared cssSolitaire face class drifted");
-}
-
-function setFaceClass(leaf, previousIndex, nextIndex) {
-  leaf.classList.remove(`f${previousIndex.toString(36)}`);
-  leaf.classList.add(`f${nextIndex.toString(36)}`);
+function readFaceIndex(leaf, atlasFaceIndices) {
+  const index = atlasFaceIndices.get(leaf.style.backgroundPosition);
+  if (Number.isSafeInteger(index)) return index;
+  throw new Error("Prepared cssSolitaire inline atlas position drifted");
 }
 
 function cryptoRandomUint32() {

--- a/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
@@ -13,6 +13,7 @@ export function createCsssolitairePreparedPlayer({
       !(host instanceof HTMLElement) || !validRenderer(renderer) ||
       !(scene instanceof HTMLElement) || !Array.isArray(leaves) ||
       leaves.length !== playback.retainedLeafCount ||
+      playback.phoneProfileIndex !== 1 ||
       JSON.stringify(portraitBreakpoints) !== "[520,720,920]") {
     throw new Error("Prepared cssSolitaire player input drifted");
   }
@@ -76,6 +77,10 @@ export function createCsssolitairePreparedPlayer({
     dirtyLeavesVisited: 0,
   });
 
+  function timelineFor(nextPattern = pattern, profileIndex = activeProfileIndex) {
+    return profileIndex === playback.phoneProfileIndex ? nextPattern.phoneTimeline : nextPattern;
+  }
+
   function layoutForPattern(nextPattern, index, profileIndex = activeProfileIndex) {
     return profileIndex === 0
       ? nextPattern.leafLayouts[index]
@@ -89,6 +94,8 @@ export function createCsssolitairePreparedPlayer({
   }
 
   function applyPresentation(nextProfileIndex, width, height, scale) {
+    const timelineChanged = (activeProfileIndex === playback.phoneProfileIndex) !==
+      (nextProfileIndex === playback.phoneProfileIndex);
     let writes = 0;
     for (let index = 0; index < foundationLeafCount; index += 1) {
       const layout = nextProfileIndex === 0
@@ -112,6 +119,13 @@ export function createCsssolitairePreparedPlayer({
     presentationScale = scale;
     responsiveTransformWrites += writes;
     presentationUpdateCount += 1;
+    if (timelineChanged) {
+      resetInitial();
+      cycleStartedAt = performance.now();
+      if (timer !== null) clearTimeout(timer);
+      timer = null;
+      schedule();
+    }
   }
 
   function syncPresentation() {
@@ -266,23 +280,24 @@ export function createCsssolitairePreparedPlayer({
     });
   }
 
-  function frameAt(timeMs) {
+  function frameAt(timeMs, timeline) {
     let low = 0;
-    let high = pattern.frameTimesMs.length - 1;
+    let high = timeline.frameTimesMs.length - 1;
     while (low <= high) {
       const middle = Math.floor((low + high) / 2);
-      if (pattern.frameTimesMs[middle] <= timeMs) low = middle + 1;
+      if (timeline.frameTimesMs[middle] <= timeMs) low = middle + 1;
       else high = middle - 1;
     }
     return Math.max(0, high);
   }
 
   function applyCycleTime(timeMs) {
-    const targetFrame = frameAt(timeMs);
+    const timeline = timelineFor();
+    const targetFrame = frameAt(timeMs, timeline);
     if (targetFrame < frameIndex) resetInitial();
     for (let index = frameIndex + 1; index <= targetFrame; index += 1) {
-      const visibilityRow = pattern.visibilityRows[index];
-      const foundationRow = pattern.foundationRows[index];
+      const visibilityRow = timeline.visibilityRows[index];
+      const foundationRow = timeline.foundationRows[index];
       const trailWrites = applyRow(visibilityRow);
       const foundationWrites = applyFoundationRow(foundationRow);
       lastApply = Object.freeze({
@@ -298,11 +313,13 @@ export function createCsssolitairePreparedPlayer({
 
   function publishNow(now = performance.now()) {
     let elapsed = Math.max(0, now - cycleStartedAt);
-    while (elapsed >= pattern.durationMs) {
-      cycleStartedAt += pattern.durationMs;
+    let timeline = timelineFor();
+    while (elapsed >= timeline.durationMs) {
+      cycleStartedAt += timeline.durationMs;
       elapsed = Math.max(0, now - cycleStartedAt);
       resetInitial();
       activatePattern(nextPatternIndex());
+      timeline = timelineFor();
       loopCount += 1;
     }
     applyCycleTime(elapsed);
@@ -311,8 +328,9 @@ export function createCsssolitairePreparedPlayer({
   function schedule() {
     if (paused || timer !== null) return;
     const now = performance.now();
-    const nextFrameTime = pattern.frameTimesMs[frameIndex + 1];
-    const deadline = cycleStartedAt + (nextFrameTime ?? pattern.durationMs);
+    const timeline = timelineFor();
+    const nextFrameTime = timeline.frameTimesMs[frameIndex + 1];
+    const deadline = cycleStartedAt + (nextFrameTime ?? timeline.durationMs);
     timer = setTimeout(tick, Math.max(0, deadline - now));
   }
 
@@ -326,6 +344,7 @@ export function createCsssolitairePreparedPlayer({
 
   function snapshot() {
     target.assertStableDomIdentity();
+    const timeline = timelineFor();
     return Object.freeze({
       ready: true,
       playing: !paused,
@@ -335,12 +354,17 @@ export function createCsssolitairePreparedPlayer({
       responsiveProfileIndex: activeProfileIndex,
       playheadMs,
       frameIndex,
-      rewinding: playheadMs >= pattern.rewindStartMilliseconds && playheadMs <= pattern.rewindEndMilliseconds,
+      durationMs: timeline.durationMs,
+      launchCardCount: timeline.launchCardCount,
+      timelineTrailLeafCount: timeline.trailLeafCount,
+      rewinding: playheadMs >= timeline.rewindStartMilliseconds && playheadMs <= timeline.rewindEndMilliseconds,
       sourceStep: Math.min(
-        pattern.sourceStepCount,
-        Math.max(0, Math.floor((playheadMs - playback.initialHoldMilliseconds) / playback.sourceStepMilliseconds)),
+        timeline.sourceStepCount,
+        Math.max(0, Math.floor(
+          (playheadMs - playback.initialHoldMilliseconds) / timeline.sourceStepMilliseconds,
+        )),
       ),
-      frameCount: pattern.frameTimesMs.length,
+      frameCount: timeline.frameTimesMs.length,
       visibleTrailCards,
       visibleFoundationCards,
       retainedLeafCount: leaves.length,
@@ -356,7 +380,7 @@ export function createCsssolitairePreparedPlayer({
 
   return Object.freeze({
     get ready() { return true; },
-    get durationMs() { return pattern.durationMs; },
+    get durationMs() { return timelineFor().durationMs; },
     get loop() { return true; },
     pause() {
       if (!paused) publishNow();
@@ -378,7 +402,7 @@ export function createCsssolitairePreparedPlayer({
       }
       this.pause();
       resetInitial();
-      applyCycleTime(timeMs % pattern.durationMs);
+      applyCycleTime(timeMs % timelineFor().durationMs);
       return snapshot();
     },
     assertStableDomIdentity() {
@@ -400,6 +424,10 @@ export function createCsssolitairePreparedPlayer({
         playheadMs,
         frameIndex,
         preparedTimelineStateCount: patterns.reduce((sum, entry) => sum + entry.frameTimesMs.length, 0),
+        preparedPhoneTimelineStateCount: patterns.reduce(
+          (sum, entry) => sum + entry.phoneTimeline.frameTimesMs.length,
+          0,
+        ),
         preparedVisibilityOperationCount: patterns.reduce((sum, entry) =>
           sum + entry.visibilityRows.reduce((entrySum, row) => entrySum + row.length, 0), 0),
         preparedFoundationOperationCount: patterns.reduce((sum, entry) =>

--- a/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
+++ b/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
@@ -62,6 +62,10 @@ const PORTRAIT_PROFILES = Object.freeze([
 const PORTRAIT_CARD_COUNTS = Object.freeze(PORTRAIT_PROFILES.map(({ cardCount }) => cardCount));
 const PORTRAIT_CARD_BREAKPOINTS = Object.freeze([520, 720, 920]);
 const PORTRAIT_HORIZONTAL_DISTANCE_SCALE = 2;
+const PHONE_HORIZONTAL_DISTANCE_SCALE = 8;
+const PHONE_LAUNCH_CARD_COUNT = 3;
+const PHONE_PLAYBACK_TIME_SCALE = 3;
+const PHONE_PROFILE_INDEX = 1;
 const LAUNCH_CYCLE_COUNT = 3;
 const RANK_NAMES = Object.freeze([
   null, "ace", "two", "three", "four", "five", "six", "seven",
@@ -175,8 +179,11 @@ function portraitCardPosition(left, top, foundationIndex, horizontalDirection, p
     ? (width - cardWidth) / 2
     : solitaireSlotLeft(width, STARTING_CARDS[displayFoundationIndex].slot, cardWidth);
   const sourceStartLeft = STARTING_CARDS[foundationIndex].x;
+  const horizontalDistanceScale = profile.cardCount === 1
+    ? PHONE_HORIZONTAL_DISTANCE_SCALE
+    : PORTRAIT_HORIZONTAL_DISTANCE_SCALE;
   const unboundedLeft = startLeft +
-    (left - sourceStartLeft) * PORTRAIT_HORIZONTAL_DISTANCE_SCALE * presentationScale;
+    (left - sourceStartLeft) * horizontalDistanceScale * presentationScale;
   const vertical = verticalCardPosition(top);
   if (profile.cardCount > 1) {
     const startProgress = startLeft / (width - cardWidth);
@@ -396,14 +403,15 @@ function cardLeaf({ cardFace, foundationIndex, horizontalDirection, left, top })
   });
 }
 
-function buildPatternPlayback(snapshots, cards, sourceStepCount) {
+function buildPatternPlayback(snapshots, cards, sourceStepCount, timeScale = 1) {
   const frameTimesMs = [0];
   const visibilityRows = [snapshots.map((_, index) => -(index + FOUNDATION_COUNT + 1))];
   const foundationRows = [[]];
   const reverseFoundationRows = [[]];
   let snapshotIndex = 0;
   let cardIndex = 0;
-  const lastRevealTimeMs = snapshots.at(-1)?.timeMs ?? INITIAL_HOLD_MS;
+  const playbackTime = (timeMs) => INITIAL_HOLD_MS + (timeMs - INITIAL_HOLD_MS) * timeScale;
+  const lastRevealTimeMs = playbackTime(snapshots.at(-1)?.timeMs ?? INITIAL_HOLD_MS);
   const frameInterval = 1_000 / PLAYBACK_FPS;
   const revealFrameCount = Math.ceil(lastRevealTimeMs / frameInterval);
   for (let frameIndex = 1; frameIndex <= revealFrameCount; frameIndex += 1) {
@@ -411,11 +419,11 @@ function buildPatternPlayback(snapshots, cards, sourceStepCount) {
     const row = [];
     const foundationRow = [];
     const reverseFoundationRow = [];
-    while (snapshotIndex < snapshots.length && snapshots[snapshotIndex].timeMs <= timeMs) {
+    while (snapshotIndex < snapshots.length && playbackTime(snapshots[snapshotIndex].timeMs) <= timeMs) {
       row.push(snapshotIndex + FOUNDATION_COUNT + 1);
       snapshotIndex += 1;
     }
-    while (cardIndex < cards.length && cards[cardIndex].timeMs <= timeMs) {
+    while (cardIndex < cards.length && playbackTime(cards[cardIndex].timeMs) <= timeMs) {
       const card = cards[cardIndex];
       const nextCard = LAUNCH_CARDS[(card.cycleIndex + 1) * FOUNDATION_COUNT + card.foundationIndex];
       const currentAtlas = atlasPosition(faceNumber(card.rank, card.suit));
@@ -446,7 +454,10 @@ function buildPatternPlayback(snapshots, cards, sourceStepCount) {
   const rewindEndTimeMs = frameTimesMs.at(-1);
   return Object.freeze({
     durationMs: rewindEndTimeMs + CLEAR_HOLD_MS,
+    sourceStepMilliseconds: SOURCE_STEP_MS * timeScale,
     sourceStepCount,
+    launchCardCount: cards.length,
+    trailLeafCount: snapshots.length,
     rewindStartMilliseconds: rewindStartTimeMs,
     rewindEndMilliseconds: rewindEndTimeMs,
     frameTimesMs,
@@ -465,6 +476,16 @@ function buildPreparedPattern(seed, index) {
     top: snapshot.y,
   }));
   const timeline = buildPatternPlayback(source.snapshots, source.cards, source.sourceSteps);
+  const phoneCards = source.cards.slice(0, PHONE_LAUNCH_CARD_COUNT);
+  const phoneTrailLeafCount = phoneCards.reduce((sum, card) => sum + card.retainedSnapshots, 0);
+  const phoneSnapshots = source.snapshots.slice(0, phoneTrailLeafCount);
+  const phoneSourceStepCount = phoneSnapshots.at(-1).sourceStep + 1;
+  const phoneTimeline = buildPatternPlayback(
+    phoneSnapshots,
+    phoneCards,
+    phoneSourceStepCount,
+    PHONE_PLAYBACK_TIME_SCALE,
+  );
   const contentBounds = buildContentBounds(source.snapshots);
   return Object.freeze({
     id: `pattern-${String(index + 1).padStart(2, "0")}`,
@@ -477,8 +498,10 @@ function buildPreparedPattern(seed, index) {
       id: `pattern-${String(index + 1).padStart(2, "0")}`,
       seed,
       trailLeafCount: trailLeaves.length,
+      launchCardCount: source.cards.length,
       sourceDrawCount: source.sourceDraws,
       sourceStepCount: source.sourceSteps,
+      sourceStepMilliseconds: SOURCE_STEP_MS,
       horizontalVelocities: source.cards.map(({ velocityX }) => velocityX),
       durationMs: timeline.durationMs,
       rewindStartMilliseconds: timeline.rewindStartMilliseconds,
@@ -486,6 +509,7 @@ function buildPreparedPattern(seed, index) {
       frameTimesMs: timeline.frameTimesMs,
       visibilityRows: timeline.visibilityRows,
       foundationRows: timeline.foundationRows,
+      phoneTimeline,
       leafLayouts: trailLeaves.map(({ layout }) => layout),
       leafPortraitLayoutsByCardCount: PORTRAIT_CARD_COUNTS.map((_, profileIndex) =>
         trailLeaves.map(({ portraitLayouts }) => {
@@ -550,6 +574,7 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
     selection: "crypto-random-shuffled-bag-no-immediate-repeat",
     patternCount: preparedPatterns.length,
     initialPatternIndex: 0,
+    phoneProfileIndex: PHONE_PROFILE_INDEX,
     sourceStepMilliseconds: SOURCE_STEP_MS,
     initialHoldMilliseconds: INITIAL_HOLD_MS,
     foundationLeafCount: FOUNDATION_COUNT,
@@ -654,8 +679,12 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       portraitReflectionReferenceWidths: PORTRAIT_PROFILES.map(({ playfield }) => playfield[0]),
       portraitCardCounts: PORTRAIT_CARD_COUNTS,
       portraitCardBreakpoints: PORTRAIT_CARD_BREAKPOINTS,
-      portraitHorizontalMotion: "mobile-reflected-wall-bounce-multi-card-full-exit",
+      portraitHorizontalMotion: "phone-reflected-three-card-cycle-wider-multi-card-exit",
       portraitWallBounceCardCounts: [1],
+      phoneLaunchCardCount: PHONE_LAUNCH_CARD_COUNT,
+      phonePlaybackTimeScale: PHONE_PLAYBACK_TIME_SCALE,
+      phoneHorizontalDistanceScale: PHONE_HORIZONTAL_DISTANCE_SCALE,
+      phoneProfileIndex: PHONE_PROFILE_INDEX,
       preparedSlotLayout: "source-seven-slot-presentation-scaled-card-size",
       slotCount: SOLITAIRE_SLOT_COUNT,
       minimumSlotGap: MINIMUM_SLOT_GAP,
@@ -683,6 +712,10 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       retainedTrailLeafCount,
       preparedPatternCount: preparedPatterns.length,
       preparedFrameCount: playback.patterns.reduce((sum, pattern) => sum + pattern.frameTimesMs.length, 0),
+      preparedPhoneFrameCount: playback.patterns.reduce(
+        (sum, pattern) => sum + pattern.phoneTimeline.frameTimesMs.length,
+        0,
+      ),
       initialPatternDurationMs: playback.patterns[0].durationMs,
       minimumPatternDurationMs: Math.min(...playback.patterns.map(({ durationMs }) => durationMs)),
       maximumPatternDurationMs: Math.max(...playback.patterns.map(({ durationMs }) => durationMs)),

--- a/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
+++ b/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
@@ -383,7 +383,6 @@ function cardLeaf({ cardFace, foundationIndex, horizontalDirection, left, top })
     return portrait ? cardLayout(portrait) : null;
   });
   return Object.freeze({
-    faceIndex: cardFace - 1,
     foundationIndex,
     matrix: cardMatrix(
       landscapeLayout,
@@ -499,25 +498,18 @@ function buildPreparedPattern(seed, index) {
 }
 
 function buildSnapshot(leaves, cardAssetUrl) {
-  const faceClass = (index) => `f${index.toString(36)}`;
   const cardNodes = leaves.map((leaf, index) => {
-    const classes = [
-      index < FOUNDATION_COUNT ? "v" : null,
-      faceClass(leaf.faceIndex),
-    ]
-      .filter(Boolean).join(" ");
-    return `<b class="${classes}" style="transform:${leaf.matrix}"></b>`;
-  }).join("");
-  const faceRules = Array.from({ length: 52 }, (_, faceIndex) => {
-    const atlas = atlasPosition(faceIndex + 1);
-    return `.polycss-scene>b.${faceClass(faceIndex)}{background-position:${-atlas.x}px ${-atlas.y}px}`;
+    const declarations = [
+      `transform:${leaf.matrix}`,
+      `background-position:${-leaf.atlas.x}px ${-leaf.atlas.y}px`,
+    ];
+    if (index < FOUNDATION_COUNT) declarations.push("visibility:visible");
+    return `<b style="${declarations.join(";")}"></b>`;
   }).join("");
   const css = [
     ".polycss-camera{position:relative;display:block;width:100%;height:100%;overflow:hidden}",
     ".polycss-scene{position:absolute;inset:0}",
     `.polycss-scene>b{position:absolute;display:block;width:${CARD_SOURCE_WIDTH}px;height:${CARD_SOURCE_HEIGHT}px;margin:0;padding:0;overflow:hidden;border:0;border-radius:14px;background-image:url('${cardAssetUrl}');background-repeat:no-repeat;background-size:${CARD_ATLAS_WIDTH}px ${CARD_ATLAS_HEIGHT}px;transform-origin:0 0;visibility:hidden;pointer-events:none;text-decoration:none;font:normal normal normal 0/0 serif;image-rendering:auto}`,
-    ".polycss-scene>b.v{visibility:visible}",
-    faceRules,
     `@media (orientation:portrait) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[0] - 1}px){.polycss-scene>b:nth-child(2),.polycss-scene>b:nth-child(3),.polycss-scene>b:nth-child(4){display:none}}`,
     `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[0]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[1] - 1}px){.polycss-scene>b:nth-child(3),.polycss-scene>b:nth-child(4){display:none}}`,
     `@media (orientation:portrait) and (min-width:${PORTRAIT_CARD_BREAKPOINTS[1]}px) and (max-width:${PORTRAIT_CARD_BREAKPOINTS[2] - 1}px){.polycss-scene>b:nth-child(4){display:none}}`,

--- a/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
@@ -126,17 +126,18 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.match(snapshot, /class="polycss-scene"/u);
   assert.doesNotMatch(snapshot, /solitaire-prepared-(?:camera|scene)/u);
   assert.doesNotMatch(snapshot, /csssolitaire-board/u);
-  assert.equal((snapshot.match(/<b class="[^"]+" style="transform:matrix\([^)]+\)"><\/b>/gu) ?? []).length,
-    1952);
+  assert.equal((snapshot.match(
+    /<b style="transform:matrix\([^)]+\);background-position:-?\d+px -?\d+px(?:;visibility:visible)?"><\/b>/gu,
+  ) ?? []).length, 1952);
   assert.doesNotMatch(snapshot, /<s\b/u);
   assert.doesNotMatch(snapshot, /--csssolitaire-(?:landscape|portrait)-/u);
   assert.equal((snapshot.match(/\sstyle="transform:/gu) ?? []).length, 1952);
-  assert.doesNotMatch(snapshot, /class="[^"]*\bl[0-9a-z]+\b/u);
+  assert.doesNotMatch(snapshot, /<b\s+class=/u);
   assert.doesNotMatch(snapshot, /\.polycss-scene>b\.[^{]+\{transform:/u);
   assert.equal((snapshot.match(/\{transform:none\}/gu) ?? []).length, 0);
-  assert.equal((snapshot.match(/\.polycss-scene>b\.f[0-9a-z]+\{background-position:/gu) ?? []).length,
-    52);
-  assert.equal((snapshot.match(/<b class="v f[0-9a-z]+" style="transform:[^"]+"><\/b>/gu) ?? []).length, 4);
+  assert.equal((snapshot.match(/;background-position:-?\d+px -?\d+px/gu) ?? []).length, 1952);
+  assert.equal((snapshot.match(/;visibility:visible/gu) ?? []).length, 4);
+  assert.doesNotMatch(snapshot, /\.polycss-scene>b\.(?:v|f[0-9a-z]+)/u);
   assert.doesNotMatch(snapshot, /\bfoundation\b|\blane-[0-3]\b/u);
   assert.match(snapshot, /\.polycss-scene\{position:absolute;inset:0\}/u);
   assert.match(snapshot, /\.polycss-scene>b\{position:absolute/u);

--- a/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
@@ -70,8 +70,12 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.deepEqual(manifest.renderer.portraitCardCounts, [1, 2, 3, 4]);
   assert.deepEqual(manifest.renderer.portraitCardBreakpoints, [520, 720, 920]);
   assert.equal(manifest.renderer.portraitHorizontalMotion,
-    "mobile-reflected-wall-bounce-multi-card-full-exit");
+    "phone-reflected-three-card-cycle-wider-multi-card-exit");
   assert.deepEqual(manifest.renderer.portraitWallBounceCardCounts, [1]);
+  assert.equal(manifest.renderer.phoneLaunchCardCount, 3);
+  assert.equal(manifest.renderer.phonePlaybackTimeScale, 3);
+  assert.equal(manifest.renderer.phoneHorizontalDistanceScale, 8);
+  assert.equal(manifest.renderer.phoneProfileIndex, 1);
   assert.equal(manifest.renderer.preparedSlotLayout, "source-seven-slot-presentation-scaled-card-size");
   assert.equal(manifest.renderer.slotCount, 7);
   assert.equal(manifest.renderer.minimumSlotGap, 11);
@@ -89,6 +93,7 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.equal(manifest.metrics.retainedTrailLeafCount, 1948);
   assert.equal(manifest.metrics.preparedPatternCount, 24);
   assert.equal(manifest.metrics.preparedFrameCount, 13774);
+  assert.equal(manifest.metrics.preparedPhoneFrameCount, 9498);
   assert.equal(manifest.metrics.initialPatternDurationMs, 27210);
   assert.equal(manifest.metrics.minimumPatternDurationMs, 20475);
   assert.equal(manifest.metrics.maximumPatternDurationMs, 31228);
@@ -153,6 +158,7 @@ test("generated product is one complete retained snapshot plus sparse prepared p
 
   const playback = JSON.parse(await readFile(join(generated, "solitaire-playback.json"), "utf8"));
   assert.equal(playback.schema, "csssolitaire-prepared-playback@2");
+  assert.equal(playback.phoneProfileIndex, 1);
   const preparedLayouts = playback.patterns.flatMap((pattern) => [
     ...pattern.leafLayouts,
     ...pattern.leafPortraitLayoutsByCardCount.flat().filter(Boolean),
@@ -189,6 +195,14 @@ test("generated product is one complete retained snapshot plus sparse prepared p
     pattern.leafPortraitLayoutsByCardCount.every((profile) =>
       profile.length === pattern.trailLeafCount && profile.every(Boolean))));
   assert.ok(playback.patterns.every((pattern) => !("leafFoundationIndices" in pattern)));
+  assert.ok(playback.patterns.every((pattern) =>
+    pattern.phoneTimeline.launchCardCount === 3 &&
+    pattern.phoneTimeline.sourceStepMilliseconds === 22.5 &&
+    pattern.phoneTimeline.trailLeafCount < pattern.trailLeafCount));
+  assert.equal(playback.patterns.reduce(
+    (sum, pattern) => sum + pattern.phoneTimeline.frameTimesMs.length,
+    0,
+  ), 9498);
   const maximumPortraitUpdateGaps = [1, 2, 3, 4].map((cardCount) => Math.max(
     ...playback.patterns.map((pattern) => {
       const updateTimes = pattern.frameTimesMs.filter((_, frameIndex) =>
@@ -203,6 +217,22 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.equal(oneCardLayouts.length, initialPattern.trailLeafCount);
   assert.ok(oneCardLayouts.every((layout) => layout.length === 5 && layout.every(Number.isFinite)));
   assert.ok(new Set(oneCardLayouts.map(JSON.stringify)).size > 100);
+  assert.deepEqual({
+    launchCardCount: initialPattern.phoneTimeline.launchCardCount,
+    trailLeafCount: initialPattern.phoneTimeline.trailLeafCount,
+    sourceStepCount: initialPattern.phoneTimeline.sourceStepCount,
+    sourceStepMilliseconds: initialPattern.phoneTimeline.sourceStepMilliseconds,
+    frameCount: initialPattern.phoneTimeline.frameTimesMs.length,
+    durationMs: initialPattern.phoneTimeline.durationMs,
+  }, {
+    launchCardCount: 3,
+    trailLeafCount: 291,
+    sourceStepCount: 291,
+    sourceStepMilliseconds: 22.5,
+    frameCount: 317,
+    durationMs: 15067,
+  });
+  assert.ok(minimumPhoneDirectionChanges(playback.patterns) >= 6);
   assert.equal(initialPattern.sourceStepCount, 1679);
   assert.equal(initialPattern.frameTimesMs.length, 609);
   assert.equal(initialPattern.visibilityRows.length, 609);
@@ -219,3 +249,29 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.equal(playback.runtimeTrajectoryCalculation, false);
   assert.equal(playback.runtimeDomGrowth, false);
 });
+
+function minimumPhoneDirectionChanges(patterns) {
+  const counts = patterns.flatMap((pattern) => {
+    const layouts = pattern.leafPortraitLayoutsByCardCount[0];
+    const values = [];
+    let start = 0;
+    for (let cardIndex = 0; cardIndex < pattern.phoneTimeline.launchCardCount; cardIndex += 1) {
+      const atlasIndex = pattern.leafAtlasIndices[start];
+      let end = start + 1;
+      while (end < pattern.phoneTimeline.trailLeafCount &&
+          pattern.leafAtlasIndices[end] === atlasIndex) end += 1;
+      const positions = layouts.slice(start, end).map((layout) => layout[0] / 100 * 384 + layout[1] * 71);
+      let previousDirection = 0;
+      let changes = 0;
+      for (let index = 1; index < positions.length; index += 1) {
+        const direction = Math.sign(positions[index] - positions[index - 1]);
+        if (direction !== 0 && previousDirection !== 0 && direction !== previousDirection) changes += 1;
+        if (direction !== 0) previousDirection = direction;
+      }
+      values.push(changes);
+      start = end;
+    }
+    return values;
+  });
+  return Math.min(...counts);
+}

--- a/src/adapters/solitaire/tools/smoke-browser.mjs
+++ b/src/adapters/solitaire/tools/smoke-browser.mjs
@@ -243,7 +243,7 @@ try {
     }
     await page.evaluate(() => {
       const state = window.__cssSolitaireDebug.snapshot();
-      const durationMs = window.__cssSolitaireDebug.manifest.sourceProfile.patterns[state.patternIndex].durationMs;
+      const durationMs = state.durationMs;
       window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
     });
     await mkdir(dirname(screenshotPath), { recursive: true });
@@ -283,7 +283,7 @@ try {
     });
     await page.evaluate(() => {
       const state = window.__cssSolitaireDebug.snapshot();
-      const durationMs = window.__cssSolitaireDebug.manifest.sourceProfile.patterns[state.patternIndex].durationMs;
+      const durationMs = state.durationMs;
       window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
     });
     const mobileEvidence = await page.evaluate(() => {
@@ -356,7 +356,7 @@ try {
             return { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
           });
         const state = window.__cssSolitaireDebug.snapshot();
-        const durationMs = window.__cssSolitaireDebug.manifest.sourceProfile.patterns[state.patternIndex].durationMs;
+        const durationMs = state.durationMs;
         window.__cssSolitaireDebug.seek(durationMs / 2 - 100);
         const visibleRects = [...document.querySelectorAll(".polycss-scene > b")]
           .filter((leaf) => {
@@ -512,7 +512,48 @@ async function captureMobileContinuity(browser, port, route) {
       window.__cssSolitaireDebug?.errors().length > 0, null, { timeout: 30_000 });
     const result = await page.evaluate(() => {
       window.__cssSolitaireDebug.pause();
+      const initial = window.__cssSolitaireDebug.seek(0);
+      const motionSamples = [];
+      for (let timeMs = 500; timeMs < initial.durationMs; timeMs += 50) {
+        const state = window.__cssSolitaireDebug.seek(timeMs);
+        if (state.rewinding) break;
+        const leaves = [...document.querySelectorAll(".polycss-scene > b")];
+        let leafIndex = leaves.length - 1;
+        while (leafIndex >= 4 && leaves[leafIndex].style.visibility !== "visible") leafIndex -= 1;
+        if (leafIndex < 4) continue;
+        const leaf = leaves[leafIndex];
+        motionSamples.push({
+          face: leaf.style.backgroundPosition,
+          x: leaf.getBoundingClientRect().x,
+        });
+      }
+      const faceGroups = [];
+      for (const sample of motionSamples) {
+        let group = faceGroups.at(-1);
+        if (!group || group.face !== sample.face) {
+          group = { face: sample.face, positions: [] };
+          faceGroups.push(group);
+        }
+        group.positions.push(sample.x);
+      }
+      const directionChanges = faceGroups.map(({ positions }) => {
+        let previousDirection = 0;
+        let changes = 0;
+        for (let index = 1; index < positions.length; index += 1) {
+          const direction = Math.sign(positions[index] - positions[index - 1]);
+          if (direction !== 0 && previousDirection !== 0 && direction !== previousDirection) changes += 1;
+          if (direction !== 0) previousDirection = direction;
+        }
+        return changes;
+      });
       return {
+        timeline: {
+          durationMs: initial.durationMs,
+          launchCardCount: initial.launchCardCount,
+          trailLeafCount: initial.timelineTrailLeafCount,
+          faceCount: faceGroups.length,
+          directionChanges,
+        },
         samples: [1_000, 2_000, 3_000, 4_000].map((timeMs) => {
           window.__cssSolitaireDebug.seek(timeMs);
           const visiblePaintedLeaves = [...document.querySelectorAll(".polycss-scene > b")]
@@ -525,7 +566,10 @@ async function captureMobileContinuity(browser, port, route) {
         errors: window.__cssSolitaireDebug.errors(),
       };
     });
-    if (result.errors.length || result.samples.some((sample, index) =>
+    if (result.errors.length || result.timeline.durationMs !== 15067 ||
+        result.timeline.launchCardCount !== 3 || result.timeline.trailLeafCount !== 291 ||
+        result.timeline.faceCount !== 3 || result.timeline.directionChanges.some((changes) => changes < 5) ||
+        result.samples.some((sample, index) =>
       index > 0 && sample.visiblePaintedLeaves <= result.samples[index - 1].visiblePaintedLeaves)) {
       throw new Error(`cssSolitaire mobile continuity failed: ${JSON.stringify(result)}`);
     }

--- a/src/adapters/solitaire/tools/smoke-browser.mjs
+++ b/src/adapters/solitaire/tools/smoke-browser.mjs
@@ -140,13 +140,9 @@ try {
             count + [...element.attributes].filter(({ name }) => name.startsWith("data-")).length, 0),
           inlineStyleDeclarationCount: [...scene.querySelectorAll("*")].reduce((count, element) =>
             count + element.style.length, 0),
-          invalidLeafClassCount: leaves.filter((leaf) => {
-            const classes = [...leaf.classList];
-            return classes.length < 1 || classes.length > 2 ||
-              classes.filter((className) => className === "v").length > 1 ||
-              classes.filter((className) => /^f[0-9a-z]+$/u.test(className)).length !== 1 ||
-              classes.some((className) => className !== "v" && !/^f[0-9a-z]+$/u.test(className));
-          }).length,
+          invalidLeafClassCount: leaves.filter((leaf) => leaf.classList.length > 0).length,
+          inlineBackgroundPositionCount: leaves.filter((leaf) => leaf.style.backgroundPosition).length,
+          inlineVisibilityCount: leaves.filter((leaf) => leaf.style.visibility === "visible").length,
         },
         radius: getComputedStyle(first).borderRadius,
         cardEdge: getComputedStyle(first).boxShadow,
@@ -197,7 +193,10 @@ try {
         evidence.structure.cameraClassName !== "polycss-camera" ||
         evidence.structure.preparedSceneClassName !== "polycss-scene" ||
         evidence.structure.unexpectedSceneElementCount !== 0 || evidence.structure.dataAttributeCount !== 0 ||
-        evidence.structure.inlineStyleDeclarationCount !== 1952 || evidence.structure.invalidLeafClassCount !== 0 ||
+        evidence.structure.inlineStyleDeclarationCount !== 5860 ||
+        evidence.structure.invalidLeafClassCount !== 0 ||
+        evidence.structure.inlineBackgroundPositionCount !== 1952 ||
+        evidence.structure.inlineVisibilityCount !== 4 ||
         evidence.radius !== "14px" ||
         evidence.cardEdge !== "none" ||
         evidence.imageRendering !== "auto" ||
@@ -213,7 +212,7 @@ try {
         !evidence.shell.sceneBackground.startsWith("linear-gradient(rgb(0, 128, 0)") ||
         evidence.composition.sceneTransformStyle !== "flat" ||
         evidence.composition.matrix2dLeafCount !== 1952 || evidence.composition.matrix3dLeafCount !== 0 ||
-        evidence.composition.leafInlineStyleDeclarationCount !== 1952 ||
+        evidence.composition.leafInlineStyleDeclarationCount !== 5860 ||
         evidence.stats.runtimeAnimationFrameCallbackCount !== 0 ||
         evidence.stats.runtimeTimerCallbackCount < 1 || evidence.stats.loopCount < 1 ||
         evidence.stats.preparedPatternCount !== 24 ||


### PR DESCRIPTION
## What changed

- remove visibility and face-selector classes from all retained card leaves
- emit prepared atlas positions and initial visibility inline
- keep runtime face and visibility changes as sparse inline style writes
- give sub-520px phones a prepared three-card cycle with longer timing and repeated wall reflections
- preserve the existing desktop and wider portrait timelines
- strengthen asset and browser smoke checks around the class-free DOM and phone motion contracts

## Why

Card-level classes hid dynamic styling state behind opaque selectors. Each retained `<b>` now carries its own prepared matrix and atlas position inline, with visibility also updated inline during playback.

The narrow phone layout also reused short desktop exit trajectories, so cards crossed the phone only a few times and appeared to freeze before the next face. The phone profile now selects a separate prepared timeline containing three longer-lived faces while retaining the same stable DOM.

## Validation

- `pnpm test:solitaire`
- `pnpm test:solitaire:assets`
- `pnpm build:solitaire:deploy`
- `pnpm test:solitaire:deploy`
- `pnpm prepare:solitaire:check`
- `pnpm verify:source-only`
- Chromium desktop and 390x844 phone smoke: three phone faces with 8, 10, and 12 horizontal reversals in the initial pattern