### PR TITLE
Fix Solitaire mobile impact angles

### DIFF
--- a/src/adapters/solitaire/README.md
+++ b/src/adapters/solitaire/README.md
@@ -24,10 +24,18 @@ to 80px, and the lowest retained bounce point to the real viewport bottom.
 Responsive cards therefore keep a natural continuous arch without clipping
 either viewport edge.
 Launch origins follow Solitaire's recovered seven-slot gap
-rule; narrow portrait viewports keep one centered full-size card stream while
-wider layouts progressively expose two, three, then four proper foundation slots.
-The one-card mobile stream reflects from normalized prepared side-wall positions;
-the wider multi-card profiles and landscape map their prepared exit boundary
+rule; narrow portrait viewports launch one centered full-size card per pattern,
+and the other retained copies are only its classic ghost trail. That card follows
+three complete prepared floor-bounce cycles and reflects from normalized prepared
+side-wall positions. On phone layouts, every wall and nonterminal floor impact
+selects a different prepared source-range horizontal step, so one card does not
+repeat the same outgoing angle through the whole path. Two prepared in-between ghosts per recovered motion step keep
+the trail tight without changing its physics; wider layouts progressively expose two, three, then four
+proper foundation slots.
+The phone bank has 24 distinct effective launch angles from the recovered integer
+horizontal and vertical step ranges. It balances direction 12/12, never reuses a
+prepared path in one shuffled pass, and alternates starting direction at handoff.
+The wider multi-card profiles and landscape map their prepared exit boundary
 fully beyond the real viewport. The first two foundation lanes occasionally
 exit right while the remaining lanes keep their leftward exit. Every card
 remains upright. As in the sibling

--- a/src/adapters/solitaire/notes/provenance-bible.md
+++ b/src/adapters/solitaire/notes/provenance-bible.md
@@ -2,7 +2,7 @@
 
 Status: behavior-backed prepared product; native pixel parity is not claimed
 
-Last verified: 2026-08-16
+Last verified: 2026-08-17
 
 Target behavior: the Windows XP Solitaire victory cascade routine identified as
 `FUN_01004df0` at `0x01004df0` in the locally held, hash-bound reference
@@ -30,10 +30,24 @@ visibility schedule. Responsive launch origins preserve the recovered seven-slot
 layout rule: the gap is the greater of `(clientWidth - cardWidth * 7) / 8` and
 `cardWidth / 8 + 3`, with signed integer truncation. The browser loads one
 complete retained snapshot and applies only signed prepared visibility operations.
-Only the one-card mobile presentation reflects at the side walls. Multi-card
-and landscape presentations map the prepared exit boundary fully beyond the
-real viewport. The prepared pattern bank permits occasional rightward exits in
+Only the one-card mobile presentation reflects at the side walls. Its prepared
+forward pass keeps the recovered integer motion through three complete floor
+bounces before rewind. Prepared floor-crossing samples anchor the visible card
+to the real viewport floor while the recovered integer position and velocity
+continue to govern the next step. The mobile-only retention adaptation changes
+to a different recovered-range integer horizontal step after every wall and
+nonterminal floor impact; this intentional deviation prevents one retained card
+from repeating a single reflected angle while gravity and floor restitution remain
+the recovered values. Two prepared interpolated ghosts between source
+motion steps tightens the trail without changing its physical states; no runtime
+physics reconstructs the path. Multi-card and
+landscape presentations map the prepared exit boundary fully beyond the real
+viewport. The prepared pattern bank permits occasional rightward exits in
 the first two foundation lanes while keeping the last two lanes leftward.
+The phone-only bank derives 24 distinct effective launch-angle ratios from the
+recovered integer horizontal and vertical step ranges. Its prepared paths are
+geometrically distinct, balance horizontal signs 12/12, and alternate sign at
+handoff inside the shuffled bag.
 The product presentation uses one smooth prepared three-anchor curve from the
 8px apex through the 80px foundation to the lowest retained source bounce point
 at the real viewport floor. It does not clamp or join separate vertical mappings

