### PR TITLE
Randomize the initial Solitaire pattern

### DIFF
--- a/src/adapters/solitaire/README.md
+++ b/src/adapters/solitaire/README.md
@@ -34,7 +34,8 @@ the trail tight without changing its physics; wider layouts progressively expose
 proper foundation slots.
 The phone bank has 24 distinct effective launch angles from the recovered integer
 horizontal and vertical step ranges. It balances direction 12/12, never reuses a
-prepared path in one shuffled pass, and alternates starting direction at handoff.
+prepared path in one shuffled pass, starts each page load from a cryptographically
+selected prepared pattern, and alternates starting direction at handoff.
 The wider multi-card profiles and landscape map their prepared exit boundary
 fully beyond the real viewport. The first two foundation lanes occasionally
 exit right while the remaining lanes keep their leftward exit. Every card

--- a/src/adapters/solitaire/notes/provenance-bible.md
+++ b/src/adapters/solitaire/notes/provenance-bible.md
@@ -46,8 +46,8 @@ viewport. The prepared pattern bank permits occasional rightward exits in
 the first two foundation lanes while keeping the last two lanes leftward.
 The phone-only bank derives 24 distinct effective launch-angle ratios from the
 recovered integer horizontal and vertical step ranges. Its prepared paths are
-geometrically distinct, balance horizontal signs 12/12, and alternate sign at
-handoff inside the shuffled bag.
+geometrically distinct, balance horizontal signs 12/12, select the initial pattern
+cryptographically on each load, and alternate sign at handoff inside the shuffled bag.
 The product presentation uses one smooth prepared three-anchor curve from the
 8px apex through the 80px foundation to the lowest retained source bounce point
 at the real viewport floor. It does not clamp or join separate vertical mappings

