### PR TITLE
Remove Solitaire scene wrapper

### DIFF
--- a/src/adapters/solitaire/index.html
+++ b/src/adapters/solitaire/index.html
@@ -59,7 +59,6 @@
         </svg>
       </a>
     </header>
-    <main id="scene"></main>
     <script type="module" src="/src/main.mjs"></script>
   </body>
 </html>

--- a/src/adapters/solitaire/src/csssolitaire/client.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/client.mjs
@@ -3,7 +3,7 @@ import { mountPreparedSolitaireSnapshot } from "./polycssScene.mjs";
 import { createCsssolitairePreparedPlayer } from "./preparedPlayback.mjs";
 
 export function mountCsssolitaireClient() {
-  const host = document.getElementById("scene");
+  const host = document.body;
   const state = { ready: false, manifest: null, mount: null, player: null, errors: [] };
   installDebugApi(state);
   window.addEventListener("error", (event) => recordError(event.message || String(event.error || "error")));
@@ -12,7 +12,6 @@ export function mountCsssolitaireClient() {
   main().catch((error) => recordError(error.stack || error.message || String(error)));
 
   async function main() {
-    if (!(host instanceof HTMLElement)) throw new Error("Missing #scene host");
     setBodyState("loading");
     const prepared = await loadPreparedSolitaire();
     state.manifest = prepared.manifest;

--- a/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/polycssScene.mjs
@@ -25,7 +25,8 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
   mountedStyle = document.importNode(style, true);
   document.head.append(mountedStyle);
   const mountedCamera = document.importNode(camera, true);
-  host.replaceChildren(mountedCamera);
+  for (const existing of host.querySelectorAll(":scope > .polycss-camera")) existing.remove();
+  host.append(mountedCamera);
   const mountedScene = mountedCamera.querySelector(":scope > .polycss-scene");
   const mountedLeaves = [...(mountedScene?.querySelectorAll(":scope > b") ?? [])];
   if (!(mountedScene instanceof HTMLElement) ||
@@ -77,7 +78,7 @@ export function mountPreparedSolitaireSnapshot({ host, manifest, snapshotHtml })
       });
     },
     destroy() {
-      host.replaceChildren();
+      mountedCamera.remove();
       mountedStyle?.remove();
       mountedStyle = null;
     },

--- a/src/adapters/solitaire/src/csssolitaire/styles.css
+++ b/src/adapters/solitaire/src/csssolitaire/styles.css
@@ -10,15 +10,16 @@
 }
 
 html,