--- a/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
@@ -73,11 +73,16 @@ function validateManifest(manifest) {
       JSON.stringify(manifest.renderer?.portraitCardCounts) !== "[1,2,3,4]" ||
       JSON.stringify(manifest.renderer?.portraitCardBreakpoints) !== "[520,720,920]" ||
       manifest.renderer?.portraitHorizontalMotion !==
-        "phone-reflected-three-card-cycle-wider-multi-card-exit" ||
+        "phone-source-gravity-prepared-wall-and-floor-impact-response-one-card" ||
       JSON.stringify(manifest.renderer?.portraitWallBounceCardCounts) !== "[1]" ||
-      manifest.renderer?.phoneLaunchCardCount !== 3 ||
+      manifest.renderer?.phoneLaunchCardCount !== 1 ||
       manifest.renderer?.phonePlaybackTimeScale !== 3 ||
-      manifest.renderer?.phoneHorizontalDistanceScale !== 8 ||
+      manifest.renderer?.phoneHorizontalDistanceScale !== 2 ||
+      manifest.renderer?.phoneFloorBounceCount !== 3 ||
+      manifest.renderer?.phoneImpactResponse !==
+        "prepared-new-horizontal-step-after-wall-and-nonterminal-floor-impact" ||
+      JSON.stringify(manifest.renderer?.phoneImpactHorizontalSteps) !== "[6,2,5,3,4]" ||
+      manifest.renderer?.phoneTrailSubstepCount !== 3 ||
       manifest.renderer?.phoneProfileIndex !== 1 ||
       manifest.renderer?.preparedSlotLayout !== "source-seven-slot-presentation-scaled-card-size" ||
       manifest.renderer?.slotCount !== 7 || manifest.renderer?.minimumSlotGap !== 11 ||
@@ -88,12 +93,18 @@ function validateManifest(manifest) {
       manifest.sourceProfile?.cards !== 12 ||
       manifest.sourceProfile?.sourceSteps !== 1679 ||
       manifest.sourceProfile?.patternCount !== 24 ||
-      manifest.sourceProfile?.patternSelection !== "crypto-random-shuffled-bag-no-immediate-repeat" ||
+      manifest.sourceProfile?.patternSelection !==
+        "crypto-random-shuffled-bag-alternating-phone-direction-unique-angle" ||
       manifest.sourceProfile?.horizontalVelocityDistribution !==
         "mild-slow-bias-first-two-lanes-quarter-right-unique-per-lane-cycle" ||
       JSON.stringify(manifest.sourceProfile?.horizontalVelocityRange) !== "[-65,65]" ||
       manifest.sourceProfile?.minimumHorizontalSpeed !== 20 ||
       manifest.sourceProfile?.horizontalVelocityBiasExponent !== 1.1 ||
+      manifest.sourceProfile?.phoneLaunchVelocityDistribution !==
+        "source-effective-steps-balanced-direction-unique-angle" ||
+      manifest.sourceProfile?.phoneRightwardPatternCount !== 12 ||
+      manifest.sourceProfile?.phoneEffectiveLaunchAngleCount !== 24 ||
+      manifest.sourceProfile?.phoneExactTrajectoryRepeats !== false ||
       JSON.stringify(manifest.sourceProfile?.rightwardFoundationIndices) !== "[0,1]" ||
       manifest.sourceProfile?.rightwardSelection !== "random-value-modulo-4-zero" ||
       manifest.sourceProfile?.exactSameLaneTrajectoryRepeats !== false ||
@@ -133,7 +144,8 @@ function validateManifest(manifest) {
 
 function validatePlayback(playback, manifest) {
   if (playback?.schema !== "csssolitaire-prepared-playback@2" || playback.loop !== true ||
-      playback.selection !== "crypto-random-shuffled-bag-no-immediate-repeat" ||
+      playback.selection !==
+        "crypto-random-shuffled-bag-alternating-phone-direction-unique-angle" ||
       playback.patternCount !== 24 || playback.initialPatternIndex !== 0 ||
       playback.phoneProfileIndex !== 1 ||
       playback.sourceStepMilliseconds !== 7.5 || playback.initialHoldMilliseconds !== 500 ||
@@ -154,6 +166,8 @@ function validatePlayback(playback, manifest) {
       playback.atlasPositions.some((position) => !/^-?\d+px -?\d+px$/u.test(position)) ||
       !Array.isArray(playback.patterns) || playback.patterns.length !== playback.patternCount ||
       playback.patterns.some((pattern, index) => !validPattern(pattern, playback, manifest, index)) ||
+      new Set(playback.patterns.map(phoneLaunchAngleKey)).size !== 24 ||
+      playback.patterns.filter(({ phoneHorizontalVelocity }) => phoneHorizontalVelocity > 0).length !== 12 ||
       playback.patterns.reduce((sum, pattern) => sum + pattern.frameTimesMs.length, 0) !==
         manifest.metrics.preparedFrameCount ||
       playback.patterns.reduce((sum, pattern) => sum + pattern.phoneTimeline.frameTimesMs.length, 0) !==
@@ -183,6 +197,17 @@ function validPattern(pattern, playback, manifest, index) {
     pattern.sourceDrawCount === sourcePattern.sourceDraws &&
     pattern.sourceStepCount === sourcePattern.sourceSteps &&
     pattern.sourceStepMilliseconds === playback.sourceStepMilliseconds &&
+    pattern.phoneHorizontalVelocity === sourcePattern.phoneHorizontalVelocity &&
+    pattern.phoneVerticalVelocity === sourcePattern.phoneVerticalVelocity &&
+    JSON.stringify(pattern.phoneImpactVelocitySteps) ===
+      JSON.stringify(sourcePattern.phoneImpactVelocitySteps) &&
+    validPhoneImpactVelocitySteps(pattern.phoneImpactVelocitySteps) &&
+    Number.isSafeInteger(pattern.phoneHorizontalVelocity) &&
+    Math.abs(pattern.phoneHorizontalVelocity) >= 20 && Math.abs(pattern.phoneHorizontalVelocity) <= 60 &&
+    pattern.phoneHorizontalVelocity % 10 === 0 &&
+    Number.isSafeInteger(pattern.phoneVerticalVelocity) &&
+    pattern.phoneVerticalVelocity >= -70 && pattern.phoneVerticalVelocity <= -10 &&
+    pattern.phoneVerticalVelocity % 10 === 0 &&
     pattern.durationMs === sourcePattern.durationMs &&
     pattern.rewindStartMilliseconds > 0 &&
     pattern.rewindEndMilliseconds > pattern.rewindStartMilliseconds &&
@@ -219,15 +244,15 @@ function validPattern(pattern, playback, manifest, index) {
     Array.isArray(pattern.leafAtlasIndices) && pattern.leafAtlasIndices.length === pattern.trailLeafCount &&
     !pattern.leafAtlasIndices.some((atlasIndex) =>
       !Number.isSafeInteger(atlasIndex) || atlasIndex < 0 || atlasIndex >= playback.atlasPositions.length) &&
-    validPhoneTimeline(pattern.phoneTimeline, playback, pattern.trailLeafCount);
+    validPhoneTimeline(pattern.phoneTimeline, playback, pattern.trailLeafCount, sourcePattern);
 }
 
-function validPhoneTimeline(timeline, playback, patternTrailLeafCount) {
+function validPhoneTimeline(timeline, playback, patternTrailLeafCount, sourcePattern) {
   const frameTimes = timeline?.frameTimesMs;
   const visibilityRows = timeline?.visibilityRows;
   const foundationRows = timeline?.foundationRows;
-  return timeline?.launchCardCount === 3 && timeline.sourceStepMilliseconds === 22.5 &&
-    Number.isSafeInteger(timeline.sourceStepCount) && timeline.sourceStepCount > 0 &&
+  return timeline?.launchCardCount === 1 && timeline.sourceStepMilliseconds === 22.5 &&
+    timeline.sourceStepCount === sourcePattern.phoneSourceSteps &&
     Number.isSafeInteger(timeline.trailLeafCount) && timeline.trailLeafCount > 0 &&
     timeline.trailLeafCount <= patternTrailLeafCount &&
     timeline.durationMs > timeline.rewindEndMilliseconds &&
@@ -254,4 +279,25 @@ function validPhoneTimeline(timeline, playback, patternTrailLeafCount) {
 
 function validPreparedLayout(layout) {
   return Array.isArray(layout) && layout.length === 5 && layout.every(Number.isFinite);
+}
+
+function validPhoneImpactVelocitySteps(steps) {
+  return Array.isArray(steps) && steps.length >= 3 &&
+    steps.filter((entry) => Array.isArray(entry) && entry[0] === "floor").length === 2 &&
+    steps.some((entry) => Array.isArray(entry) && entry[0] === "wall") &&
+    steps.every((entry, index) => Array.isArray(entry) && entry.length === 2 &&
+      (entry[0] === "wall" || entry[0] === "floor") &&
+      Number.isSafeInteger(entry[1]) && Math.abs(entry[1]) >= 2 && Math.abs(entry[1]) <= 6 &&
+      (index === 0 || Math.abs(entry[1]) !== Math.abs(steps[index - 1][1])));
+}
+
+function phoneLaunchAngleKey({ phoneHorizontalVelocity, phoneVerticalVelocity }) {
+  let horizontalStep = Math.abs(Math.trunc(phoneHorizontalVelocity / 10));
+  let verticalStep = Math.abs(Math.trunc(phoneVerticalVelocity / 10));
+  let left = horizontalStep;
+  let right = verticalStep;
+  while (right !== 0) [left, right] = [right, left % right];
+  horizontalStep /= left;
+  verticalStep /= left;
+  return `${horizontalStep}:${verticalStep}`;
 }

--- a/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
@@ -77,6 +77,7 @@ export function createCsssolitairePreparedPlayer({
   let presentationHeight = renderer.landscapePresentationBase[1];
   let presentationScale = renderer.landscapePresentationBaseScale;
   let patternFaceInitializedLeafCount = pattern.trailLeafCount;
+  let patternFacesUsePhoneCard = false;
   let lastApply = Object.freeze({
     visibilityWrites: 0,
     foundationWrites: 0,
@@ -96,6 +97,12 @@ export function createCsssolitairePreparedPlayer({
 
   function trailLeafCountFor(nextPattern = pattern, profileIndex = activeProfileIndex) {
     return timelineFor(nextPattern, profileIndex).trailLeafCount;
+  }
+
+  function faceIndexForPattern(nextPattern, index, profileIndex = activeProfileIndex) {
+    return profileIndex === playback.phoneProfileIndex
+      ? nextPattern.leafAtlasIndices[0]
+      : nextPattern.leafAtlasIndices[index];
   }
 
   function matrixForLayout(layout, width = presentationWidth, height = presentationHeight,
@@ -124,11 +131,15 @@ export function createCsssolitairePreparedPlayer({
       trailLeaves[index].style.transform = transform;
       writes += 1;
     }
-    if (patternFaceInitializedLeafCount < nextTrailLeafCount) {
-      const required = nextTrailLeafCount - patternFaceInitializedLeafCount;
+    const nextFacesUsePhoneCard = nextProfileIndex === playback.phoneProfileIndex;
+    const faceStartIndex = patternFacesUsePhoneCard === nextFacesUsePhoneCard
+      ? Math.min(patternFaceInitializedLeafCount, nextTrailLeafCount)
+      : 0;
+    if (faceStartIndex < nextTrailLeafCount) {
+      const required = nextTrailLeafCount - faceStartIndex;
       responsiveFaceLeavesRequired += required;
-      for (let index = patternFaceInitializedLeafCount; index < nextTrailLeafCount; index += 1) {
-        const faceIndex = pattern.leafAtlasIndices[index];
+      for (let index = faceStartIndex; index < nextTrailLeafCount; index += 1) {
+        const faceIndex = faceIndexForPattern(pattern, index, nextProfileIndex);
         responsiveFaceLeavesVisited += 1;
         if (trailFaceIndices[index] === faceIndex) continue;
         trailLeaves[index].style.backgroundPosition = playback.atlasPositions[faceIndex];
@@ -136,6 +147,7 @@ export function createCsssolitairePreparedPlayer({
         patternLayoutWrites += 1;
       }
       patternFaceInitializedLeafCount = nextTrailLeafCount;
+      patternFacesUsePhoneCard = nextFacesUsePhoneCard;
     }
     if (nextProfileIndex !== activeProfileIndex) responsiveProfileSwitchCount += 1;
     activeProfileIndex = nextProfileIndex;
@@ -221,7 +233,7 @@ export function createCsssolitairePreparedPlayer({
     for (let index = 0; index < requiredLeafCount; index += 1) {
       const leaf = trailLeaves[index];
       const transform = matrixForLayout(layoutForPattern(nextPattern, index));
-      const faceIndex = nextPattern.leafAtlasIndices[index];
+      const faceIndex = faceIndexForPattern(nextPattern, index);
       patternLayoutLeavesVisited += 1;
       if (leaf.style.transform !== transform) {
         leaf.style.transform = transform;
@@ -234,6 +246,7 @@ export function createCsssolitairePreparedPlayer({
       }
     }
     patternFaceInitializedLeafCount = requiredLeafCount;
+    patternFacesUsePhoneCard = activeProfileIndex === playback.phoneProfileIndex;
     patternLayoutWrites += writes;
     return writes;
   }
@@ -291,7 +304,10 @@ export function createCsssolitairePreparedPlayer({
         randomSelectionCount += 1;
       }
     }
-    return shuffleBag.shift();
+    const oppositeDirection = -Math.sign(pattern.phoneHorizontalVelocity);
+    const oppositeIndex = shuffleBag.findIndex((patternIndex) =>
+      Math.sign(patterns[patternIndex].phoneHorizontalVelocity) === oppositeDirection);
+    return oppositeIndex < 0 ? shuffleBag.shift() : shuffleBag.splice(oppositeIndex, 1)[0];
   }
 
   function activatePattern(nextIndex) {
@@ -489,7 +505,8 @@ export function createCsssolitairePreparedPlayer({
         responsiveProfileIndex: activeProfileIndex,
         runtimePreparedPatternSwitchCount: patternSwitchCount,
         runtimeRandomSelectionCount: randomSelectionCount,
-        runtimeRandomSelectionPurpose: "prepared-pattern-shuffled-bag-index-only",
+        runtimeRandomSelectionPurpose:
+          "prepared-pattern-shuffled-bag-alternating-phone-direction-unique-angle",
         runtimeTimerCallbackCount: timerCallbackCount,
         runtimeAnimationFrameCallbackCount: 0,
         runtimeSchedulerTransport: "deadline-setTimeout-prepared-visibility-publication",

--- a/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
+++ b/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
@@ -62,10 +62,12 @@ const PORTRAIT_PROFILES = Object.freeze([
 const PORTRAIT_CARD_COUNTS = Object.freeze(PORTRAIT_PROFILES.map(({ cardCount }) => cardCount));
 const PORTRAIT_CARD_BREAKPOINTS = Object.freeze([520, 720, 920]);
 const PORTRAIT_HORIZONTAL_DISTANCE_SCALE = 2;
-const PHONE_HORIZONTAL_DISTANCE_SCALE = 8;
-const PHONE_LAUNCH_CARD_COUNT = 3;
+const PHONE_HORIZONTAL_DISTANCE_SCALE = 2;
+const PHONE_LAUNCH_CARD_COUNT = 1;
 const PHONE_PLAYBACK_TIME_SCALE = 3;
 const PHONE_PROFILE_INDEX = 1;
+const PHONE_FLOOR_BOUNCE_COUNT = 3;
+const PHONE_TRAIL_SUBSTEP_COUNT = 3;
 const LAUNCH_CYCLE_COUNT = 3;
 const RANK_NAMES = Object.freeze([
   null, "ace", "two", "three", "four", "five", "six", "seven",
@@ -94,6 +96,8 @@ const PREPARED_PATTERN_SEEDS = Object.freeze(Array.from(
   { length: PREPARED_PATTERN_COUNT },
   (_, index) => 1 + index * 9_973,
 ));
+const PHONE_LAUNCH_VECTORS = buildPhoneLaunchVectors();
+const PHONE_IMPACT_HORIZONTAL_STEPS = buildPhoneImpactHorizontalSteps();
 const CARD_SOURCE_FILE = "card-faces-english-pattern-cc0.png";
 const EXPECTED_CARD_SHA256 = "e782179fb60932722548e3e6b46038a2df16d15001d3ea8cbdd22cc005f2841d";
 
@@ -326,6 +330,60 @@ function nearestUnusedVelocity(velocity, usedVelocities) {
   throw new Error("Unable to prepare a unique same-lane Solitaire trajectory");
 }
 
+function greatestCommonDivisor(left, right) {
+  let a = Math.abs(left);
+  let b = Math.abs(right);
+  while (b !== 0) [a, b] = [b, a % b];
+  return a;
+}
+
+function launchAngleKey(horizontalStep, verticalStep) {
+  const divisor = greatestCommonDivisor(horizontalStep, verticalStep);
+  return `${horizontalStep / divisor}:${verticalStep / divisor}`;
+}
+
+function buildPhoneLaunchVectors() {
+  const candidates = [];
+  const angleKeys = new Set();
+  for (let verticalStep = 1; verticalStep <= 7; verticalStep += 1) {
+    for (let horizontalStep = 2; horizontalStep <= 6; horizontalStep += 1) {
+      const angleKey = launchAngleKey(horizontalStep, verticalStep);
+      if (angleKeys.has(angleKey)) continue;
+      angleKeys.add(angleKey);
+      candidates.push({ horizontalStep, verticalStep, angleKey });
+    }
+  }
+  const initialIndex = candidates.findIndex(({ horizontalStep, verticalStep }) =>
+    horizontalStep === 6 && verticalStep === 7);
+  const initial = candidates.splice(initialIndex, 1)[0];
+  const random = msvcRandom(PREPARED_PATTERN_SEEDS[0]);
+  for (let index = candidates.length - 1; index > 0; index -= 1) {
+    const swapIndex = random() % (index + 1);
+    [candidates[index], candidates[swapIndex]] = [candidates[swapIndex], candidates[index]];
+  }
+  return Object.freeze([initial, ...candidates.slice(0, PREPARED_PATTERN_COUNT - 1)]
+    .map(({ horizontalStep, verticalStep, angleKey }, index) => Object.freeze({
+      velocityX: (index % 2 === 0 ? -1 : 1) * horizontalStep * 10,
+      velocityY: -verticalStep * 10,
+      angleKey,
+    })));
+}
+
+function buildPhoneImpactHorizontalSteps() {
+  const steps = [];
+  let slowStep = 2;
+  let fastStep = 6;
+  while (slowStep <= fastStep) {
+    steps.push(fastStep);
+    fastStep -= 1;
+    if (slowStep <= fastStep) {
+      steps.push(slowStep);
+      slowStep += 1;
+    }
+  }
+  return Object.freeze(steps);
+}
+
 function simulateSource(seed) {
   const random = msvcRandom(seed);
   const snapshots = [];
@@ -379,6 +437,110 @@ function simulateSource(seed) {
     });
   }
   return Object.freeze({ cards, snapshots, sourceDraws, sourceSteps: sourceStep });
+}
+
+function simulatePhoneCard(sourceCard, impactPhase) {
+  const snapshots = [];
+  const impacts = [];
+  const [profileWidth, profileHeight] = PORTRAIT_PROFILES[0].playfield;
+  const presentationScale = Math.min(profileWidth / 384, profileHeight / 720);
+  const displayCardWidth = CARD_WIDTH * presentationScale;
+  const displayStartLeft = (profileWidth - displayCardWidth) / 2;
+  const sourceDistanceScale = PHONE_HORIZONTAL_DISTANCE_SCALE * presentationScale;
+  const minimumX = sourceCard.x - displayStartLeft / sourceDistanceScale;
+  const maximumX = sourceCard.x +
+    (profileWidth - displayCardWidth - displayStartLeft) / sourceDistanceScale;
+  let velocityY = sourceCard.velocityY;
+  let velocityX = sourceCard.velocityX;
+  let x = sourceCard.x;
+  let y = FOUNDATION_Y;
+  let lastKeptX = Number.NEGATIVE_INFINITY;
+  let lastKeptY = Number.NEGATIVE_INFINITY;
+  let sourceStep = 0;
+  let floorBounceCount = 0;
+  let impactIndex = impactPhase;
+  const changeHorizontalVelocity = (direction, kind) => {
+    const currentStep = Math.abs(Math.trunc(velocityX / 10));
+    let nextStep;
+    do {
+      nextStep = PHONE_IMPACT_HORIZONTAL_STEPS[impactIndex % PHONE_IMPACT_HORIZONTAL_STEPS.length];
+      impactIndex += 1;
+    } while (nextStep === currentStep);
+    velocityX = direction * nextStep * 10;
+    impacts.push(Object.freeze({ kind, sourceStep, velocityX }));
+  };
+  const retainSnapshot = (snapshotY = y, force = false) => {
+    if (snapshots.length > 0 && x === lastKeptX && snapshotY === lastKeptY) return;
+    if (!force && snapshots.length > 0 &&
+        Math.hypot(x - lastKeptX, y - lastKeptY) < TRAIL_SAMPLE_DISTANCE) return;
+    snapshots.push({
+      id: snapshotId(snapshots.length),
+      faceNumber: faceNumber(sourceCard.rank, sourceCard.suit),
+      foundationIndex: sourceCard.foundationIndex,
+      horizontalDirection: Math.sign(velocityX),
+      sourceStep,
+      timeMs: INITIAL_HOLD_MS + sourceStep * SOURCE_STEP_MS,
+      x,
+      y: snapshotY,
+    });
+    lastKeptX = x;
+    lastKeptY = y;
+  };
+  while (floorBounceCount < PHONE_FLOOR_BOUNCE_COUNT) {
+    retainSnapshot();
+    x += Math.trunc(velocityX / 10);
+    y += Math.trunc(velocityY / 10);
+    velocityY += 3;
+    sourceStep += 1;
+    if (x < minimumX) {
+      x = minimumX;
+      changeHorizontalVelocity(1, "wall");
+      retainSnapshot(y, true);
+    } else if (x > maximumX) {
+      x = maximumX;
+      changeHorizontalVelocity(-1, "wall");
+      retainSnapshot(y, true);
+    }
+    if (y > FLOOR_Y && velocityY > 0) {
+      velocityY = Math.trunc(-8 * velocityY / 10);
+      floorBounceCount += 1;
+      retainSnapshot(SOURCE_BOUNCE_BOTTOM, true);
+      if (floorBounceCount < PHONE_FLOOR_BOUNCE_COUNT) {
+        changeHorizontalVelocity(Math.sign(velocityX), "floor");
+      }
+    }
+  }
+  return Object.freeze({
+    card: Object.freeze({
+      ...sourceCard,
+      retainedSnapshots: snapshots.length,
+      startStep: 0,
+      timeMs: INITIAL_HOLD_MS,
+    }),
+    snapshots: Object.freeze(snapshots),
+    impacts: Object.freeze(impacts),
+    sourceSteps: sourceStep,
+  });
+}
+
+function densifyPhoneSnapshots(snapshots) {
+  const denseSnapshots = [{ ...snapshots[0], id: snapshotId(0) }];
+  for (let index = 1; index < snapshots.length; index += 1) {
+    const previous = snapshots[index - 1];
+    const current = snapshots[index];
+    for (let substep = 1; substep <= PHONE_TRAIL_SUBSTEP_COUNT; substep += 1) {
+      const progress = substep / PHONE_TRAIL_SUBSTEP_COUNT;
+      denseSnapshots.push({
+        ...current,
+        id: snapshotId(denseSnapshots.length),
+        sourceStep: previous.sourceStep + (current.sourceStep - previous.sourceStep) * progress,
+        timeMs: previous.timeMs + (current.timeMs - previous.timeMs) * progress,
+        x: previous.x + (current.x - previous.x) * progress,
+        y: previous.y + (current.y - previous.y) * progress,
+      });
+    }
+  }
+  return Object.freeze(denseSnapshots.map(Object.freeze));
 }
 
 function cardLeaf({ cardFace, foundationIndex, horizontalDirection, left, top }) {
@@ -476,14 +638,27 @@ function buildPreparedPattern(seed, index) {
     top: snapshot.y,
   }));
   const timeline = buildPatternPlayback(source.snapshots, source.cards, source.sourceSteps);
-  const phoneCards = source.cards.slice(0, PHONE_LAUNCH_CARD_COUNT);
-  const phoneTrailLeafCount = phoneCards.reduce((sum, card) => sum + card.retainedSnapshots, 0);
-  const phoneSnapshots = source.snapshots.slice(0, phoneTrailLeafCount);
-  const phoneSourceStepCount = phoneSnapshots.at(-1).sourceStep + 1;
+  const phoneLaunch = PHONE_LAUNCH_VECTORS[index];
+  const phone = simulatePhoneCard({
+    ...source.cards[0],
+    velocityX: phoneLaunch.velocityX,
+    velocityY: phoneLaunch.velocityY,
+  }, index);
+  const phoneSnapshots = densifyPhoneSnapshots(phone.snapshots);
+  const phoneLeaves = phoneSnapshots.map((snapshot) => cardLeaf({
+    cardFace: snapshot.faceNumber,
+    foundationIndex: snapshot.foundationIndex,
+    horizontalDirection: snapshot.horizontalDirection,
+    left: snapshot.x,
+    top: snapshot.y,
+  }));
+  if (phoneLeaves.length > trailLeaves.length) {
+    throw new Error("Prepared phone Solitaire trajectory exceeds the retained leaf pool");
+  }
   const phoneTimeline = buildPatternPlayback(
     phoneSnapshots,
-    phoneCards,
-    phoneSourceStepCount,
+    [{ ...phone.card, retainedSnapshots: phoneSnapshots.length }],
+    phone.sourceSteps,
     PHONE_PLAYBACK_TIME_SCALE,
   );
   const contentBounds = buildContentBounds(source.snapshots);
@@ -503,6 +678,10 @@ function buildPreparedPattern(seed, index) {
       sourceStepCount: source.sourceSteps,
       sourceStepMilliseconds: SOURCE_STEP_MS,
       horizontalVelocities: source.cards.map(({ velocityX }) => velocityX),
+      phoneHorizontalVelocity: phoneLaunch.velocityX,
+      phoneVerticalVelocity: phoneLaunch.velocityY,
+      phoneImpactVelocitySteps: phone.impacts.map(({ kind, velocityX }) =>
+        Object.freeze([kind, Math.trunc(velocityX / 10)])),
       durationMs: timeline.durationMs,
       rewindStartMilliseconds: timeline.rewindStartMilliseconds,
       rewindEndMilliseconds: timeline.rewindEndMilliseconds,
@@ -512,7 +691,10 @@ function buildPreparedPattern(seed, index) {
       phoneTimeline,
       leafLayouts: trailLeaves.map(({ layout }) => layout),
       leafPortraitLayoutsByCardCount: PORTRAIT_CARD_COUNTS.map((_, profileIndex) =>
-        trailLeaves.map(({ portraitLayouts }) => {
+        trailLeaves.map(({ portraitLayouts }, leafIndex) => {
+          if (profileIndex === PHONE_PROFILE_INDEX - 1 && phoneLeaves[leafIndex]) {
+            return phoneLeaves[leafIndex].portraitLayouts[profileIndex];
+          }
           const portraitLayout = portraitLayouts[profileIndex];
           return portraitLayout;
         })),
@@ -551,7 +733,7 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
   const preparedCardAtlas = await prepareCardAtlas(cardBytes);
   const cardSha256 = sha256(preparedCardAtlas.bytes);
 
-  const preparedPatterns = PREPARED_PATTERN_SEEDS.map((seed, index) => buildPreparedPattern(seed, index));
+  const preparedPatterns = PREPARED_PATTERN_SEEDS.map(buildPreparedPattern);
   const initialPattern = preparedPatterns[0];
   const source = initialPattern.source;
   const contentBounds = initialPattern.contentBounds;
@@ -571,7 +753,7 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
   const playback = Object.freeze({
     schema: "csssolitaire-prepared-playback@2",
     loop: true,
-    selection: "crypto-random-shuffled-bag-no-immediate-repeat",
+    selection: "crypto-random-shuffled-bag-alternating-phone-direction-unique-angle",
     patternCount: preparedPatterns.length,
     initialPatternIndex: 0,
     phoneProfileIndex: PHONE_PROFILE_INDEX,
@@ -625,6 +807,10 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       minimumHorizontalSpeed: 20,
       horizontalVelocityDistribution: "mild-slow-bias-first-two-lanes-quarter-right-unique-per-lane-cycle",
       horizontalVelocityBiasExponent: HORIZONTAL_VELOCITY_BIAS_EXPONENT,
+      phoneLaunchVelocityDistribution: "source-effective-steps-balanced-direction-unique-angle",
+      phoneRightwardPatternCount: PREPARED_PATTERN_COUNT / 2,
+      phoneEffectiveLaunchAngleCount: PREPARED_PATTERN_COUNT,
+      phoneExactTrajectoryRepeats: false,
       rightwardFoundationIndices: [0, 1],
       rightwardSelection: "random-value-modulo-4-zero",
       exactSameLaneTrajectoryRepeats: false,
@@ -638,9 +824,15 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       sourceDraws: source.sourceDraws,
       sourceSteps: source.sourceSteps,
       sourceStepMilliseconds: SOURCE_STEP_MS,
-      patterns: preparedPatterns.map(({ id, seed, source: patternSource, trailLeaves: patternLeaves, timeline }) => ({
+      patterns: preparedPatterns.map(({
+        id, seed, source: patternSource, trailLeaves: patternLeaves, timeline, playback: patternPlayback,
+      }) => ({
         id,
         seed,
+        phoneHorizontalVelocity: patternPlayback.phoneHorizontalVelocity,
+        phoneVerticalVelocity: patternPlayback.phoneVerticalVelocity,
+        phoneImpactVelocitySteps: patternPlayback.phoneImpactVelocitySteps,
+        phoneSourceSteps: patternPlayback.phoneTimeline.sourceStepCount,
         sourceDraws: patternSource.sourceDraws,
         sourceSteps: patternSource.sourceSteps,
         rightwardLaunchCount: patternSource.cards.filter(({ velocityX }) => velocityX > 0).length,
@@ -679,11 +871,17 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
       portraitReflectionReferenceWidths: PORTRAIT_PROFILES.map(({ playfield }) => playfield[0]),
       portraitCardCounts: PORTRAIT_CARD_COUNTS,
       portraitCardBreakpoints: PORTRAIT_CARD_BREAKPOINTS,
-      portraitHorizontalMotion: "phone-reflected-three-card-cycle-wider-multi-card-exit",
+      portraitHorizontalMotion:
+        "phone-source-gravity-prepared-wall-and-floor-impact-response-one-card",
       portraitWallBounceCardCounts: [1],
       phoneLaunchCardCount: PHONE_LAUNCH_CARD_COUNT,
       phonePlaybackTimeScale: PHONE_PLAYBACK_TIME_SCALE,
       phoneHorizontalDistanceScale: PHONE_HORIZONTAL_DISTANCE_SCALE,
+      phoneFloorBounceCount: PHONE_FLOOR_BOUNCE_COUNT,
+      phoneImpactResponse:
+        "prepared-new-horizontal-step-after-wall-and-nonterminal-floor-impact",
+      phoneImpactHorizontalSteps: PHONE_IMPACT_HORIZONTAL_STEPS,
+      phoneTrailSubstepCount: PHONE_TRAIL_SUBSTEP_COUNT,
       phoneProfileIndex: PHONE_PROFILE_INDEX,
       preparedSlotLayout: "source-seven-slot-presentation-scaled-card-size",
       slotCount: SOLITAIRE_SLOT_COUNT,

--- a/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
@@ -70,11 +70,16 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.deepEqual(manifest.renderer.portraitCardCounts, [1, 2, 3, 4]);
   assert.deepEqual(manifest.renderer.portraitCardBreakpoints, [520, 720, 920]);
   assert.equal(manifest.renderer.portraitHorizontalMotion,
-    "phone-reflected-three-card-cycle-wider-multi-card-exit");
+    "phone-source-gravity-prepared-wall-and-floor-impact-response-one-card");
   assert.deepEqual(manifest.renderer.portraitWallBounceCardCounts, [1]);
-  assert.equal(manifest.renderer.phoneLaunchCardCount, 3);
+  assert.equal(manifest.renderer.phoneLaunchCardCount, 1);
   assert.equal(manifest.renderer.phonePlaybackTimeScale, 3);
-  assert.equal(manifest.renderer.phoneHorizontalDistanceScale, 8);
+  assert.equal(manifest.renderer.phoneHorizontalDistanceScale, 2);
+  assert.equal(manifest.renderer.phoneFloorBounceCount, 3);
+  assert.equal(manifest.renderer.phoneImpactResponse,
+    "prepared-new-horizontal-step-after-wall-and-nonterminal-floor-impact");
+  assert.deepEqual(manifest.renderer.phoneImpactHorizontalSteps, [6, 2, 5, 3, 4]);
+  assert.equal(manifest.renderer.phoneTrailSubstepCount, 3);
   assert.equal(manifest.renderer.phoneProfileIndex, 1);
   assert.equal(manifest.renderer.preparedSlotLayout, "source-seven-slot-presentation-scaled-card-size");
   assert.equal(manifest.renderer.slotCount, 7);
@@ -93,7 +98,7 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.equal(manifest.metrics.retainedTrailLeafCount, 1948);
   assert.equal(manifest.metrics.preparedPatternCount, 24);
   assert.equal(manifest.metrics.preparedFrameCount, 13774);
-  assert.equal(manifest.metrics.preparedPhoneFrameCount, 9498);
+  assert.equal(manifest.metrics.preparedPhoneFrameCount, 5360);
   assert.equal(manifest.metrics.initialPatternDurationMs, 27210);
   assert.equal(manifest.metrics.minimumPatternDurationMs, 20475);
   assert.equal(manifest.metrics.maximumPatternDurationMs, 31228);
@@ -169,12 +174,29 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.ok(topAnchoredPixels.length > 0);
   assert.equal(Math.min(...topAnchoredPixels), 8);
   assert.ok(Math.max(...topAnchoredPixels) <= 80);
-  assert.equal(playback.selection, "crypto-random-shuffled-bag-no-immediate-repeat");
+  assert.equal(playback.selection,
+    "crypto-random-shuffled-bag-alternating-phone-direction-unique-angle");
   assert.equal(playback.patternCount, 24);
   assert.equal(playback.patterns.length, 24);
   assert.equal(playback.retainedTrailLeafCount, 1948);
   assert.equal(new Set(playback.patterns.map(({ seed }) => seed)).size, 24);
   assert.equal(new Set(playback.patterns.map(({ horizontalVelocities }) => horizontalVelocities.join(","))).size, 24);
+  const phoneHorizontalVelocities = playback.patterns.map(({ phoneHorizontalVelocity }) =>
+    phoneHorizontalVelocity);
+  assert.equal(phoneHorizontalVelocities.filter((velocity) => velocity > 0).length, 12);
+  assert.ok(phoneHorizontalVelocities.every((velocity) =>
+    Number.isSafeInteger(velocity) && Math.abs(velocity) >= 20 && Math.abs(velocity) <= 60 &&
+    velocity % 10 === 0));
+  assert.ok(playback.patterns.every((pattern) =>
+    pattern.phoneImpactVelocitySteps.filter(([kind]) => kind === "floor").length === 2 &&
+    pattern.phoneImpactVelocitySteps.some(([kind]) => kind === "wall") &&
+    pattern.phoneImpactVelocitySteps.every(([, step], index, steps) =>
+      Number.isSafeInteger(step) && Math.abs(step) >= 2 && Math.abs(step) <= 6 &&
+      (index === 0 || Math.abs(step) !== Math.abs(steps[index - 1][1])))));
+  assert.equal(new Set(playback.patterns.map(phoneLaunchAngleKey)).size, 24);
+  assert.equal(new Set(playback.patterns.map((pattern) => JSON.stringify(
+    pattern.leafPortraitLayoutsByCardCount[0].slice(0, pattern.phoneTimeline.trailLeafCount),
+  ))).size, 24);
   assert.equal(playback.patterns.reduce((sum, pattern) => sum + pattern.trailLeafCount, 0), 38014);
   const rightwardVelocities = playback.patterns.flatMap((pattern) =>
     pattern.horizontalVelocities
@@ -196,13 +218,13 @@ test("generated product is one complete retained snapshot plus sparse prepared p
       profile.length === pattern.trailLeafCount && profile.every(Boolean))));
   assert.ok(playback.patterns.every((pattern) => !("leafFoundationIndices" in pattern)));
   assert.ok(playback.patterns.every((pattern) =>
-    pattern.phoneTimeline.launchCardCount === 3 &&
+    pattern.phoneTimeline.launchCardCount === 1 &&
     pattern.phoneTimeline.sourceStepMilliseconds === 22.5 &&
     pattern.phoneTimeline.trailLeafCount < pattern.trailLeafCount));
   assert.equal(playback.patterns.reduce(
     (sum, pattern) => sum + pattern.phoneTimeline.frameTimesMs.length,
     0,
-  ), 9498);
+  ), 5360);
   const maximumPortraitUpdateGaps = [1, 2, 3, 4].map((cardCount) => Math.max(
     ...playback.patterns.map((pattern) => {
       const updateTimes = pattern.frameTimesMs.filter((_, frameIndex) =>
@@ -225,14 +247,23 @@ test("generated product is one complete retained snapshot plus sparse prepared p
     frameCount: initialPattern.phoneTimeline.frameTimesMs.length,
     durationMs: initialPattern.phoneTimeline.durationMs,
   }, {
-    launchCardCount: 3,
-    trailLeafCount: 291,
-    sourceStepCount: 291,
+    launchCardCount: 1,
+    trailLeafCount: 679,
+    sourceStepCount: 226,
     sourceStepMilliseconds: 22.5,
-    frameCount: 317,
-    durationMs: 15067,
+    frameCount: 249,
+    durationMs: 12210,
   });
-  assert.ok(minimumPhoneDirectionChanges(playback.patterns) >= 6);
+  assert.equal(minimumPhoneDirectionChanges(playback.patterns), 3);
+  assert.ok(playback.patterns.every((pattern) => {
+    const verticalPositions = phoneVerticalPositions(pattern);
+    return verticalPositions[0] === 80 && Math.min(...verticalPositions) >= 8 &&
+      Math.max(...verticalPositions) === 624 && verticalPositions.at(-1) === 624;
+  }));
+  assert.equal(Math.min(...phoneVerticalPositions(initialPattern)), 8);
+  assert.ok(new Set(playback.patterns.map((pattern) =>
+    Math.min(...phoneVerticalPositions(pattern)))).size > 1);
+  assert.ok(playback.patterns.every((pattern) => phoneVerticalDirectionChanges(pattern) === 5));
   assert.equal(initialPattern.sourceStepCount, 1679);
   assert.equal(initialPattern.frameTimesMs.length, 609);
   assert.equal(initialPattern.visibilityRows.length, 609);
@@ -251,27 +282,48 @@ test("generated product is one complete retained snapshot plus sparse prepared p
 });
 
 function minimumPhoneDirectionChanges(patterns) {
-  const counts = patterns.flatMap((pattern) => {
-    const layouts = pattern.leafPortraitLayoutsByCardCount[0];
-    const values = [];
-    let start = 0;
-    for (let cardIndex = 0; cardIndex < pattern.phoneTimeline.launchCardCount; cardIndex += 1) {
-      const atlasIndex = pattern.leafAtlasIndices[start];
-      let end = start + 1;
-      while (end < pattern.phoneTimeline.trailLeafCount &&
-          pattern.leafAtlasIndices[end] === atlasIndex) end += 1;
-      const positions = layouts.slice(start, end).map((layout) => layout[0] / 100 * 384 + layout[1] * 71);
-      let previousDirection = 0;
-      let changes = 0;
-      for (let index = 1; index < positions.length; index += 1) {
-        const direction = Math.sign(positions[index] - positions[index - 1]);
-        if (direction !== 0 && previousDirection !== 0 && direction !== previousDirection) changes += 1;
-        if (direction !== 0) previousDirection = direction;
-      }
-      values.push(changes);
-      start = end;
+  const counts = patterns.map((pattern) => {
+    const positions = pattern.leafPortraitLayoutsByCardCount[0]
+      .slice(0, pattern.phoneTimeline.trailLeafCount)
+      .map((layout) => layout[0] / 100 * 384 + layout[1] * 71);
+    let previousDirection = 0;
+    let changes = 0;
+    for (let index = 1; index < positions.length; index += 1) {
+      const direction = Math.sign(positions[index] - positions[index - 1]);
+      if (direction !== 0 && previousDirection !== 0 && direction !== previousDirection) changes += 1;
+      if (direction !== 0) previousDirection = direction;
     }
-    return values;
+    return changes;
   });
   return Math.min(...counts);
+}
+
+function phoneVerticalPositions(pattern) {
+  return pattern.leafPortraitLayoutsByCardCount[0]
+    .slice(0, pattern.phoneTimeline.trailLeafCount)
+    .map(([,, yViewport, yPixels, yCardHeightFactor]) =>
+      yViewport / 100 * 720 + yPixels + yCardHeightFactor * 96);
+}
+
+function phoneVerticalDirectionChanges(pattern) {
+  const positions = phoneVerticalPositions(pattern);
+  let previousDirection = 0;
+  let changes = 0;
+  for (let index = 1; index < positions.length; index += 1) {
+    const direction = Math.sign(positions[index] - positions[index - 1]);
+    if (direction !== 0 && previousDirection !== 0 && direction !== previousDirection) changes += 1;
+    if (direction !== 0) previousDirection = direction;
+  }
+  return changes;
+}
+
+function phoneLaunchAngleKey({ phoneHorizontalVelocity, phoneVerticalVelocity }) {
+  let horizontalStep = Math.abs(Math.trunc(phoneHorizontalVelocity / 10));
+  let verticalStep = Math.abs(Math.trunc(phoneVerticalVelocity / 10));
+  let left = horizontalStep;
+  let right = verticalStep;
+  while (right !== 0) [left, right] = [right, left % right];
+  horizontalStep /= left;
+  verticalStep /= left;
+  return `${horizontalStep}:${verticalStep}`;
 }

--- a/src/adapters/solitaire/tools/smoke-browser.mjs
+++ b/src/adapters/solitaire/tools/smoke-browser.mjs
@@ -86,7 +86,7 @@ try {
       await new Promise((resolveWait) => setTimeout(resolveWait, 650));
       return window.__cssSolitaireDebug.pause();
     });
-    const bankSequence = await page.evaluate(async (firstPatternId) => {
+    const bank = await page.evaluate(async (firstPatternId) => {
       const patternIds = [firstPatternId, window.__cssSolitaireDebug.snapshot().patternId];
       for (let index = 0; index < 22; index += 1) {
         const state = window.__cssSolitaireDebug.snapshot();
@@ -96,8 +96,28 @@ try {
         await new Promise((resolveWait) => setTimeout(resolveWait, 100));
         patternIds.push(window.__cssSolitaireDebug.pause().patternId);
       }
-      return patternIds;
+      const sourcePatterns = window.__cssSolitaireDebug.manifest.sourceProfile.patterns;
+      const selectedPatterns = patternIds.map((patternId) =>
+        sourcePatterns.find(({ id }) => id === patternId));
+      return {
+        patternIds,
+        directions: selectedPatterns.map(({ phoneHorizontalVelocity }) =>
+          Math.sign(phoneHorizontalVelocity)),
+        angles: selectedPatterns.map(({ phoneHorizontalVelocity, phoneVerticalVelocity }) => {
+          let horizontalStep = Math.abs(Math.trunc(phoneHorizontalVelocity / 10));
+          let verticalStep = Math.abs(Math.trunc(phoneVerticalVelocity / 10));
+          let left = horizontalStep;
+          let right = verticalStep;
+          while (right !== 0) [left, right] = [right, left % right];
+          horizontalStep /= left;
+          verticalStep /= left;
+          return `${horizontalStep}:${verticalStep}`;
+        }),
+      };
     }, initial.patternId);
+    const bankSequence = bank.patternIds;
+    const bankDirections = bank.directions;
+    const bankAngles = bank.angles;
     const evidence = await page.evaluate(() => {
       const leaves = [...document.querySelectorAll(".polycss-scene > b")];
       const first = leaves[0];
@@ -186,6 +206,9 @@ try {
         autoplayLoop.patternIndex === 0 || autoplayLoop.patternCount !== 24 ||
         bankSequence.length !== 24 || new Set(bankSequence).size !== 24 ||
         bankSequence.some((patternId, index) => index > 0 && patternId === bankSequence[index - 1]) ||
+        bankDirections.some((direction, index) => index > 0 && direction === bankDirections[index - 1]) ||
+        new Set(bankAngles).size !== 24 ||
+        bankAngles.some((angle, index) => index > 0 && angle === bankAngles[index - 1]) ||
         !evidence.stable || evidence.retainedLeaves !== 1952 || evidence.visibleLeaves !== 4 ||
         evidence.forbiddenSceneElements !== 0 || evidence.mutations.added !== 0 || evidence.mutations.removed !== 0 ||
         JSON.stringify(evidence.structure.bodyChildren) !==
@@ -232,7 +255,8 @@ try {
         evidence.stats.runtimeResetTrailLeavesVisited !== evidence.stats.runtimeResetTrailLeavesRequired ||
         evidence.stats.runtimeResetUnusedLeavesVisited !== 0 ||
         evidence.stats.runtimeRandomSelectionCount < 1 ||
-        evidence.stats.runtimeRandomSelectionPurpose !== "prepared-pattern-shuffled-bag-index-only" ||
+        evidence.stats.runtimeRandomSelectionPurpose !==
+          "prepared-pattern-shuffled-bag-alternating-phone-direction-unique-angle" ||
         evidence.stats.runtimeGeometryCalculationCount !== 0 ||
         evidence.stats.runtimeGeometryBoundsCalculationCount !== 0 ||
         evidence.stats.runtimeFitCalculationPurpose !== "prepared-layout-inline-matrix-resolution" ||
@@ -452,7 +476,9 @@ try {
     await page.evaluate(() => window.__cssSolitaireSmoke.observer.disconnect());
     process.stdout.write(`${JSON.stringify({
       status: "passed", headless: true, browser: browser.version(), deploy, route,
-      readyMs, sampled, autoplayLoop, bankSequence, evidence, visibleBounds, cardPixelRatio, screenshotPath,
+      readyMs, sampled, autoplayLoop, bankSequence, bankDirections, bankAngles, evidence, visibleBounds,
+      cardPixelRatio,
+      screenshotPath,
       mobileInitial, mobileEvidence, mobileCardPixelRatio, mobileScreenshotPath,
       responsiveCardCounts, landscapeViewports, reducedMotionMobileAutoplay, mobileContinuity,
       mobileHandoffWork,
@@ -481,7 +507,7 @@ async function captureReducedMotionMobileAutoplay(browser, port, route) {
       window.__cssSolitaireDebug?.errors().length > 0, null, { timeout: 30_000 });
     const result = await page.evaluate(async () => {
       const initialState = window.__cssSolitaireDebug.snapshot();
-      await new Promise((resolveWait) => setTimeout(resolveWait, 500));
+      await new Promise((resolveWait) => setTimeout(resolveWait, 3_500));
       const advancedState = window.__cssSolitaireDebug.snapshot();
       const stats = window.__cssSolitaireDebug.stats();
       return {
@@ -502,7 +528,7 @@ async function captureReducedMotionMobileAutoplay(browser, port, route) {
       };
     });
     if (!result.reducedMotion || result.errors.length || !result.initial.playing ||
-        !result.advanced.playing || result.advanced.playheadMs < 350 ||
+        !result.advanced.playing || result.advanced.playheadMs < 3_000 ||
         result.advanced.frameIndex <= result.initial.frameIndex ||
         result.timerCallbacks === 0 || result.visibilityWrites === 0) {
       throw new Error(`cssSolitaire reduced-motion mobile autoplay failed: ${JSON.stringify(result)}`);
@@ -561,6 +587,23 @@ async function captureMobileContinuity(browser, port, route) {
         }
         return changes;
       });
+      let lastForwardTimeMs = 0;
+      let firstRewindTimeMs = initial.durationMs;
+      while (firstRewindTimeMs - lastForwardTimeMs > 1) {
+        const middleTimeMs = Math.floor((lastForwardTimeMs + firstRewindTimeMs) / 2);
+        if (window.__cssSolitaireDebug.seek(middleTimeMs).rewinding) {
+          firstRewindTimeMs = middleTimeMs;
+        } else {
+          lastForwardTimeMs = middleTimeMs;
+        }
+      }
+      window.__cssSolitaireDebug.seek(lastForwardTimeMs);
+      const endLeaves = [...document.querySelectorAll(".polycss-scene > b")];
+      let endLeafIndex = endLeaves.length - 1;
+      while (endLeafIndex >= 4 && endLeaves[endLeafIndex].style.visibility !== "visible") {
+        endLeafIndex -= 1;
+      }
+      const endRect = endLeaves[endLeafIndex].getBoundingClientRect();
       return {
         timeline: {
           durationMs: initial.durationMs,
@@ -568,6 +611,7 @@ async function captureMobileContinuity(browser, port, route) {
           trailLeafCount: initial.timelineTrailLeafCount,
           faceCount: faceGroups.length,
           directionChanges,
+          floorGapCssPixels: innerHeight - endRect.bottom,
         },
         samples: [1_000, 2_000, 3_000, 4_000].map((timeMs) => {
           window.__cssSolitaireDebug.seek(timeMs);
@@ -581,9 +625,10 @@ async function captureMobileContinuity(browser, port, route) {
         errors: window.__cssSolitaireDebug.errors(),
       };
     });
-    if (result.errors.length || result.timeline.durationMs !== 15067 ||
-        result.timeline.launchCardCount !== 3 || result.timeline.trailLeafCount !== 291 ||
-        result.timeline.faceCount !== 3 || result.timeline.directionChanges.some((changes) => changes < 5) ||
+    if (result.errors.length || result.timeline.durationMs !== 12210 ||
+        result.timeline.launchCardCount !== 1 || result.timeline.trailLeafCount !== 679 ||
+        result.timeline.faceCount !== 1 || Math.abs(result.timeline.floorGapCssPixels) > 0.1 ||
+        result.timeline.directionChanges.some((changes) => changes < 3) ||
         result.samples.some((sample, index) =>
       index > 0 && sample.visiblePaintedLeaves <= result.samples[index - 1].visiblePaintedLeaves)) {
       throw new Error(`cssSolitaire mobile continuity failed: ${JSON.stringify(result)}`);
@@ -668,7 +713,7 @@ async function captureMobileHandoffWork(browser, port, route) {
       expansion,
       errors: await page.evaluate(() => window.__cssSolitaireDebug.errors()),
     };
-    const expansionLeafCount = handoff.fullTrailLeafCount - handoff.activeTrailLeafCount;
+    const expansionLeafCount = handoff.fullTrailLeafCount;
     if (result.errors.length || reset.visible <= 0 || reset.visited !== reset.visible ||
         reset.required !== reset.visible || reset.unused !== 0 || handoff.patternSwitches !== 1 ||
         handoff.profileIndex !== 1 || handoff.activeTrailLeafCount >= handoff.fullTrailLeafCount ||


### PR DESCRIPTION
## What changed

- prebake a new recovered-range horizontal step after every mobile wall and nonterminal floor impact
- keep one retained mobile card, recovered gravity/floor restitution, three floor bounces, and dense prepared ghosts
- alternate starting direction across the 24-pattern shuffled bank while keeping every launch angle and prepared path unique
- validate the impact sequence, exact floor endpoint, retained DOM, and zero runtime geometry work

## Validation

- `pnpm test:solitaire`
- `pnpm test:solitaire:assets`
- `pnpm test:solitaire:browser`
- `pnpm prepare:solitaire:check`
- `pnpm verify:source-only`
- `pnpm build:solitaire:full`
- `git diff --check`