### PR TITLE
feat(site): add Solitaire to landing

### DIFF
--- a/site/public/projects.json
+++ b/site/public/projects.json
@@ -2,6 +2,16 @@
   "schema": "cssgraphics.projects@2",
   "projects": [
     {
+      "number": 6,
+      "id": "solitaire",
+      "name": "Solitaire",
+      "route": "/solitaire/",
+      "preview": "/landing/solitaire.webp",
+      "source": "Classic Solitaire",
+      "description": "The classic Solitaire victory cascade rendered entirely with HTML and CSS using PolyCSS.",
+      "date": "2026-08-17"
+    },
+    {
       "number": 5,
       "id": "electropaint",
       "name": "ElectroPaint",

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -7,13 +7,14 @@ import { fileURLToPath } from "node:url";
 const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = resolve(siteRoot, "..");
 const expectedProjects = [
+  ["solitaire", 6, "Classic Solitaire", "2026-08-17", "The classic Solitaire victory cascade"],
   ["electropaint", 5, "David Tristram", "2026-08-10", "ElectroPaint, originally written by David Tristram"],
   ["menger", 4, "XScreenSaver", "2026-08-13", "XScreenSaver Menger"],
   ["maze", 3, "XScreenSaver", "2026-08-09", "XScreenSaver Maze3D"],
   ["gears", 2, "XScreenSaver", "2026-08-07", "XScreenSaver Gears"],
   ["pipes", 1, "Original", "2026-08-06", "CSS Pipes"],
 ];
-const projectsExcludedFromLanding = ["flowerbox", "gravitywell", "solitaire"];
+const projectsExcludedFromLanding = ["flowerbox", "gravitywell"];
 const projectAdapterDirectories = new Map([
   ["electropaint", "electropaint"],
   ["flowerbox", "flowerbox"],


### PR DESCRIPTION
## Summary

- add Solitaire as project #006 on the css.graphics landing page
- reuse the existing 960x960 Solitaire preview and live `/solitaire/` route
- update the landing collection test to keep numbering, metadata, and exclusion rules explicit

## Verification

- `pnpm test:site`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:solitaire:deploy`
- local browser click-through from the landing to a ready Solitaire bank with zero console errors