-body,
-#scene {
+body {
   width: 100%;
   height: 100%;
   margin: 0;
 }
 
 body {
+  position: relative;
   overflow: hidden;
+  background: linear-gradient(180deg, #008000 0%, #003d00 100%);
 }
 
 body.loading::after {
@@ -133,12 +134,11 @@ body.loading::after {
   outline-offset: -5px;
 }
 
-#scene {
+body > .polycss-camera {
   position: absolute;
   inset: 0;
   overflow: hidden;
   contain: layout paint size style;
-  background: linear-gradient(180deg, #008000 0%, #003d00 100%);
 }
 
 .csssolitaire-error-message {

--- a/src/adapters/solitaire/test/csssolitaire-shell.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-shell.test.mjs
@@ -20,7 +20,7 @@ test("product shell is the standard css.graphics route without demo controls", a
   assert.match(html, /class="site-header"/u);
   assert.match(html, /class="site-wordmark-svg"/u);
   assert.match(html, /href="https:\/\/github\.com\/layoutit\/cssGraphics"/u);
-  assert.match(html, /<main id="scene"><\/main>/u);
+  assert.doesNotMatch(html, /<main\b|id="scene"/iu);
   assert.equal((html.match(/\saria-label=/gu) ?? []).length, 1);
   assert.doesNotMatch(html, /aria-busy/u);
   assert.doesNotMatch(html, /<button\b|<nav\b|<section\b|<output\b|<canvas\b/u);
@@ -32,11 +32,13 @@ test("product shell is the standard css.graphics route without demo controls", a
     (css.match(/background: linear-gradient\(180deg, #008000 0%, #003d00 100%\);/gu) ?? []).length,
     2,
   );
-  assert.match(css, /#scene \{[^}]*position: absolute;[^}]*inset: 0;[^}]*contain: layout paint size style;/u);
+  assert.match(css,
+    /body > \.polycss-camera \{[^}]*position: absolute;[^}]*inset: 0;[^}]*contain: layout paint size style;/u);
   assert.doesNotMatch(css, /clip-path|mask(?:-image)?|filter|box-shadow|text-shadow|mix-blend-mode/iu);
   assert.match(client, /loadPreparedSolitaire/u);
   assert.match(client, /state\.player\.resume\(\)/u);
   assert.doesNotMatch(client, /aria-busy/u);
+  assert.doesNotMatch(client, /getElementById\("scene"\)|querySelector\("#scene"\)/u);
   assert.doesNotMatch(client, /prefers-reduced-motion/u);
   assert.match(player, /createPolyMorphPreparedDomTarget/u);
   assert.match(player, /deadline-setTimeout-prepared-visibility-publication/u);
@@ -48,5 +50,7 @@ test("product shell is the standard css.graphics route without demo controls", a
   assert.match(player, /prepared-layout-inline-matrix-resolution/u);
   assert.match(player, /return `matrix\(0,/u);
   assert.match(snapshotMount, /runtimeGeometryBoundsCalculationCount: 0/u);
+  assert.match(snapshotMount, /host\.append\(mountedCamera\)/u);
+  assert.doesNotMatch(snapshotMount, /host\.replaceChildren/u);
   assert.doesNotMatch(snapshotMount, /renderer\.contentBounds/u);
 });

--- a/src/adapters/solitaire/tools/smoke-browser.mjs
+++ b/src/adapters/solitaire/tools/smoke-browser.mjs
@@ -112,8 +112,8 @@ try {
         };
       });
       const computedTransforms = leaves.map((leaf) => getComputedStyle(leaf).transform);
-      const scene = document.getElementById("scene");
-      const camera = scene?.querySelector(":scope > .polycss-camera");
+      const host = document.body;
+      const camera = host.querySelector(":scope > .polycss-camera");
       const preparedScene = camera?.querySelector(":scope > .polycss-scene");
       const resources = performance.getEntriesByType("resource")
         .map((entry) => new URL(entry.name).pathname)
@@ -124,21 +124,23 @@ try {
         mutations: { ...window.__cssSolitaireSmoke.mutations },
         retainedLeaves: leaves.length,
         visibleLeaves: leaves.filter((leaf) => getComputedStyle(leaf).visibility === "visible").length,
-        forbiddenSceneElements: document.querySelectorAll("#scene canvas, #scene svg").length,
+        forbiddenSceneElements: camera?.querySelectorAll("canvas, svg").length,
         structure: {
-          bodyChildren: [...document.body.children].map((element) => element.tagName),
-          sceneChildCount: scene?.childElementCount,
+          bodyChildren: [...host.children].map((element) =>
+            `${element.tagName}${element.className ? `.${element.className}` : ""}`),
+          mainCount: host.querySelectorAll(":scope > main").length,
+          sceneHostCount: host.querySelectorAll(":scope > #scene").length,
           cameraChildCount: camera?.childElementCount,
           preparedSceneChildCount: preparedScene?.childElementCount,
           cameraClassName: camera?.className,
           preparedSceneClassName: preparedScene?.className,
-          sceneDescendantCount: scene?.querySelectorAll("*").length,
-          unexpectedSceneElementCount: scene?.querySelectorAll(
+          cameraDescendantCount: camera?.querySelectorAll("*").length,
+          unexpectedSceneElementCount: camera?.querySelectorAll(
             "button,canvas,nav,output,section,svg,style,[contenteditable]",
           ).length,
-          dataAttributeCount: [...scene.querySelectorAll("*")].reduce((count, element) =>
+          dataAttributeCount: [...camera.querySelectorAll("*")].reduce((count, element) =>
             count + [...element.attributes].filter(({ name }) => name.startsWith("data-")).length, 0),
-          inlineStyleDeclarationCount: [...scene.querySelectorAll("*")].reduce((count, element) =>
+          inlineStyleDeclarationCount: [...camera.querySelectorAll("*")].reduce((count, element) =>
             count + element.style.length, 0),
           invalidLeafClassCount: leaves.filter((leaf) => leaf.classList.length > 0).length,
           inlineBackgroundPositionCount: leaves.filter((leaf) => leaf.style.backgroundPosition).length,
@@ -156,7 +158,7 @@ try {
           ariaLabels: [...document.querySelectorAll("[aria-label]")]
             .map((element) => element.getAttribute("aria-label")),
           ariaBusyCount: document.querySelectorAll("[aria-busy]").length,
-          sceneBackground: getComputedStyle(document.getElementById("scene")).backgroundImage,
+          sceneBackground: getComputedStyle(host).backgroundImage,
         },
         composition: {
           sceneTransformStyle: getComputedStyle(document.querySelector(".polycss-scene")).transformStyle,
@@ -187,9 +189,12 @@ try {
         !evidence.stable || evidence.retainedLeaves !== 1952 || evidence.visibleLeaves !== 4 ||
         evidence.forbiddenSceneElements !== 0 || evidence.mutations.added !== 0 || evidence.mutations.removed !== 0 ||
         JSON.stringify(evidence.structure.bodyChildren) !==
-          JSON.stringify(deploy ? ["HEADER", "MAIN"] : ["HEADER", "MAIN", "SCRIPT"]) ||
-        evidence.structure.sceneChildCount !== 1 || evidence.structure.cameraChildCount !== 1 ||
-        evidence.structure.preparedSceneChildCount !== 1952 || evidence.structure.sceneDescendantCount !== 1954 ||
+          JSON.stringify(deploy
+            ? ["HEADER.site-header", "DIV.polycss-camera"]
+            : ["HEADER.site-header", "SCRIPT", "DIV.polycss-camera"]) ||
+        evidence.structure.mainCount !== 0 || evidence.structure.sceneHostCount !== 0 ||
+        evidence.structure.cameraChildCount !== 1 || evidence.structure.preparedSceneChildCount !== 1952 ||
+        evidence.structure.cameraDescendantCount !== 1953 ||
         evidence.structure.cameraClassName !== "polycss-camera" ||
         evidence.structure.preparedSceneClassName !== "polycss-scene" ||
         evidence.structure.unexpectedSceneElementCount !== 0 || evidence.structure.dataAttributeCount !== 0 ||


### PR DESCRIPTION
## What changed

- remove the unnecessary `<main id="scene">` wrapper
- mount the prepared PolyCSS camera directly under `<body>`
- preserve the css.graphics header when mounting and destroying the scene
- pin the clean direct-body DOM contract in shell and browser smoke tests

## Why

The wrapper was redundant and did not match the retained-DOM structure used by the clean cssGraphics adapters. The body can own the single prepared camera directly.

## Validation

- `pnpm test:solitaire`
- `pnpm test:solitaire:assets`
- `pnpm test:solitaire:browser`
- `pnpm build:solitaire:deploy`
- `pnpm test:solitaire:deploy`
- `pnpm prepare:solitaire:check`
- `pnpm verify:source-only`