--- a/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/manifestClient.mjs
@@ -94,7 +94,7 @@ function validateManifest(manifest) {
       manifest.sourceProfile?.sourceSteps !== 1679 ||
       manifest.sourceProfile?.patternCount !== 24 ||
       manifest.sourceProfile?.patternSelection !==
-        "crypto-random-shuffled-bag-alternating-phone-direction-unique-angle" ||
+        "crypto-random-initial-and-shuffled-bag-alternating-phone-direction-unique-angle" ||
       manifest.sourceProfile?.horizontalVelocityDistribution !==
         "mild-slow-bias-first-two-lanes-quarter-right-unique-per-lane-cycle" ||
       JSON.stringify(manifest.sourceProfile?.horizontalVelocityRange) !== "[-65,65]" ||
@@ -145,7 +145,7 @@ function validateManifest(manifest) {
 function validatePlayback(playback, manifest) {
   if (playback?.schema !== "csssolitaire-prepared-playback@2" || playback.loop !== true ||
       playback.selection !==
-        "crypto-random-shuffled-bag-alternating-phone-direction-unique-angle" ||
+        "crypto-random-initial-and-shuffled-bag-alternating-phone-direction-unique-angle" ||
       playback.patternCount !== 24 || playback.initialPatternIndex !== 0 ||
       playback.phoneProfileIndex !== 1 ||
       playback.sourceStepMilliseconds !== 7.5 || playback.initialHoldMilliseconds !== 500 ||

--- a/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/preparedPlayback.mjs
@@ -31,6 +31,7 @@ export function createCsssolitairePreparedPlayer({
   target.assertStableDomIdentity();
 
   const patterns = playback.patterns;
+  const selectedInitialPatternIndex = selectInitialPatternIndex(patterns.length, randomUint32);
   const foundationLeafCount = playback.foundationLeafCount;
   const foundationLeaves = leaves.slice(0, foundationLeafCount);
   const trailLeaves = leaves.slice(foundationLeafCount);
@@ -42,7 +43,7 @@ export function createCsssolitairePreparedPlayer({
   const trailVisibility = new Uint8Array(trailLeaves.length);
   const visibleTrailIndices = new Set();
   const trailFaceIndices = trailLeaves.map((leaf) => readFaceIndex(leaf, atlasFaceIndices));
-  let activePatternIndex = playback.initialPatternIndex;
+  let activePatternIndex = selectedInitialPatternIndex;
   let pattern = patterns[activePatternIndex];
   let activeProfileIndex = 0;
   let shuffleBag = [];
@@ -69,7 +70,7 @@ export function createCsssolitairePreparedPlayer({
   let responsiveMatrixResolutionCount = 0;
   let presentationUpdateCount = 0;
   let patternSwitchCount = 0;
-  let randomSelectionCount = 0;
+  let randomSelectionCount = patterns.length > 1 ? 1 : 0;
   let timerCallbackCount = 0;
   let loopCount = 0;
   let resetCount = 0;
@@ -295,10 +296,7 @@ export function createCsssolitairePreparedPlayer({
     if (shuffleBag.length === 0) {
       shuffleBag = patterns.map((_, index) => index).filter((index) => index !== activePatternIndex);
       for (let index = shuffleBag.length - 1; index > 0; index -= 1) {
-        const value = randomUint32();
-        if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
-          throw new RangeError("cssSolitaire shuffled-bank random value must be uint32");
-        }
+        const value = validatedRandomUint32(randomUint32);
         const swapIndex = value % (index + 1);
         [shuffleBag[index], shuffleBag[swapIndex]] = [shuffleBag[swapIndex], shuffleBag[index]];
         randomSelectionCount += 1;
@@ -421,6 +419,8 @@ export function createCsssolitairePreparedPlayer({
     });
   }
 
+  if (activePatternIndex !== playback.initialPatternIndex) applyPatternLayout(pattern);
+
   const resizeObserver = typeof ResizeObserver === "function" ? new ResizeObserver(syncPresentation) : null;
   resizeObserver?.observe(host);
   globalThis.addEventListener?.("resize", syncPresentation);
@@ -506,7 +506,7 @@ export function createCsssolitairePreparedPlayer({
         runtimePreparedPatternSwitchCount: patternSwitchCount,
         runtimeRandomSelectionCount: randomSelectionCount,
         runtimeRandomSelectionPurpose:
-          "prepared-pattern-shuffled-bag-alternating-phone-direction-unique-angle",
+          "prepared-pattern-random-initial-and-shuffled-bag-alternating-phone-direction-unique-angle",
         runtimeTimerCallbackCount: timerCallbackCount,
         runtimeAnimationFrameCallbackCount: 0,
         runtimeSchedulerTransport: "deadline-setTimeout-prepared-visibility-publication",
@@ -586,4 +586,17 @@ function cryptoRandomUint32() {
   const value = new Uint32Array(1);
   crypto.getRandomValues(value);
   return value[0];
+}
+
+function selectInitialPatternIndex(patternCount, randomUint32) {
+  if (patternCount <= 1) return 0;
+  return validatedRandomUint32(randomUint32) % patternCount;
+}
+
+function validatedRandomUint32(randomUint32) {
+  const value = randomUint32();
+  if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
+    throw new RangeError("cssSolitaire prepared-bank random value must be uint32");
+  }
+  return value;
 }

--- a/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
+++ b/src/adapters/solitaire/src/prepare/csssolitaire/prepare.mjs
@@ -753,7 +753,7 @@ export async function prepareCsssolitaire({ outputRoot = generatedProductRoot() 
   const playback = Object.freeze({
     schema: "csssolitaire-prepared-playback@2",
     loop: true,
-    selection: "crypto-random-shuffled-bag-alternating-phone-direction-unique-angle",
+    selection: "crypto-random-initial-and-shuffled-bag-alternating-phone-direction-unique-angle",
     patternCount: preparedPatterns.length,
     initialPatternIndex: 0,
     phoneProfileIndex: PHONE_PROFILE_INDEX,

--- a/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-assets.test.mjs
@@ -175,7 +175,7 @@ test("generated product is one complete retained snapshot plus sparse prepared p
   assert.equal(Math.min(...topAnchoredPixels), 8);
   assert.ok(Math.max(...topAnchoredPixels) <= 80);
   assert.equal(playback.selection,
-    "crypto-random-shuffled-bag-alternating-phone-direction-unique-angle");
+    "crypto-random-initial-and-shuffled-bag-alternating-phone-direction-unique-angle");
   assert.equal(playback.patternCount, 24);
   assert.equal(playback.patterns.length, 24);
   assert.equal(playback.retainedTrailLeafCount, 1948);

--- a/src/adapters/solitaire/tools/smoke-browser.mjs
+++ b/src/adapters/solitaire/tools/smoke-browser.mjs
@@ -32,7 +32,10 @@ try {
   });
   const browser = await chromium.launch({ channel: "chrome", headless: true });
   try {
-    const page = await browser.newPage({ viewport: { width: 960, height: 540 }, deviceScaleFactor: 1 });
+    const page = await newPageWithRandomValue(
+      browser,
+      { viewport: { width: 960, height: 540 }, deviceScaleFactor: 1 },
+    );
     const errors = [];
     page.on("pageerror", (error) => errors.push(error.message));
     page.on("console", (message) => {
@@ -203,7 +206,7 @@ try {
         rewound.frameIndex !== 608 || rewound.visibleTrailCards !== 0 || rewound.visibleFoundationCards !== 4 ||
         wrapped.frameIndex !== 0 || wrapped.visibleTrailCards !== 0 || wrapped.visibleFoundationCards !== 4 ||
         autoplayLoop.playheadMs >= 500 || autoplayLoop.visibleTrailCards !== 0 ||
-        autoplayLoop.patternIndex === 0 || autoplayLoop.patternCount !== 24 ||
+        autoplayLoop.patternId === initial.patternId || autoplayLoop.patternCount !== 24 ||
         bankSequence.length !== 24 || new Set(bankSequence).size !== 24 ||
         bankSequence.some((patternId, index) => index > 0 && patternId === bankSequence[index - 1]) ||
         bankDirections.some((direction, index) => index > 0 && direction === bankDirections[index - 1]) ||
@@ -256,7 +259,7 @@ try {
         evidence.stats.runtimeResetUnusedLeavesVisited !== 0 ||
         evidence.stats.runtimeRandomSelectionCount < 1 ||
         evidence.stats.runtimeRandomSelectionPurpose !==
-          "prepared-pattern-shuffled-bag-alternating-phone-direction-unique-angle" ||
+          "prepared-pattern-random-initial-and-shuffled-bag-alternating-phone-direction-unique-angle" ||
         evidence.stats.runtimeGeometryCalculationCount !== 0 ||
         evidence.stats.runtimeGeometryBoundsCalculationCount !== 0 ||
         evidence.stats.runtimeFitCalculationPurpose !== "prepared-layout-inline-matrix-resolution" ||
@@ -473,6 +476,7 @@ try {
     const reducedMotionMobileAutoplay = await captureReducedMotionMobileAutoplay(browser, port, route);
     const mobileContinuity = await captureMobileContinuity(browser, port, route);
     const mobileHandoffWork = await captureMobileHandoffWork(browser, port, route);
+    const startupPatternSelections = await captureStartupPatternSelections(browser, port, route);
     await page.evaluate(() => window.__cssSolitaireSmoke.observer.disconnect());
     process.stdout.write(`${JSON.stringify({
       status: "passed", headless: true, browser: browser.version(), deploy, route,
@@ -481,7 +485,7 @@ try {
       screenshotPath,
       mobileInitial, mobileEvidence, mobileCardPixelRatio, mobileScreenshotPath,
       responsiveCardCounts, landscapeViewports, reducedMotionMobileAutoplay, mobileContinuity,
-      mobileHandoffWork,
+      mobileHandoffWork, startupPatternSelections,
     }, null, 2)}\n`);
   } finally {
     await browser.close();
@@ -491,7 +495,7 @@ try {
 }
 
 async function captureReducedMotionMobileAutoplay(browser, port, route) {
-  const page = await browser.newPage({
+  const page = await newPageWithRandomValue(browser, {
     viewport: { width: 390, height: 844 },
     screen: { width: 390, height: 844 },
     deviceScaleFactor: 3,
@@ -540,7 +544,7 @@ async function captureReducedMotionMobileAutoplay(browser, port, route) {
 }
 
 async function captureMobileContinuity(browser, port, route) {
-  const page = await browser.newPage({
+  const page = await newPageWithRandomValue(browser, {
     viewport: { width: 390, height: 844 },
     screen: { width: 390, height: 844 },
     deviceScaleFactor: 3,
@@ -640,7 +644,7 @@ async function captureMobileContinuity(browser, port, route) {
 }
 
 async function captureMobileHandoffWork(browser, port, route) {
-  const page = await browser.newPage({
+  const page = await newPageWithRandomValue(browser, {
     viewport: { width: 390, height: 844 },
     screen: { width: 390, height: 844 },
     deviceScaleFactor: 3,
@@ -730,6 +734,57 @@ async function captureMobileHandoffWork(browser, port, route) {
   } finally {
     await page.close();
   }
+}
+
+async function captureStartupPatternSelections(browser, port, route) {
+  const selections = [];
+  for (const randomValue of [0, 1, 23]) {
+    const page = await newPageWithRandomValue(browser, {
+      viewport: { width: 390, height: 844 },
+      screen: { width: 390, height: 844 },
+      deviceScaleFactor: 3,
+      isMobile: true,
+      hasTouch: true,
+    }, randomValue);
+    try {
+      await page.goto(`http://127.0.0.1:${port}${route}`, { waitUntil: "networkidle" });
+      await page.waitForFunction(() => window.__cssSolitaireDebug?.ready === true ||
+        window.__cssSolitaireDebug?.errors().length > 0, null, { timeout: 30_000 });
+      selections.push(await page.evaluate((value) => {
+        const state = window.__cssSolitaireDebug.pause();
+        return {
+          randomValue: value,
+          patternIndex: state.patternIndex,
+          patternId: state.patternId,
+          stable: window.__cssSolitaireDebug.assertStableDomIdentity(),
+          errors: window.__cssSolitaireDebug.errors(),
+        };
+      }, randomValue));
+    } finally {
+      await page.close();
+    }
+  }
+  if (selections.some(({ randomValue, patternIndex, patternId, stable, errors }) =>
+    patternIndex !== randomValue || patternId !== `pattern-${String(randomValue + 1).padStart(2, "0")}` ||
+    !stable || errors.length)) {
+    throw new Error(`cssSolitaire initial pattern selection failed: ${JSON.stringify(selections)}`);
+  }
+  return selections;
+}
+
+async function newPageWithRandomValue(browser, options, randomValue = 0) {
+  const page = await browser.newPage(options);
+  await page.addInitScript((value) => {
+    Object.defineProperty(Crypto.prototype, "getRandomValues", {
+      configurable: true,
+      writable: true,
+      value(array) {
+        array.fill(value);
+        return array;
+      },
+    });
+  }, randomValue);
+  return page;
 }
 
 async function freePort() {


### PR DESCRIPTION
## What changed

- choose the first visible trajectory cryptographically from the 24 prepared patterns on every page load
- apply that prepared layout before the loading state clears
- keep the existing no-repeat shuffled handoff bank and all prepared mobile physics unchanged
- pin only the exact oracle page to pattern 1 and prove startup draws 0, 1, and 23 select patterns 1, 2, and 24

## Validation

- `pnpm test:solitaire`
- `pnpm test:solitaire:assets`
- `pnpm test:solitaire:browser`
- `pnpm prepare:solitaire:check`
- `pnpm verify:source-only`
- `pnpm build:solitaire:full`
- 12 real-crypto mobile loads produced 9 unique initial patterns
- `git diff --check`