### PR TITLE
Eliminate unused Solitaire handoff work

### DIFF
--- a/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
@@ -40,6 +40,7 @@ export function createCsssolitairePreparedPlayer({
   const foundationVisibility = new Uint8Array(foundationLeafCount);
   foundationVisibility.fill(1);
   const trailVisibility = new Uint8Array(trailLeaves.length);
+  const visibleTrailIndices = new Set();
   const trailFaceIndices = trailLeaves.map((leaf) => readFaceIndex(leaf, atlasFaceIndices));
   let activePatternIndex = playback.initialPatternIndex;
   let pattern = patterns[activePatternIndex];
@@ -58,6 +59,11 @@ export function createCsssolitairePreparedPlayer({
   let foundationOperationsApplied = 0;
   let patternLayoutWrites = 0;
   let patternLayoutLeavesVisited = 0;
+  let patternLayoutLeavesRequired = 0;
+  let responsiveFaceLeavesVisited = 0;
+  let responsiveFaceLeavesRequired = 0;
+  let resetTrailLeavesVisited = 0;
+  let resetTrailLeavesRequired = 0;
   let responsiveTransformWrites = 0;
   let responsiveProfileSwitchCount = 0;
   let responsiveMatrixResolutionCount = 0;
@@ -70,6 +76,7 @@ export function createCsssolitairePreparedPlayer({
   let presentationWidth = renderer.landscapePresentationBase[0];
   let presentationHeight = renderer.landscapePresentationBase[1];
   let presentationScale = renderer.landscapePresentationBaseScale;
+  let patternFaceInitializedLeafCount = pattern.trailLeafCount;
   let lastApply = Object.freeze({
     visibilityWrites: 0,
     foundationWrites: 0,
@@ -85,6 +92,10 @@ export function createCsssolitairePreparedPlayer({
     return profileIndex === 0
       ? nextPattern.leafLayouts[index]
       : nextPattern.leafPortraitLayoutsByCardCount[profileIndex - 1][index];
+  }
+
+  function trailLeafCountFor(nextPattern = pattern, profileIndex = activeProfileIndex) {
+    return timelineFor(nextPattern, profileIndex).trailLeafCount;
   }
 
   function matrixForLayout(layout, width = presentationWidth, height = presentationHeight,
@@ -106,11 +117,25 @@ export function createCsssolitairePreparedPlayer({
       foundationLeaves[index].style.transform = transform;
       writes += 1;
     }
-    for (let index = 0; index < pattern.trailLeafCount; index += 1) {
+    const nextTrailLeafCount = trailLeafCountFor(pattern, nextProfileIndex);
+    for (let index = 0; index < nextTrailLeafCount; index += 1) {
       const transform = matrixForLayout(layoutForPattern(pattern, index, nextProfileIndex), width, height, scale);
       if (trailLeaves[index].style.transform === transform) continue;
       trailLeaves[index].style.transform = transform;
       writes += 1;
+    }
+    if (patternFaceInitializedLeafCount < nextTrailLeafCount) {
+      const required = nextTrailLeafCount - patternFaceInitializedLeafCount;
+      responsiveFaceLeavesRequired += required;
+      for (let index = patternFaceInitializedLeafCount; index < nextTrailLeafCount; index += 1) {
+        const faceIndex = pattern.leafAtlasIndices[index];
+        responsiveFaceLeavesVisited += 1;
+        if (trailFaceIndices[index] === faceIndex) continue;
+        trailLeaves[index].style.backgroundPosition = playback.atlasPositions[faceIndex];
+        trailFaceIndices[index] = faceIndex;
+        patternLayoutWrites += 1;
+      }
+      patternFaceInitializedLeafCount = nextTrailLeafCount;
     }
     if (nextProfileIndex !== activeProfileIndex) responsiveProfileSwitchCount += 1;
     activeProfileIndex = nextProfileIndex;
@@ -148,6 +173,8 @@ export function createCsssolitairePreparedPlayer({
       if (Boolean(trailVisibility[trailIndex]) === visible) continue;
       trailVisibility[trailIndex] = Number(visible);
       leaves[leafIndex].style.visibility = visible ? "visible" : "";
+      if (visible) visibleTrailIndices.add(trailIndex);
+      else visibleTrailIndices.delete(trailIndex);
       visibleTrailCards += visible ? 1 : -1;
       visibilityWrites += 1;
       writes += 1;
@@ -189,7 +216,9 @@ export function createCsssolitairePreparedPlayer({
 
   function applyPatternLayout(nextPattern) {
     let writes = 0;
-    for (let index = 0; index < nextPattern.trailLeafCount; index += 1) {
+    const requiredLeafCount = trailLeafCountFor(nextPattern);
+    patternLayoutLeavesRequired += requiredLeafCount;
+    for (let index = 0; index < requiredLeafCount; index += 1) {
       const leaf = trailLeaves[index];
       const transform = matrixForLayout(layoutForPattern(nextPattern, index));
       const faceIndex = nextPattern.leafAtlasIndices[index];
@@ -204,18 +233,20 @@ export function createCsssolitairePreparedPlayer({
         writes += 1;
       }
     }
+    patternFaceInitializedLeafCount = requiredLeafCount;
     patternLayoutWrites += writes;
     return writes;
   }
 
   function resetInitial() {
-    let writes = 0;
-    for (let index = 0; index < trailVisibility.length; index += 1) {
-      if (trailVisibility[index] === 0) continue;
+    const writes = visibleTrailIndices.size;
+    resetTrailLeavesRequired += writes;
+    for (const index of visibleTrailIndices) {
+      resetTrailLeavesVisited += 1;
       trailVisibility[index] = 0;
       trailLeaves[index].style.visibility = "";
-      writes += 1;
     }
+    visibleTrailIndices.clear();
     let foundationWrites = 0;
     for (let index = 0; index < foundationLeafCount; index += 1) {
       const leaf = foundationLeaves[index];
@@ -269,6 +300,7 @@ export function createCsssolitairePreparedPlayer({
       throw new RangeError("Prepared cssSolitaire pattern handoff is invalid");
     }
     const layoutWrites = applyPatternLayout(nextPattern);
+    const dirtyLeavesVisited = trailLeafCountFor(nextPattern);
     activePatternIndex = nextIndex;
     pattern = nextPattern;
     patternSwitchCount += 1;
@@ -276,7 +308,7 @@ export function createCsssolitairePreparedPlayer({
       visibilityWrites: 0,
       foundationWrites: 0,
       layoutWrites,
-      dirtyLeavesVisited: nextPattern.trailLeafCount,
+      dirtyLeavesVisited,
     });
   }
 
@@ -439,6 +471,15 @@ export function createCsssolitairePreparedPlayer({
         runtimeFoundationStyleWrites: foundationStyleWrites,
         runtimePatternLayoutWrites: patternLayoutWrites,
         runtimePatternLayoutLeavesVisited: patternLayoutLeavesVisited,
+        runtimePatternLayoutLeavesRequired: patternLayoutLeavesRequired,
+        runtimePatternLayoutUnusedLeavesVisited: patternLayoutLeavesVisited - patternLayoutLeavesRequired,
+        runtimeResponsiveFaceLeavesVisited: responsiveFaceLeavesVisited,
+        runtimeResponsiveFaceLeavesRequired: responsiveFaceLeavesRequired,
+        runtimeResponsiveFaceUnusedLeavesVisited: responsiveFaceLeavesVisited - responsiveFaceLeavesRequired,
+        runtimeResetTrailLeavesVisited: resetTrailLeavesVisited,
+        runtimeResetTrailLeavesRequired: resetTrailLeavesRequired,
+        runtimeResetUnusedLeavesVisited: resetTrailLeavesVisited - resetTrailLeavesRequired,
+        activePatternFaceInitializedLeafCount: patternFaceInitializedLeafCount,
         runtimeResponsiveTransformWrites: responsiveTransformWrites,
         runtimeResponsiveProfileSwitchCount: responsiveProfileSwitchCount,
         runtimeResponsiveMatrixResolutionCount: responsiveMatrixResolutionCount,

--- a/src/adapters/solitaire/tools/smoke-browser.mjs
+++ b/src/adapters/solitaire/tools/smoke-browser.mjs
@@ -223,6 +223,14 @@ try {
         evidence.stats.preparedPatternCount !== 24 ||
         evidence.stats.runtimePreparedPatternSwitchCount !== 23 ||
         evidence.stats.runtimePatternLayoutWrites < 1 ||
+        evidence.stats.runtimePatternLayoutLeavesVisited !==
+          evidence.stats.runtimePatternLayoutLeavesRequired ||
+        evidence.stats.runtimePatternLayoutUnusedLeavesVisited !== 0 ||
+        evidence.stats.runtimeResponsiveFaceLeavesVisited !==
+          evidence.stats.runtimeResponsiveFaceLeavesRequired ||
+        evidence.stats.runtimeResponsiveFaceUnusedLeavesVisited !== 0 ||
+        evidence.stats.runtimeResetTrailLeavesVisited !== evidence.stats.runtimeResetTrailLeavesRequired ||
+        evidence.stats.runtimeResetUnusedLeavesVisited !== 0 ||
         evidence.stats.runtimeRandomSelectionCount < 1 ||
         evidence.stats.runtimeRandomSelectionPurpose !== "prepared-pattern-shuffled-bag-index-only" ||
         evidence.stats.runtimeGeometryCalculationCount !== 0 ||
@@ -440,12 +448,14 @@ try {
     }
     const reducedMotionMobileAutoplay = await captureReducedMotionMobileAutoplay(browser, port, route);
     const mobileContinuity = await captureMobileContinuity(browser, port, route);
+    const mobileHandoffWork = await captureMobileHandoffWork(browser, port, route);
     await page.evaluate(() => window.__cssSolitaireSmoke.observer.disconnect());
     process.stdout.write(`${JSON.stringify({
       status: "passed", headless: true, browser: browser.version(), deploy, route,
       readyMs, sampled, autoplayLoop, bankSequence, evidence, visibleBounds, cardPixelRatio, screenshotPath,
       mobileInitial, mobileEvidence, mobileCardPixelRatio, mobileScreenshotPath,
       responsiveCardCounts, landscapeViewports, reducedMotionMobileAutoplay, mobileContinuity,
+      mobileHandoffWork,
     }, null, 2)}\n`);
   } finally {
     await browser.close();
@@ -577,6 +587,99 @@ async function captureMobileContinuity(browser, port, route) {
         result.samples.some((sample, index) =>
       index > 0 && sample.visiblePaintedLeaves <= result.samples[index - 1].visiblePaintedLeaves)) {
       throw new Error(`cssSolitaire mobile continuity failed: ${JSON.stringify(result)}`);
+    }
+    return result;
+  } finally {
+    await page.close();
+  }
+}
+
+async function captureMobileHandoffWork(browser, port, route) {
+  const page = await browser.newPage({
+    viewport: { width: 390, height: 844 },
+    screen: { width: 390, height: 844 },
+    deviceScaleFactor: 3,
+    isMobile: true,
+    hasTouch: true,
+  });
+  try {
+    await page.goto(`http://127.0.0.1:${port}${route}`, { waitUntil: "networkidle" });
+    await page.waitForFunction(() => window.__cssSolitaireDebug?.ready === true ||
+      window.__cssSolitaireDebug?.errors().length > 0, null, { timeout: 30_000 });
+    const reset = await page.evaluate(() => {
+      window.__cssSolitaireDebug.pause();
+      const visible = window.__cssSolitaireDebug.seek(5_000).visibleTrailCards;
+      const before = window.__cssSolitaireDebug.stats();
+      window.__cssSolitaireDebug.seek(0);
+      const after = window.__cssSolitaireDebug.stats();
+      return {
+        visible,
+        visited: after.runtimeResetTrailLeavesVisited - before.runtimeResetTrailLeavesVisited,
+        required: after.runtimeResetTrailLeavesRequired - before.runtimeResetTrailLeavesRequired,
+        unused: after.runtimeResetUnusedLeavesVisited - before.runtimeResetUnusedLeavesVisited,
+      };
+    });
+    const handoffStart = await page.evaluate(() => {
+      const state = window.__cssSolitaireDebug.snapshot();
+      window.__cssSolitaireDebug.seek(state.durationMs - 40);
+      const before = window.__cssSolitaireDebug.stats();
+      const patternIndex = window.__cssSolitaireDebug.snapshot().patternIndex;
+      window.__cssSolitaireDebug.resume();
+      return { before, patternIndex };
+    });
+    await page.waitForFunction((patternIndex) =>
+      window.__cssSolitaireDebug.snapshot().patternIndex !== patternIndex,
+    handoffStart.patternIndex, { timeout: 2_000 });
+    const handoff = await page.evaluate((before) => {
+      const state = window.__cssSolitaireDebug.pause();
+      const after = window.__cssSolitaireDebug.stats();
+      const fullTrailLeafCount = window.__cssSolitaireDebug.manifest.sourceProfile
+        .patterns[state.patternIndex].trailLeafCount;
+      return {
+        patternIndex: state.patternIndex,
+        profileIndex: state.responsiveProfileIndex,
+        activeTrailLeafCount: state.timelineTrailLeafCount,
+        fullTrailLeafCount,
+        initializedFaceLeafCount: after.activePatternFaceInitializedLeafCount,
+        patternSwitches: after.runtimePreparedPatternSwitchCount - before.runtimePreparedPatternSwitchCount,
+        visited: after.runtimePatternLayoutLeavesVisited - before.runtimePatternLayoutLeavesVisited,
+        required: after.runtimePatternLayoutLeavesRequired - before.runtimePatternLayoutLeavesRequired,
+        unused: after.runtimePatternLayoutUnusedLeavesVisited - before.runtimePatternLayoutUnusedLeavesVisited,
+      };
+    }, handoffStart.before);
+    const beforeExpansion = await page.evaluate(() => window.__cssSolitaireDebug.stats());
+    await page.setViewportSize({ width: 600, height: 900 });
+    await page.waitForFunction(() => window.__cssSolitaireDebug.snapshot().responsiveProfileIndex === 2);
+    const expansion = await page.evaluate((before) => {
+      const state = window.__cssSolitaireDebug.snapshot();
+      const after = window.__cssSolitaireDebug.stats();
+      return {
+        profileIndex: state.responsiveProfileIndex,
+        activeTrailLeafCount: state.timelineTrailLeafCount,
+        initializedFaceLeafCount: after.activePatternFaceInitializedLeafCount,
+        visited: after.runtimeResponsiveFaceLeavesVisited - before.runtimeResponsiveFaceLeavesVisited,
+        required: after.runtimeResponsiveFaceLeavesRequired - before.runtimeResponsiveFaceLeavesRequired,
+        unused: after.runtimeResponsiveFaceUnusedLeavesVisited - before.runtimeResponsiveFaceUnusedLeavesVisited,
+      };
+    }, beforeExpansion);
+    const result = {
+      reset,
+      handoff,
+      expansion,
+      errors: await page.evaluate(() => window.__cssSolitaireDebug.errors()),
+    };
+    const expansionLeafCount = handoff.fullTrailLeafCount - handoff.activeTrailLeafCount;
+    if (result.errors.length || reset.visible <= 0 || reset.visited !== reset.visible ||
+        reset.required !== reset.visible || reset.unused !== 0 || handoff.patternSwitches !== 1 ||
+        handoff.profileIndex !== 1 || handoff.activeTrailLeafCount >= handoff.fullTrailLeafCount ||
+        handoff.initializedFaceLeafCount !== handoff.activeTrailLeafCount ||
+        handoff.visited !== handoff.activeTrailLeafCount ||
+        handoff.required !== handoff.activeTrailLeafCount || handoff.unused !== 0 ||
+        expansion.profileIndex !== 2 || expansion.activeTrailLeafCount !== handoff.fullTrailLeafCount ||
+        expansion.initializedFaceLeafCount !== handoff.fullTrailLeafCount ||
+        expansion.visited !== expansionLeafCount || expansion.required !== expansionLeafCount ||
+        expansion.unused !== 0) {
+      throw new Error(`cssSolitaire mobile handoff work failed: ${JSON.stringify(result)}`);
     }
     return result;
   } finally {


### PR DESCRIPTION
## What changed

- limit pattern handoffs to the active responsive timeline
- reset only leaves that are actually visible
- initialize only newly required atlas faces when a phone layout expands
- add exact visited-versus-required browser counters and regression coverage

## Why

Phone handoffs were scanning and rewriting the full retained desktop pattern even though the phone timeline used only a small prefix. Reset also scanned every retained trail leaf. This removes those unused visits without changing rendering, timing, prepared assets, or DOM topology.

## Validation

- `pnpm test:solitaire`
- `pnpm test:solitaire:assets`
- `pnpm test:solitaire:browser`
- `pnpm build:solitaire:deploy`
- `pnpm test:solitaire:deploy`
- `pnpm prepare:solitaire:check`
- `pnpm verify:source-only`
- `pnpm test:framesleuth`
- DPR3, 4x CPU Chrome trace and FrameSleuth comparison