### PR TITLE
fix(cyclone): balance prepared palette variety

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -11,18 +11,31 @@ address writes are limited to the six leaves of a particle when the source
 restarts it with a new color.
 There is no Canvas, SVG, WebGL, runtime random walk, geometry construction,
 lighting calculation, matrix formatting, atlas rasterization, or DOM growth.
-The prepared presentation applies a square-root bias to the source's random
-saturation samples. Hue, lightness, RNG cadence, and geometry stay unchanged,
-while low-saturation grey runs occur less often. This is an intentional product
-color bias rather than an exact native-color claim. Viewports below 600px use a
+The prepared presentation maps the source's random saturation samples into a
+0.55-1.0 range. The source's uniform random hue-target timing and its rule that
+particles change color only when they restart are preserved. At preparation,
+each source hue is assigned to one of three slots in the selected session palette.
+Five lossless lighting-atlas variants provide blue-, yellow-, red-, magenta-,
+and green-centered palettes; each variant spans at most three adjacent hue
+families for the entire playback. The browser selects one prepared atlas and
+performs no color calculation. The same source RNG draws preserve lightness,
+RNG cadence, geometry, restart timing, and coherent color bands, but prepared
+hue values are intentionally quantized and are not exact source colors.
+Startup is prebaked to ten audited 40-frame source windows. The selector gives
+equal probability to the five prepared palette variants—blue, yellow, red,
+magenta, and green—then chooses between two expressive browser-reviewed source
+windows in that family. It never phases individual particles around a full hue
+wheel. This is an intentional presentation and startup-selection bias rather
+than an exact native-color or random-start claim.
+Viewports below 600px use a
 90-degree presentation field of view instead of the source-default 80 degrees
 so the cyclone fits narrow screens without changing prepared motion or geometry.
 
 The stream discards the source's dark startup by preparing 24 seconds before its
 first published frame. Its 10,800 states cover 216 seconds before repeating.
-Startup uses `crypto.getRandomValues` once to select a logical chunk and an
-early frame from the first half of the stream, excluding the previous session
-start chunk. Playback then follows the original source order. Each hash-bound
+Startup uses `crypto.getRandomValues` once to select an audited palette family,
+source window, and frame, excluding the previous exact window. Playback
+then follows the original source order. Each hash-bound
 gzip block prefetches its exact successor; only the active and lookahead blocks
 remain resident. The single terminal stream wrap is the only
 non-source-continuous boundary.

--- a/src/adapters/cyclone/src/csscyclone/client.mjs
+++ b/src/adapters/cyclone/src/csscyclone/client.mjs
@@ -10,7 +10,7 @@ import {
 } from "./preparedStream.mjs";
 
 const MODEL_ID = "cyclone";
-const LAST_START_CHUNK_STORAGE_KEY = "csscyclone:last-start-chunk";
+const LAST_START_SELECTION_STORAGE_KEY = "csscyclone:last-start-selection";
 
 export async function mountCycloneClient(host) {
   const state = {
@@ -37,13 +37,16 @@ export async function mountCycloneClient(host) {
         metadata.model?.id !== MODEL_ID ||
         metadata.presentation?.preparedStream?.id !== catalog.streamId ||
         metadata.playback?.chunkCount !== catalog.chunkCount ||
-        metadata.playback?.preparedBlockCount !== catalog.blockCount) {
+        metadata.playback?.preparedBlockCount !== catalog.blockCount ||
+        metadata.lighting?.maximumColorFamilyCount !== catalog.maximumColorFamilyCount ||
+        metadata.lighting?.paletteFamilies?.some((family, index) =>
+          family !== catalog.startupPaletteFamilies[index])) {
       throw new Error("Cyclone prepared model binding drifted");
     }
     const selection = selectInitialCyclonePosition(catalog, {
-      previousChunkIndex: readPreviousStartChunk(catalog.randomStartChunkCount),
+      previousSelectionId: readPreviousStartSelection(catalog.startupSelections),
     });
-    rememberStartChunk(selection.chunkIndex);
+    rememberStartSelection(selection.selectionId);
     const initialStreamFrameIndex = selection.chunkIndex * catalog.chunkFrameCount + selection.frameIndex;
     const initialBlockIndex = Math.floor(initialStreamFrameIndex / catalog.blockFrameCount);
     const initialBlockFrameIndex = initialStreamFrameIndex % catalog.blockFrameCount;
@@ -52,7 +55,7 @@ export async function mountCycloneClient(host) {
     blockLoader.retain([initialBlockIndex, nextBlockIndex]);
     const [initialBlock, loadedLightingAsset] = await Promise.all([
       blockLoader.load(initialBlockIndex),
-      loadCyclonePreparedLightingAsset(metadata.lighting),
+      loadCyclonePreparedLightingAsset(metadata.lighting, selection.paletteFamily),
     ]);
     lightingAsset = loadedLightingAsset;
     const mounted = mountPolyMorphModel(host, loaded.model, {
@@ -138,6 +141,8 @@ function installDebugApi(state) {
           retainedPolygonLeafCount: state.mounted.leafHandles.size,
           initialChunkIndex: state.selection.chunkIndex,
           initialFrameIndex: state.selection.frameIndex,
+          startupSelectionId: state.selection.selectionId ?? null,
+          startupPaletteFamily: state.selection.paletteFamily ?? null,
           startupSelectionMode: state.selection.mode,
           ...state.blockLoader.stats(),
           ...state.player.stats(),
@@ -147,22 +152,20 @@ function installDebugApi(state) {
   });
 }
 
-function readPreviousStartChunk(randomStartChunkCount) {
+function readPreviousStartSelection(startupSelections) {
   try {
-    const stored = globalThis.sessionStorage?.getItem(LAST_START_CHUNK_STORAGE_KEY);
+    const stored = globalThis.sessionStorage?.getItem(LAST_START_SELECTION_STORAGE_KEY);
     if (stored === null || stored === undefined) return null;
-    const chunkIndex = Number(stored);
-    return Number.isSafeInteger(chunkIndex) && chunkIndex >= 0 && chunkIndex < randomStartChunkCount
-      ? chunkIndex
-      : null;
+    return startupSelections.some((selection) => selection.id === stored) ? stored : null;
   } catch {
     return null;
   }
 }
 
-function rememberStartChunk(chunkIndex) {
+function rememberStartSelection(selectionId) {
+  if (typeof selectionId !== "string") return;
   try {
-    globalThis.sessionStorage?.setItem(LAST_START_CHUNK_STORAGE_KEY, String(chunkIndex));
+    globalThis.sessionStorage?.setItem(LAST_START_SELECTION_STORAGE_KEY, selectionId);
   } catch {
     // Startup remains cryptographically random when storage is unavailable.
   }

--- a/src/adapters/cyclone/src/csscyclone/preparedLightingAsset.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedLightingAsset.mjs
@@ -1,16 +1,27 @@
-export async function loadCyclonePreparedLightingAsset(lighting) {
-  if (lighting?.schema !== "csscyclone-prepared-smooth-lighting-atlas@4" ||
-      typeof lighting.assetUrl !== "string" ||
-      !/^[a-f0-9]{64}$/u.test(lighting.assetSha256 ?? "") ||
+export async function loadCyclonePreparedLightingAsset(lighting, paletteFamily) {
+  const variant = lighting?.variants?.find((entry) => entry?.paletteFamily === paletteFamily);
+  if (lighting?.schema !== "csscyclone-prepared-smooth-lighting-atlas@5" ||
+      lighting.maximumColorFamilyCount !== 3 ||
+      lighting.paletteHueSlotCount !== 3 ||
+      !Array.isArray(lighting.paletteFamilies) ||
+      !lighting.paletteFamilies.includes(paletteFamily) ||
+      lighting.variants?.length !== lighting.paletteFamilies.length ||
+      typeof variant?.assetUrl !== "string" ||
+      !/^[a-f0-9]{64}$/u.test(variant.assetSha256 ?? "") ||
+      !Number.isSafeInteger(variant.byteLength) || variant.byteLength < 1 ||
+      variant.hueSlots?.length !== lighting.maximumColorFamilyCount ||
       !Number.isSafeInteger(lighting.width) || lighting.width < 1 ||
       !Number.isSafeInteger(lighting.height) || lighting.height < 1) {
     throw new Error("Prepared Cyclone lighting asset contract is invalid");
   }
-  const response = await fetch(lighting.assetUrl, { cache: "force-cache" });
+  const response = await fetch(variant.assetUrl, { cache: "force-cache" });
   if (!response.ok) throw new Error(`Prepared Cyclone lighting failed: ${response.status}`);
   const bytes = await response.arrayBuffer();
+  if (bytes.byteLength !== variant.byteLength) {
+    throw new Error(`Prepared Cyclone lighting byte length drifted (${bytes.byteLength})`);
+  }
   const actualSha256 = hex(await crypto.subtle.digest("SHA-256", bytes));
-  if (actualSha256 !== lighting.assetSha256) {
+  if (actualSha256 !== variant.assetSha256) {
     throw new Error(`Prepared Cyclone lighting hash drifted (${actualSha256})`);
   }
   const url = URL.createObjectURL(new Blob([bytes], { type: lighting.mimeType }));
@@ -33,6 +44,8 @@ export async function loadCyclonePreparedLightingAsset(lighting) {
     url,
     byteLength: bytes.byteLength,
     sha256: actualSha256,
+    paletteFamily,
+    hueSlots: variant.hueSlots,
     destroy() {
       if (destroyed) return;
       destroyed = true;

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -4,7 +4,7 @@ import { createPolyMorphPreparedDomTarget } from "@layoutit/polycss-morph";
 const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@1";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@1";
 const PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@3";
-const LIGHTING_SCHEMA = "csscyclone-prepared-smooth-lighting-atlas@4";
+const LIGHTING_SCHEMA = "csscyclone-prepared-smooth-lighting-atlas@5";
 const LIGHTING_BLOCK_SCHEMA = "csscyclone-prepared-lighting-block@1";
 const SOURCE_FIELD_OF_VIEW_DEGREES = 80;
 const MOBILE_FIELD_OF_VIEW_DEGREES = 90;
@@ -319,6 +319,8 @@ export function createCyclonePreparedPlayer({
       preparedContinuousHandoffCount,
       preparedTerminalWrapCount,
       preparedLightingAssetBytes: lightingAsset.byteLength,
+      preparedLightingPaletteFamily: lightingAsset.paletteFamily,
+      preparedLightingMaximumColorFamilyCount: lighting.maximumColorFamilyCount,
       preparedLightingColorStateCount: lighting.colorStateCount,
       preparedLightingColorRestartCount: lighting.colorRestartCount,
       runtimeGeometryConstructionCount: 0,
@@ -356,6 +358,8 @@ export function createCyclonePreparedPlayer({
 }
 
 function validateBinding(mounted, catalog, initialBlock, initialFrameIndex, lighting, lightingAsset, loadBlock) {
+  const lightingVariant = lighting?.variants?.find((variant) =>
+    variant?.paletteFamily === lightingAsset?.paletteFamily);
   if (catalog?.schema !== CATALOG_SCHEMA ||
       catalog.blockCount !== catalog.entries?.length ||
       catalog.runtimeLookaheadBlockCount !== 1 ||
@@ -366,9 +370,12 @@ function validateBinding(mounted, catalog, initialBlock, initialFrameIndex, ligh
       lighting.leafCount !== mounted.model.render.leaves.length ||
       lighting.facesPerParticle * mounted.model.render.shapes.length !== lighting.leafCount ||
       lighting.tileBackgroundPositions?.length !== lighting.tileCount ||
+      lighting.maximumColorFamilyCount !== 3 ||
+      lighting.paletteHueSlotCount !== 3 ||
+      lightingAsset?.hueSlots?.length !== lighting.maximumColorFamilyCount ||
       lighting.runtime?.lightingCalculations !== 0 ||
       lighting.runtime?.atlasConstruction !== 0 ||
-      lightingAsset?.sha256 !== lighting.assetSha256 ||
+      lightingAsset?.sha256 !== lightingVariant?.assetSha256 ||
       typeof loadBlock !== "function" ||
       !Number.isSafeInteger(initialFrameIndex) || initialFrameIndex < 0 ||
       initialFrameIndex >= catalog.blockFrameCount) {

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -2,6 +2,10 @@ const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@1";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@1";
 const PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@3";
 const LIGHTING_BLOCK_SCHEMA = "csscyclone-prepared-lighting-block@1";
+const STARTUP_HUE_SECTOR_NAMES = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
+const STARTUP_PALETTE_FAMILIES = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
+const STARTUP_SILHOUETTE_SAMPLING = "browser-reviewed-expressive-source-windows";
+const STARTUP_SELECTION = "session-crypto-random-balanced-source-palette-window-no-immediate-repeat";
 
 export async function loadCyclonePreparedCatalog(descriptor) {
   if (typeof descriptor?.catalogUrl !== "string" ||
@@ -18,39 +22,52 @@ export async function loadCyclonePreparedCatalog(descriptor) {
 
 export function selectInitialCyclonePosition(catalog, {
   search = globalThis.location?.search ?? "",
-  previousChunkIndex = null,
+  previousSelectionId = null,
   randomUint32Pair = cryptoRandomUint32Pair,
 } = {}) {
   validateCatalog(catalog);
   const params = new URLSearchParams(search);
   const requestedChunk = params.get("chunk");
   const requestedFrame = params.get("frame");
+  const requestedPaletteFamily = params.get("palette");
   if (requestedChunk !== null || requestedFrame !== null) {
     const chunkIndex = requestedChunk === null ? 0 : Number(requestedChunk);
     const frameIndex = requestedFrame === null ? 0 : Number(requestedFrame);
+    const paletteFamily = requestedPaletteFamily ?? catalog.startupPaletteFamilies[0];
     validatePosition(catalog, chunkIndex, frameIndex);
-    return Object.freeze({ chunkIndex, frameIndex, mode: "explicit" });
+    if (!catalog.startupPaletteFamilies.includes(paletteFamily)) {
+      throw new RangeError("Requested Cyclone palette family is invalid");
+    }
+    return Object.freeze({ paletteFamily, chunkIndex, frameIndex, mode: "explicit" });
   }
-  if (previousChunkIndex !== null &&
-      (!Number.isSafeInteger(previousChunkIndex) || previousChunkIndex < 0 ||
-        previousChunkIndex >= catalog.randomStartChunkCount)) {
-    throw new RangeError("Previous Cyclone start chunk is invalid");
+  if (previousSelectionId !== null &&
+      (typeof previousSelectionId !== "string" ||
+        !catalog.startupSelections.some((selection) => selection.id === previousSelectionId))) {
+    throw new RangeError("Previous Cyclone start selection is invalid");
   }
   const values = randomUint32Pair();
   if (!Array.isArray(values) || values.length !== 2 ||
       values.some((value) => !Number.isSafeInteger(value) || value < 0 || value > 0xffffffff)) {
     throw new RangeError("Cyclone startup random values must be two uint32 values");
   }
-  const availableChunkCount = previousChunkIndex === null || catalog.randomStartChunkCount === 1
-    ? catalog.randomStartChunkCount
-    : catalog.randomStartChunkCount - 1;
-  let chunkIndex = values[0] % availableChunkCount;
-  if (previousChunkIndex !== null && chunkIndex >= previousChunkIndex) chunkIndex += 1;
-  const frameIndex = values[1] % catalog.randomStartFrameCount;
+  const paletteFamilyIndex = values[0] % catalog.startupPaletteFamilies.length;
+  const paletteFamily = catalog.startupPaletteFamilies[paletteFamilyIndex];
+  const familySelections = catalog.startupSelections.filter((selection) =>
+    selection.paletteFamily === paletteFamily);
+  let selectionIndex = Math.floor(values[0] / catalog.startupPaletteFamilies.length) % familySelections.length;
+  if (familySelections[selectionIndex].id === previousSelectionId && familySelections.length > 1) {
+    selectionIndex = (selectionIndex + 1) % familySelections.length;
+  }
+  const selection = familySelections[selectionIndex];
+  const frameIndex = selection.startFrameIndex + values[1] % selection.frameCount;
   return Object.freeze({
-    chunkIndex,
+    selectionId: selection.id,
+    paletteFamily,
+    chunkIndex: selection.chunkIndex,
     frameIndex,
-    mode: previousChunkIndex === null ? "crypto-random" : "crypto-random-no-repeat",
+    mode: previousSelectionId === null
+      ? "crypto-random-balanced-source-palette"
+      : "crypto-random-balanced-source-palette-no-repeat",
   });
 }
 
@@ -155,10 +172,31 @@ function validateCatalog(catalog) {
       !Number.isSafeInteger(catalog.frameMilliseconds) || catalog.frameMilliseconds < 1 ||
       catalog.streamFrameCount !== catalog.chunkCount * catalog.chunkFrameCount ||
       catalog.streamDurationMilliseconds !== catalog.streamFrameCount * catalog.frameMilliseconds ||
-      !Number.isSafeInteger(catalog.randomStartChunkCount) || catalog.randomStartChunkCount < 1 ||
-      catalog.randomStartChunkCount > catalog.chunkCount ||
-      !Number.isSafeInteger(catalog.randomStartFrameCount) || catalog.randomStartFrameCount < 1 ||
-      catalog.randomStartFrameCount > catalog.chunkFrameCount ||
+      !Array.isArray(catalog.startupPaletteFamilies) ||
+      catalog.startupPaletteFamilies.length !== STARTUP_PALETTE_FAMILIES.length ||
+      catalog.startupPaletteFamilies.some((family, index) =>
+        family !== STARTUP_PALETTE_FAMILIES[index]) ||
+      !Array.isArray(catalog.startupSelections) || catalog.startupSelections.length < 2 ||
+      new Set(catalog.startupSelections.map((selection) => selection?.id)).size !==
+        catalog.startupSelections.length ||
+      catalog.startupSelections.some((selection) =>
+        typeof selection?.id !== "string" || selection.id.length < 1 ||
+        !catalog.startupPaletteFamilies.includes(selection.paletteFamily) ||
+        !Number.isSafeInteger(selection.chunkIndex) || selection.chunkIndex < 0 ||
+        selection.chunkIndex >= catalog.chunkCount ||
+        !Number.isSafeInteger(selection.startFrameIndex) || selection.startFrameIndex < 0 ||
+        !Number.isSafeInteger(selection.frameCount) || selection.frameCount < 1 ||
+        selection.startFrameIndex + selection.frameCount > catalog.chunkFrameCount) ||
+      catalog.maximumColorFamilyCount !== 3 ||
+      catalog.startupSilhouetteSampling !== STARTUP_SILHOUETTE_SAMPLING ||
+      !Array.isArray(catalog.startupSilhouetteSampleFrameOffsets) ||
+      catalog.startupSilhouetteSampleFrameOffsets.length < 1 ||
+      new Set(catalog.startupSilhouetteSampleFrameOffsets).size !==
+        catalog.startupSilhouetteSampleFrameOffsets.length ||
+      catalog.startupSilhouetteSampleFrameOffsets.some((frameOffset) =>
+        !Number.isSafeInteger(frameOffset) || frameOffset < 0 ||
+        catalog.startupSelections.some((selection) => frameOffset >= selection.frameCount)) ||
+      catalog.selection !== STARTUP_SELECTION ||
       catalog.runtimeLookaheadBlockCount !== 1 ||
       catalog.entries.some((entry, index) => entry?.index !== index ||
         entry.chunkIndex !== Math.floor(index / catalog.blocksPerChunk) ||
@@ -173,6 +211,53 @@ function validateCatalog(catalog) {
         !/^[a-f0-9]{64}$/u.test(entry.sha256 ?? "") ||
         !/^[a-f0-9]{64}$/u.test(entry.decodedSha256 ?? ""))) {
     throw new Error("Prepared Cyclone stream catalog drifted");
+  }
+  validateStartupColorProfile(catalog.startupColorProfile, catalog);
+}
+
+function validateStartupColorProfile(profile, catalog) {
+  const familySelectionCounts = new Map(catalog.startupPaletteFamilies.map((family) => [family, 0]));
+  for (const selection of catalog.startupSelections) {
+    familySelectionCounts.set(selection.paletteFamily, familySelectionCounts.get(selection.paletteFamily) + 1);
+  }
+  if (profile?.schema !== "csscyclone-prepared-startup-color-profile@2" ||
+      profile.metric !== "prepared-source-particle-rgb-hsv-dominant-family-per-curated-window" ||
+      typeof profile.minimumMeanSaturation !== "number" || profile.minimumMeanSaturation < 0 ||
+      profile.minimumMeanSaturation > 1 ||
+      typeof profile.minimumDominantHueShare !== "number" ||
+      profile.minimumDominantHueShare <= 0 || profile.minimumDominantHueShare > 1 ||
+      profile.maximumColorFamilyCount !== catalog.maximumColorFamilyCount ||
+      !Array.isArray(profile.hueSectorNames) ||
+      profile.hueSectorNames.length !== STARTUP_HUE_SECTOR_NAMES.length ||
+      profile.hueSectorNames.some((name, index) => name !== STARTUP_HUE_SECTOR_NAMES[index]) ||
+      !Array.isArray(profile.paletteFamilies) ||
+      profile.paletteFamilies.length !== catalog.startupPaletteFamilies.length ||
+      profile.paletteFamilies.some((family, index) => family !== catalog.startupPaletteFamilies[index]) ||
+      !Number.isSafeInteger(profile.familySelectionCount) || profile.familySelectionCount < 1 ||
+      [...familySelectionCounts.values()].some((count) => count !== profile.familySelectionCount) ||
+      !Array.isArray(profile.selections) ||
+      profile.selections.length !== catalog.startupSelections.length ||
+      profile.selections.some((selectionProfile, index) => {
+        const selection = catalog.startupSelections[index];
+        return selectionProfile?.id !== selection.id ||
+          selectionProfile.paletteFamily !== selection.paletteFamily ||
+          selectionProfile.chunkIndex !== selection.chunkIndex ||
+          selectionProfile.startFrameIndex !== selection.startFrameIndex ||
+          selectionProfile.frameCount !== selection.frameCount ||
+          typeof selectionProfile.meanSaturation !== "number" ||
+          selectionProfile.meanSaturation < profile.minimumMeanSaturation ||
+          selectionProfile.dominantHueSector !== selection.paletteFamily ||
+          typeof selectionProfile.dominantHueShare !== "number" ||
+          selectionProfile.dominantHueShare < profile.minimumDominantHueShare ||
+          selectionProfile.dominantHueShare > 1 ||
+          !Array.isArray(selectionProfile.hueSectorShares) ||
+          selectionProfile.hueSectorShares.length !== STARTUP_HUE_SECTOR_NAMES.length ||
+          selectionProfile.hueSectorShares.some((share) =>
+            typeof share !== "number" || share < 0 || share > 1) ||
+          Math.abs(selectionProfile.hueSectorShares.reduce((sum, share) => sum + share, 0) - 1) >
+            0.00001;
+      })) {
+    throw new Error("Prepared Cyclone startup color profile drifted");
   }
 }
 

--- a/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
@@ -4,6 +4,7 @@ import {
   CSSCYCLONE_FACE_INDICES,
   CSSCYCLONE_PARTICLE_VERTICES,
 } from "./modelBuilder.mjs";
+import { CSSCYCLONE_PRESENTATION } from "./sourceModel.mjs";
 
 const CONTENT_SIZE = 2;
 const GUTTER = 1;
@@ -11,6 +12,13 @@ const SLOT_SIZE = CONTENT_SIZE + GUTTER * 2;
 const MAXIMUM_COLUMNS = 1_200;
 const MAXIMUM_TEXTURE_DIMENSION = 8_192;
 const DISPLAY_SCALE = 16;
+const PALETTE_CENTER_HUES = Object.freeze({
+  blue: 2 / 3,
+  yellow: 1 / 6,
+  red: 0,
+  magenta: 5 / 6,
+  green: 1 / 3,
+});
 const LIGHT_DIRECTION = normalize([400, -200, 400]);
 const HALF_VECTOR = normalize([
   LIGHT_DIRECTION[0],
@@ -137,48 +145,70 @@ async function buildPreparedLightingAsset({
   if (width > MAXIMUM_TEXTURE_DIMENSION || height > MAXIMUM_TEXTURE_DIMENSION) {
     throw new Error(`Prepared Cyclone lighting atlas ${width}x${height} exceeds the image contract`);
   }
-  const rgba = Buffer.alloc(width * height * 4);
-  for (let stateIndex = 0; stateIndex < colorStates.length; stateIndex += 1) {
-    const state = colorStates[stateIndex];
-    const vertexColors = frozenVertexNormals[state.particleIndex].map((normal) => shadeVertex({
-      baseColor: state.baseColor,
-      normal,
-    }));
-    for (let faceIndex = 0; faceIndex < CSSCYCLONE_FACE_INDICES.length; faceIndex += 1) {
-      writeAffineTriangleTile({
-        rgba,
-        width,
-        columns,
-        tileIndex: stateIndex * CSSCYCLONE_FACE_INDICES.length + faceIndex,
-        vertexColors,
-        vertexIndices: CSSCYCLONE_FACE_INDICES[faceIndex],
-      });
-    }
+  if (CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount !== 3 ||
+      CSSCYCLONE_PRESENTATION.maximumColorFamilyCount !== 3 ||
+      CSSCYCLONE_PRESENTATION.startupPaletteFamilies.some((family) =>
+        !Object.hasOwn(PALETTE_CENTER_HUES, family))) {
+    throw new Error("Cyclone prepared three-family palette configuration drifted");
   }
-  const bytes = await sharp(rgba, {
-    raw: { width, height, channels: 4 },
-    limitInputPixels: false,
-  }).webp({ lossless: true, effort: 6 }).toBuffer();
-  const assetSha256 = createHash("sha256").update(bytes).digest("hex");
+  const assets = [];
+  for (const paletteFamily of CSSCYCLONE_PRESENTATION.startupPaletteFamilies) {
+    const hueSlots = preparedPaletteHues(paletteFamily);
+    const rgba = Buffer.alloc(width * height * 4);
+    for (let stateIndex = 0; stateIndex < colorStates.length; stateIndex += 1) {
+      const state = colorStates[stateIndex];
+      const baseColor = preparedPaletteColor(state.baseColor, paletteFamily);
+      const vertexColors = frozenVertexNormals[state.particleIndex].map((normal) => shadeVertex({
+        baseColor,
+        normal,
+      }));
+      for (let faceIndex = 0; faceIndex < CSSCYCLONE_FACE_INDICES.length; faceIndex += 1) {
+        writeAffineTriangleTile({
+          rgba,
+          width,
+          columns,
+          tileIndex: stateIndex * CSSCYCLONE_FACE_INDICES.length + faceIndex,
+          vertexColors,
+          vertexIndices: CSSCYCLONE_FACE_INDICES[faceIndex],
+        });
+      }
+    }
+    const bytes = await sharp(rgba, {
+      raw: { width, height, channels: 4 },
+      limitInputPixels: false,
+    }).webp({ lossless: true, effort: 6 }).toBuffer();
+    const assetSha256 = createHash("sha256").update(bytes).digest("hex");
+    assets.push(Object.freeze({
+      paletteFamily,
+      assetUrl: `/csscyclone/assets/lighting-${paletteFamily}-${assetSha256}.webp`,
+      assetSha256,
+      byteLength: bytes.byteLength,
+      hueSlots,
+      bytes,
+    }));
+  }
   const tileBackgroundPositions = Object.freeze(Array.from({ length: tileCount }, (_, tileIndex) => {
     const contentX = tileIndex % columns * SLOT_SIZE + GUTTER;
     const contentY = Math.floor(tileIndex / columns) * SLOT_SIZE + GUTTER;
     return `${-contentX * DISPLAY_SCALE}px ${-contentY * DISPLAY_SCALE}px`;
   }));
   const contract = deepFreeze({
-    schema: "csscyclone-prepared-smooth-lighting-atlas@4",
-    technique: "prepared-stream-frame-zero-smooth-lighting-with-sparse-source-color-restarts",
+    schema: "csscyclone-prepared-smooth-lighting-atlas@5",
+    technique: "prepared-session-three-family-lighting-variants-with-sparse-source-color-restarts",
     source: "src/cyclone/cyclone.cpp#particle::update+initSaver",
     streamId,
-    assetUrl: `/csscyclone/assets/lighting-${assetSha256}.webp`,
-    assetSha256,
     encoding: "WebP-lossless-RGBA8",
     mimeType: "image/webp",
     lossless: true,
     width,
     height,
     decodedBytes: width * height * 4,
-    byteLength: bytes.byteLength,
+    paletteFamilyCount: CSSCYCLONE_PRESENTATION.startupPaletteFamilies.length,
+    paletteFamilies: CSSCYCLONE_PRESENTATION.startupPaletteFamilies,
+    paletteHueSlotCount: CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount,
+    paletteAssignment: CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
+    maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
+    variants: Object.freeze(assets.map(({ bytes: ignored, ...asset }) => Object.freeze(asset))),
     contentSize: CONTENT_SIZE,
     gutterPixels: GUTTER,
     slotSize: SLOT_SIZE,
@@ -196,7 +226,9 @@ async function buildPreparedLightingAsset({
     colorRestartCount,
     facesPerParticle: CSSCYCLONE_FACE_INDICES.length,
     lightingReferenceFrameIndex: 0,
-    sourceColorRestartsExact: true,
+    sourceColorRestartTimingExact: true,
+    sourceHueTimingExact: true,
+    sourceHueValuesExact: false,
     dynamicLightOrientation: false,
     displayScale: DISPLAY_SCALE,
     sampling: "two-by-two-affine-field-with-one-extrapolated-sample-gutter",
@@ -204,7 +236,7 @@ async function buildPreparedLightingAsset({
     backgroundSize: `${width * DISPLAY_SCALE}px ${height * DISPLAY_SCALE}px`,
     tileBackgroundPositions,
     material: Object.freeze({
-      ambientAndDiffuse: "source-particle-rgb",
+      ambientAndDiffuse: "prepared-session-three-family-palette-from-source-particle-rgb",
       specular: Object.freeze([0.7, 0.7, 0.7, 1]),
       shininess: 20,
     }),
@@ -229,13 +261,15 @@ async function buildPreparedLightingAsset({
   });
   return Object.freeze({
     contract,
-    bytes,
+    assets: Object.freeze(assets),
     metrics: Object.freeze({
       preparedLightingChunkCount: chunkCount,
       preparedLightingStreamFrameCount: sourceStreamFrameCount,
       preparedLightingColorStateCount: colorStates.length,
       preparedLightingColorRestartCount: colorRestartCount,
-      preparedLightingAtlasBytes: bytes.byteLength,
+      preparedLightingPaletteVariantCount: assets.length,
+      preparedLightingAtlasBytes: assets.reduce((sum, asset) => sum + asset.byteLength, 0),
+      preparedLightingMaximumVariantAtlasBytes: Math.max(...assets.map((asset) => asset.byteLength)),
       preparedLightingAtlasDecodedBytes: contract.decodedBytes,
       preparedLightingLeafBindingCount: leafCount,
       runtimeLightingCalculations: 0,
@@ -252,6 +286,50 @@ function validateSourceChunk(source) {
       source.frames.some((frame) => frame.particles?.length !== source.bank?.particleCount)) {
     throw new TypeError("Complete Cyclone source chunk is required for prepared lighting");
   }
+}
+
+function preparedPaletteHues(paletteFamily) {
+  const centerHue = PALETTE_CENTER_HUES[paletteFamily];
+  return Object.freeze([-1, 0, 1].map((offset) => {
+    const hue = centerHue + offset / 6;
+    return hue < 0 ? hue + 1 : hue >= 1 ? hue - 1 : hue;
+  }));
+}
+
+function preparedPaletteColor(baseColor, paletteFamily) {
+  const maximum = Math.max(...baseColor);
+  const minimum = Math.min(...baseColor);
+  const chroma = maximum - minimum;
+  const saturation = maximum > 0 ? chroma / maximum : 0;
+  let hue = 0;
+  if (chroma > 1e-12) {
+    if (maximum === baseColor[0]) hue = ((baseColor[1] - baseColor[2]) / chroma) % 6;
+    else if (maximum === baseColor[1]) hue = (baseColor[2] - baseColor[0]) / chroma + 2;
+    else hue = (baseColor[0] - baseColor[1]) / chroma + 4;
+    hue = (hue / 6 + 1) % 1;
+  }
+  const hueSlotIndex = Math.min(
+    CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount - 1,
+    Math.floor(hue * CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount),
+  );
+  return hsvToRgb(preparedPaletteHues(paletteFamily)[hueSlotIndex], saturation, maximum);
+}
+
+function hsvToRgb(hue, saturation, value) {
+  const sector = hue * 6;
+  const index = Math.floor(sector) % 6;
+  const fraction = sector - Math.floor(sector);
+  const minimum = value * (1 - saturation);
+  const descending = value * (1 - fraction * saturation);
+  const ascending = value * (1 - (1 - fraction) * saturation);
+  return [
+    [value, ascending, minimum],
+    [descending, value, minimum],
+    [minimum, value, ascending],
+    [minimum, descending, value],
+    [ascending, minimum, value],
+    [value, minimum, descending],
+  ][index];
 }
 
 function writeAffineTriangleTile({

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -32,7 +32,30 @@ export const CSSCYCLONE_BANK = Object.freeze({
 });
 
 export const CSSCYCLONE_PRESENTATION = Object.freeze({
-  saturationSampling: "sqrt-uniform",
+  saturationSampling: "floor-0.55-plus-0.45-sqrt-uniform",
+  minimumSaturation: 0.55,
+  hueSampling: "source-uniform-random-targets",
+  particleColorAssignment: "source-hue-at-particle-restart",
+  preparedPaletteHueSlotCount: 3,
+  preparedPaletteAssignment: "source-hue-quantized-to-session-three-family-variant",
+  maximumColorFamilyCount: 3,
+  startupPaletteFamilies: Object.freeze(["blue", "yellow", "red", "magenta", "green"]),
+  startupSelections: Object.freeze([
+    Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 20, frameCount: 40 }),
+    Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 190, frameCount: 40 }),
+    Object.freeze({ id: "yellow-a", paletteFamily: "yellow", chunkIndex: 1, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "yellow-b", paletteFamily: "yellow", chunkIndex: 7, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "red-a", paletteFamily: "red", chunkIndex: 5, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "red-b", paletteFamily: "red", chunkIndex: 9, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "magenta-a", paletteFamily: "magenta", chunkIndex: 4, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "magenta-b", paletteFamily: "magenta", chunkIndex: 11, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "green-a", paletteFamily: "green", chunkIndex: 17, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "green-b", paletteFamily: "green", chunkIndex: 19, startFrameIndex: 55, frameCount: 40 }),
+  ]),
+  startupSilhouetteSampling: "browser-reviewed-expressive-source-windows",
+  startupSilhouetteSampleFrameOffsets: Object.freeze([0, 10, 20, 30, 39]),
+  startupMinimumMeanSaturation: 0.68,
+  startupMinimumDominantHueShare: 0.25,
 });
 
 const FACTORIALS = Object.freeze([1, 1, 2, 6, 24, 120, 720]);
@@ -382,7 +405,9 @@ function randf(rng, maximum) {
 }
 
 function randomSaturation(rng) {
-  return Math.sqrt(randf(rng, 1));
+  const vividSample = Math.sqrt(randf(rng, 1));
+  return CSSCYCLONE_PRESENTATION.minimumSaturation +
+    (1 - CSSCYCLONE_PRESENTATION.minimumSaturation) * vividSample;
 }
 
 function identity4() {

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -55,7 +55,7 @@ function fixture() {
     ],
   };
   const lighting = {
-    schema: "csscyclone-prepared-smooth-lighting-atlas@4",
+    schema: "csscyclone-prepared-smooth-lighting-atlas@5",
     streamId: "stream",
     chunkCount: 1,
     chunkFrameCount: 4,
@@ -65,7 +65,9 @@ function fixture() {
     colorRestartCount: 0,
     tileCount: 1,
     tileBackgroundPositions: ["0 0"],
-    assetSha256: "hash",
+    paletteHueSlotCount: 3,
+    maximumColorFamilyCount: 3,
+    variants: [{ paletteFamily: "blue", assetSha256: "hash" }],
     runtime: { lightingCalculations: 0, atlasConstruction: 0 },
   };
   const block = {
@@ -124,7 +126,14 @@ function fixture() {
     initialBlock: block,
     initialFrameIndex: 0,
     lighting,
-    lightingAsset: { url: "atlas.png", byteLength: 1, sha256: "hash", destroy: identity },
+    lightingAsset: {
+      url: "atlas.png",
+      byteLength: 1,
+      sha256: "hash",
+      paletteFamily: "blue",
+      hueSlots: [0.5, 2 / 3, 5 / 6],
+      destroy: identity,
+    },
     loadBlock: async () => block,
     readNow: () => now,
     requestFrame(callback) {

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -27,7 +27,39 @@ test("pins the current Really Slick Cyclone source profile", () => {
   assert.equal(CSSCYCLONE_SOURCE.speed, 10);
   assert.equal(CSSCYCLONE_BANK.chunkCount, 24);
   assert.equal(CSSCYCLONE_BANK.frameCount, 450);
-  assert.equal(CSSCYCLONE_PRESENTATION.saturationSampling, "sqrt-uniform");
+  assert.equal(CSSCYCLONE_PRESENTATION.saturationSampling, "floor-0.55-plus-0.45-sqrt-uniform");
+  assert.equal(CSSCYCLONE_PRESENTATION.minimumSaturation, 0.55);
+  assert.equal(CSSCYCLONE_PRESENTATION.hueSampling, "source-uniform-random-targets");
+  assert.equal(CSSCYCLONE_PRESENTATION.particleColorAssignment, "source-hue-at-particle-restart");
+  assert.equal(CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount, 3);
+  assert.equal(
+    CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
+    "source-hue-quantized-to-session-three-family-variant",
+  );
+  assert.equal(CSSCYCLONE_PRESENTATION.maximumColorFamilyCount, 3);
+  assert.deepEqual(
+    CSSCYCLONE_PRESENTATION.startupPaletteFamilies,
+    ["blue", "yellow", "red", "magenta", "green"],
+  );
+  assert.equal(CSSCYCLONE_PRESENTATION.startupSelections.length, 10);
+  assert.deepEqual(
+    CSSCYCLONE_PRESENTATION.startupSelections.map(({ id, paletteFamily, chunkIndex }) =>
+      [id, paletteFamily, chunkIndex]),
+    [
+      ["blue-a", "blue", 0], ["blue-b", "blue", 0],
+      ["yellow-a", "yellow", 1], ["yellow-b", "yellow", 7],
+      ["red-a", "red", 5], ["red-b", "red", 9],
+      ["magenta-a", "magenta", 4], ["magenta-b", "magenta", 11],
+      ["green-a", "green", 17], ["green-b", "green", 19],
+    ],
+  );
+  assert.equal(
+    CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
+    "browser-reviewed-expressive-source-windows",
+  );
+  assert.deepEqual(CSSCYCLONE_PRESENTATION.startupSilhouetteSampleFrameOffsets, [0, 10, 20, 30, 39]);
+  assert.equal(CSSCYCLONE_PRESENTATION.startupMinimumMeanSaturation, 0.68);
+  assert.equal(CSSCYCLONE_PRESENTATION.startupMinimumDominantHueShare, 0.25);
 });
 
 test("widens only the mobile presentation field of view", () => {
@@ -59,7 +91,7 @@ test("prepares smooth reference lighting without a runtime lighting timeline", a
   const bank = { ...CSSCYCLONE_BANK, particleCount: 3, warmupFrames: 20, frameCount: 4 };
   const source = buildCycloneSourceSequence({ bank });
   const prepared = await buildCyclonePreparedLighting({ source });
-  assert.equal(prepared.contract.schema, "csscyclone-prepared-smooth-lighting-atlas@4");
+  assert.equal(prepared.contract.schema, "csscyclone-prepared-smooth-lighting-atlas@5");
   assert.equal(prepared.contract.contentSize, 2);
   assert.equal(prepared.contract.gutterPixels, 1);
   assert.equal(prepared.contract.leafCount, 18);
@@ -67,6 +99,11 @@ test("prepares smooth reference lighting without a runtime lighting timeline", a
   assert.equal(prepared.contract.colorRestartCount, 0);
   assert.equal(prepared.contract.tileCount, 18);
   assert.equal(prepared.contract.tileBackgroundPositions.length, 18);
+  assert.equal(prepared.contract.paletteFamilyCount, 5);
+  assert.equal(prepared.contract.paletteHueSlotCount, 3);
+  assert.equal(prepared.contract.maximumColorFamilyCount, 3);
+  assert.equal(prepared.contract.variants.length, 5);
+  assert.ok(prepared.contract.variants.every((variant) => variant.hueSlots.length === 3));
   assert.equal(prepared.contract.sourceStreamFrameCount, 4);
   assert.equal(prepared.contract.chunkCount, 1);
   assert.equal(prepared.chunk.frameParticleColorStateIndices.length, 4);
@@ -75,8 +112,9 @@ test("prepares smooth reference lighting without a runtime lighting timeline", a
   assert.equal(prepared.contract.runtime.rootLightingRowWritesPerSample, 0);
   assert.equal(prepared.contract.runtime.lightingCalculations, 0);
   assert.equal(prepared.contract.runtime.atlasConstruction, 0);
-  assert.ok(prepared.bytes.byteLength > 0);
-  assert.match(prepared.contract.assetSha256, /^[a-f0-9]{64}$/u);
+  assert.equal(prepared.assets.length, 5);
+  assert.ok(prepared.assets.every((asset) => asset.bytes.byteLength > 0));
+  assert.ok(prepared.contract.variants.every((variant) => /^[a-f0-9]{64}$/u.test(variant.assetSha256)));
 });
 
 test("publishes only exact source color restarts through sparse leaf addresses", async () => {

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -3,6 +3,20 @@ import test from "node:test";
 import { selectInitialCyclonePosition } from "../src/csscyclone/preparedStream.mjs";
 
 const hash = "0".repeat(64);
+const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
+const startupPaletteFamilies = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
+const startupSelections = Object.freeze([
+  Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 20, frameCount: 40 }),
+  Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 190, frameCount: 40 }),
+  Object.freeze({ id: "yellow-a", paletteFamily: "yellow", chunkIndex: 1, startFrameIndex: 55, frameCount: 40 }),
+  Object.freeze({ id: "yellow-b", paletteFamily: "yellow", chunkIndex: 7, startFrameIndex: 55, frameCount: 40 }),
+  Object.freeze({ id: "red-a", paletteFamily: "red", chunkIndex: 5, startFrameIndex: 55, frameCount: 40 }),
+  Object.freeze({ id: "red-b", paletteFamily: "red", chunkIndex: 9, startFrameIndex: 55, frameCount: 40 }),
+  Object.freeze({ id: "magenta-a", paletteFamily: "magenta", chunkIndex: 4, startFrameIndex: 55, frameCount: 40 }),
+  Object.freeze({ id: "magenta-b", paletteFamily: "magenta", chunkIndex: 11, startFrameIndex: 55, frameCount: 40 }),
+  Object.freeze({ id: "green-a", paletteFamily: "green", chunkIndex: 17, startFrameIndex: 55, frameCount: 40 }),
+  Object.freeze({ id: "green-b", paletteFamily: "green", chunkIndex: 19, startFrameIndex: 55, frameCount: 40 }),
+]);
 const catalog = Object.freeze({
   schema: "csscyclone-prepared-stream-catalog@1",
   streamId: "desktop-stream",
@@ -14,8 +28,33 @@ const catalog = Object.freeze({
   frameMilliseconds: 20,
   streamFrameCount: 10_800,
   streamDurationMilliseconds: 216_000,
-  randomStartChunkCount: 12,
-  randomStartFrameCount: 150,
+  startupPaletteFamilies,
+  startupSelections,
+  startupSilhouetteSampling: "browser-reviewed-expressive-source-windows",
+  startupSilhouetteSampleFrameOffsets: Object.freeze([0, 10, 20, 30, 39]),
+  maximumColorFamilyCount: 3,
+  selection: "session-crypto-random-balanced-source-palette-window-no-immediate-repeat",
+  startupColorProfile: Object.freeze({
+    schema: "csscyclone-prepared-startup-color-profile@2",
+    metric: "prepared-source-particle-rgb-hsv-dominant-family-per-curated-window",
+    minimumMeanSaturation: 0.68,
+    minimumDominantHueShare: 0.25,
+    maximumColorFamilyCount: 3,
+    hueSectorNames,
+    paletteFamilies: startupPaletteFamilies,
+    familySelectionCount: 2,
+    selections: Object.freeze(startupSelections.map((selection) => {
+      const dominantIndex = hueSectorNames.indexOf(selection.paletteFamily);
+      return Object.freeze({
+        ...selection,
+        meanSaturation: 0.9,
+        dominantHueSector: selection.paletteFamily,
+        dominantHueShare: 1,
+        hueSectorShares: Object.freeze(hueSectorNames.map((_, index) =>
+          index === dominantIndex ? 1 : 0)),
+      });
+    })),
+  }),
   runtimeLookaheadBlockCount: 1,
   entries: Object.freeze(Array.from({ length: 216 }, (_, index) => Object.freeze({
     index,
@@ -33,33 +72,77 @@ const catalog = Object.freeze({
   }))),
 });
 
-test("selects a cryptographically supplied prepared stream position once", () => {
+test("selects a balanced prepared source-palette window once", () => {
   assert.deepEqual(selectInitialCyclonePosition(catalog, {
     randomUint32Pair: () => [7, 901],
   }), {
-    chunkIndex: 7,
-    frameIndex: 1,
-    mode: "crypto-random",
+    selectionId: "red-b",
+    paletteFamily: "red",
+    chunkIndex: 9,
+    frameIndex: 76,
+    mode: "crypto-random-balanced-source-palette",
   });
 });
 
-test("does not immediately repeat the previous randomized start chunk", () => {
+test("does not immediately repeat the previous prepared window", () => {
   assert.deepEqual(selectInitialCyclonePosition(catalog, {
-    previousChunkIndex: 7,
+    previousSelectionId: "red-b",
     randomUint32Pair: () => [7, 901],
   }), {
-    chunkIndex: 8,
-    frameIndex: 1,
-    mode: "crypto-random-no-repeat",
+    selectionId: "red-a",
+    paletteFamily: "red",
+    chunkIndex: 5,
+    frameIndex: 76,
+    mode: "crypto-random-balanced-source-palette-no-repeat",
   });
+});
+
+test("rejects a previous start outside the prepared window pool", () => {
+  assert.throws(() => selectInitialCyclonePosition(catalog, {
+    previousSelectionId: "cyan-a",
+    randomUint32Pair: () => [7, 901],
+  }), /Previous Cyclone start selection is invalid/u);
+});
+
+test("gives each prepared three-family palette variant equal selection coverage", () => {
+  const selected = Array.from({ length: 10 }, (_, value) => selectInitialCyclonePosition(catalog, {
+    randomUint32Pair: () => [value, value],
+  }));
+  assert.deepEqual([...new Set(selected.map(({ paletteFamily }) => paletteFamily))], startupPaletteFamilies);
+  assert.deepEqual([...new Set(selected.map(({ selectionId }) => selectionId))].sort(),
+    [...startupSelections.map(({ id }) => id)].sort());
 });
 
 test("accepts an explicit chunk and frame for deterministic browser proof", () => {
   assert.deepEqual(selectInitialCyclonePosition(catalog, {
-    search: "?chunk=23&frame=449",
+    search: "?chunk=23&frame=449&palette=green",
   }), {
+    paletteFamily: "green",
     chunkIndex: 23,
     frameIndex: 449,
     mode: "explicit",
   });
+});
+
+test("rejects startup source-palette profile drift", () => {
+  const driftedCatalog = {
+    ...catalog,
+    startupColorProfile: {
+      ...catalog.startupColorProfile,
+      paletteFamilies: ["blue", "yellow", "red", "magenta", "cyan"],
+    },
+  };
+  assert.throws(() => selectInitialCyclonePosition(driftedCatalog, {
+    randomUint32Pair: () => [7, 901],
+  }), /Prepared Cyclone startup color profile drifted/u);
+});
+
+test("rejects startup selection policy drift", () => {
+  const driftedCatalog = {
+    ...catalog,
+    selection: "session-crypto-random-prepared-any-chunk",
+  };
+  assert.throws(() => selectInitialCyclonePosition(driftedCatalog, {
+    randomUint32Pair: () => [7, 901],
+  }), /Prepared Cyclone stream catalog drifted/u);
 });

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -26,6 +26,10 @@ const sourceLock = JSON.parse(await readFile(join(adapterRoot, "notes/references
 const blockFrameCount = 50;
 const blocksPerChunk = CSSCYCLONE_BANK.frameCount / blockFrameCount;
 const blockCount = CSSCYCLONE_BANK.chunkCount * blocksPerChunk;
+const startupPaletteFamilies = CSSCYCLONE_PRESENTATION.startupPaletteFamilies;
+const startupSelections = CSSCYCLONE_PRESENTATION.startupSelections;
+const startupSilhouetteSampleFrameOffsets = CSSCYCLONE_PRESENTATION.startupSilhouetteSampleFrameOffsets;
+const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
 
 if (!Number.isSafeInteger(blocksPerChunk)) {
   throw new Error("Cyclone prepared chunk must divide into exact transport blocks");
@@ -37,6 +41,7 @@ await mkdir(stagingRoot, { recursive: true });
 
 const lightingStream = createCyclonePreparedLightingStream();
 const blockEntries = [];
+const startupSelectionColorProfiles = new Map();
 let preparedModel = null;
 let preparedFrameCount = 0;
 let uniquePreparedTransformCount = 0;
@@ -53,6 +58,10 @@ for (const source of buildCycloneSourceChunks()) {
   }
   const preparedPlayback = buildCyclonePreparedPlayback({ source });
   const lighting = lightingStream.add(source);
+  for (const selection of startupSelections.filter((entry) =>
+    entry.chunkIndex === source.bank.chunkIndex)) {
+    startupSelectionColorProfiles.set(selection.id, analyzeStartupSelectionColors(source, selection));
+  }
   for (let blockIndex = 0; blockIndex < blocksPerChunk; blockIndex += 1) {
     const streamBlockIndex = source.bank.chunkIndex * blocksPerChunk + blockIndex;
     const localStartFrameIndex = blockIndex * blockFrameCount;
@@ -125,6 +134,9 @@ maximumResidentBlockPairDecodedBytes = Math.max(
   maximumResidentBlockPairDecodedBytes,
   previousBlockDecodedBytes + firstBlockDecodedBytes,
 );
+const startupColorProfile = buildStartupColorProfile(
+  startupSelections.map((selection) => startupSelectionColorProfiles.get(selection.id)),
+);
 const preparedLighting = await lightingStream.finalize();
 const catalogBytes = Buffer.from(`${JSON.stringify({
   schema: "csscyclone-prepared-stream-catalog@1",
@@ -139,9 +151,13 @@ const catalogBytes = Buffer.from(`${JSON.stringify({
   streamFrameCount: CSSCYCLONE_BANK.chunkCount * CSSCYCLONE_BANK.frameCount,
   streamDurationMilliseconds:
     CSSCYCLONE_BANK.chunkCount * CSSCYCLONE_BANK.frameCount * CSSCYCLONE_BANK.frameMilliseconds,
-  randomStartChunkCount: Math.ceil(CSSCYCLONE_BANK.chunkCount / 2),
-  randomStartFrameCount: Math.floor(CSSCYCLONE_BANK.frameCount / 3),
-  selection: "session-crypto-random-chunk-and-frame-no-immediate-chunk-repeat",
+  startupPaletteFamilies,
+  startupSelections,
+  startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
+  startupSilhouetteSampleFrameOffsets,
+  maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
+  startupColorProfile,
+  selection: "session-crypto-random-balanced-source-palette-window-no-immediate-repeat",
   playbackOrder: "source-continuous-ascending-chunks-with-one-terminal-stream-wrap",
   runtimeLookaheadBlockCount: 1,
   entries: blockEntries,
@@ -161,10 +177,12 @@ const catalog = await buildPolyMorphCatalog(CSSCYCLONE_MODEL_ID, [{
   manifestSha256: built.manifestSha256,
 }]);
 await writeBytes(join(stagingRoot, "model", "catalog.json"), catalog.bytes);
-await writeBytes(
-  join(stagingRoot, preparedLighting.contract.assetUrl.replace(/^\/csscyclone\//u, "")),
-  preparedLighting.bytes,
-);
+for (const asset of preparedLighting.assets) {
+  await writeBytes(
+    join(stagingRoot, asset.assetUrl.replace(/^\/csscyclone\//u, "")),
+    asset.bytes,
+  );
+}
 
 await writeJson(join(stagingRoot, "prepared.json"), {
   schema: "csscyclone-prepared-scene@1",
@@ -189,7 +207,13 @@ await writeJson(join(stagingRoot, "prepared.json"), {
       complexity: CSSCYCLONE_SOURCE.complexity,
       speed: CSSCYCLONE_SOURCE.speed,
       stretch: CSSCYCLONE_SOURCE.stretch,
-      saturationSampling: CSSCYCLONE_PRESENTATION.saturationSampling
+      saturationSampling: CSSCYCLONE_PRESENTATION.saturationSampling,
+      minimumSaturation: CSSCYCLONE_PRESENTATION.minimumSaturation,
+      hueSampling: CSSCYCLONE_PRESENTATION.hueSampling,
+      particleColorAssignment: CSSCYCLONE_PRESENTATION.particleColorAssignment,
+      preparedPaletteHueSlotCount: CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount,
+      preparedPaletteAssignment: CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
+      maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
     },
     preparedStream: {
       id: CSSCYCLONE_BANK.id,
@@ -199,9 +223,13 @@ await writeJson(join(stagingRoot, "prepared.json"), {
       streamFrameCount: CSSCYCLONE_BANK.chunkCount * CSSCYCLONE_BANK.frameCount,
       streamDurationMilliseconds:
         CSSCYCLONE_BANK.chunkCount * CSSCYCLONE_BANK.frameCount * CSSCYCLONE_BANK.frameMilliseconds,
-      randomStartChunkCount: Math.ceil(CSSCYCLONE_BANK.chunkCount / 2),
-      randomStartFrameCount: Math.floor(CSSCYCLONE_BANK.frameCount / 3),
-      startupSelection: "session-crypto-random-chunk-and-frame-no-immediate-chunk-repeat",
+      startupPaletteFamilies,
+      startupSelections,
+      startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
+      startupSilhouetteSampleFrameOffsets,
+      maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
+      startupColorProfile,
+      startupSelection: "session-crypto-random-balanced-source-palette-window-no-immediate-repeat",
       handoff: "source-continuous-next-block-with-one-block-lookahead",
     },
     productParticleCount: CSSCYCLONE_BANK.particleCount,
@@ -296,6 +324,124 @@ function slicePreparedPlayback({
     }),
     frames: Object.freeze(frames),
   });
+}
+
+function analyzeStartupSelectionColors(source, selection) {
+  const hueSectorCounts = Array(hueSectorNames.length).fill(0);
+  let saturationSum = 0;
+  let sampleCount = 0;
+  for (const frame of source.frames.slice(
+    selection.startFrameIndex,
+    selection.startFrameIndex + selection.frameCount,
+  )) {
+    for (const particle of frame.particles) {
+      const [red, green, blue] = particle.colorRgb;
+      const maximum = Math.max(red, green, blue);
+      const minimum = Math.min(red, green, blue);
+      const chroma = maximum - minimum;
+      saturationSum += maximum > 0 ? chroma / maximum : 0;
+      hueSectorCounts[hueSector(red, green, blue, maximum, chroma)] += 1;
+      sampleCount += 1;
+    }
+  }
+  const hueSectorShares = hueSectorCounts.map((count) => count / sampleCount);
+  const dominantHueSectorIndex = hueSectorShares.reduce(
+    (bestIndex, share, index) => share > hueSectorShares[bestIndex] ? index : bestIndex,
+    0,
+  );
+  return Object.freeze({
+    id: selection.id,
+    paletteFamily: selection.paletteFamily,
+    chunkIndex: source.bank.chunkIndex,
+    startFrameIndex: selection.startFrameIndex,
+    frameCount: selection.frameCount,
+    meanSaturation: saturationSum / sampleCount,
+    dominantHueSector: hueSectorNames[dominantHueSectorIndex],
+    dominantHueShare: hueSectorShares[dominantHueSectorIndex],
+    hueSectorShares: Object.freeze(hueSectorShares),
+  });
+}
+
+function buildStartupColorProfile(selectionProfiles) {
+  const familySelectionCounts = new Map(startupPaletteFamilies.map((family) => [family, 0]));
+  const selectionIds = new Set();
+  for (const selection of startupSelections) {
+    familySelectionCounts.set(
+      selection.paletteFamily,
+      (familySelectionCounts.get(selection.paletteFamily) ?? 0) + 1,
+    );
+    selectionIds.add(selection.id);
+  }
+  const familySelectionCount = familySelectionCounts.get(startupPaletteFamilies[0]);
+  if (startupPaletteFamilies.length < 2 ||
+      new Set(startupPaletteFamilies).size !== startupPaletteFamilies.length ||
+      startupPaletteFamilies.some((family) => !hueSectorNames.includes(family)) ||
+      selectionIds.size !== startupSelections.length ||
+      startupSelections.some((selection) =>
+        typeof selection.id !== "string" || selection.id.length < 1 ||
+        !startupPaletteFamilies.includes(selection.paletteFamily) ||
+        !Number.isSafeInteger(selection.chunkIndex) || selection.chunkIndex < 0 ||
+        selection.chunkIndex >= CSSCYCLONE_BANK.chunkCount ||
+        !Number.isSafeInteger(selection.startFrameIndex) || selection.startFrameIndex < 0 ||
+        !Number.isSafeInteger(selection.frameCount) || selection.frameCount < 1 ||
+        selection.startFrameIndex + selection.frameCount > CSSCYCLONE_BANK.frameCount) ||
+      !Number.isSafeInteger(familySelectionCount) || familySelectionCount < 1 ||
+      [...familySelectionCounts.values()].some((count) => count !== familySelectionCount) ||
+      new Set(startupSilhouetteSampleFrameOffsets).size !== startupSilhouetteSampleFrameOffsets.length ||
+      startupSilhouetteSampleFrameOffsets.some((offset) =>
+        !Number.isSafeInteger(offset) || offset < 0 ||
+        startupSelections.some((selection) => offset >= selection.frameCount))) {
+    throw new Error("Cyclone prepared startup selection configuration is invalid");
+  }
+  if (selectionProfiles.length !== startupSelections.length ||
+      selectionProfiles.some((profile, index) => {
+        const selection = startupSelections[index];
+        return profile?.id !== selection.id ||
+          profile.paletteFamily !== selection.paletteFamily ||
+          profile.chunkIndex !== selection.chunkIndex ||
+          profile.startFrameIndex !== selection.startFrameIndex ||
+          profile.frameCount !== selection.frameCount ||
+          profile.meanSaturation < CSSCYCLONE_PRESENTATION.startupMinimumMeanSaturation ||
+          profile.dominantHueSector !== selection.paletteFamily ||
+          profile.dominantHueShare < CSSCYCLONE_PRESENTATION.startupMinimumDominantHueShare;
+      })) {
+    throw new Error("Cyclone prepared startup source-palette profile drifted");
+  }
+  return Object.freeze({
+    schema: "csscyclone-prepared-startup-color-profile@2",
+    metric: "prepared-source-particle-rgb-hsv-dominant-family-per-curated-window",
+    minimumMeanSaturation: CSSCYCLONE_PRESENTATION.startupMinimumMeanSaturation,
+    minimumDominantHueShare: CSSCYCLONE_PRESENTATION.startupMinimumDominantHueShare,
+    maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
+    hueSectorNames,
+    paletteFamilies: startupPaletteFamilies,
+    familySelectionCount,
+    selections: Object.freeze(selectionProfiles.map((profile) => Object.freeze({
+      id: profile.id,
+      paletteFamily: profile.paletteFamily,
+      chunkIndex: profile.chunkIndex,
+      startFrameIndex: profile.startFrameIndex,
+      frameCount: profile.frameCount,
+      meanSaturation: roundMetric(profile.meanSaturation),
+      dominantHueSector: profile.dominantHueSector,
+      dominantHueShare: roundMetric(profile.dominantHueShare),
+      hueSectorShares: Object.freeze(profile.hueSectorShares.map(roundMetric)),
+    }))),
+  });
+}
+
+function hueSector(red, green, blue, maximum, chroma) {
+  if (chroma <= 1e-12) return 0;
+  let hue;
+  if (maximum === red) hue = 60 * (((green - blue) / chroma) % 6);
+  else if (maximum === green) hue = 60 * ((blue - red) / chroma + 2);
+  else hue = 60 * ((red - green) / chroma + 4);
+  if (hue < 0) hue += 360;
+  return Math.floor((hue + 30) % 360 / 60);
+}
+
+function roundMetric(value) {
+  return Number(value.toFixed(6));
 }
 
 async function assertSourceIdentity() {


### PR DESCRIPTION
## Summary

- preserve the original hue-target and particle-restart timing while raising the saturation floor
- prepare five equally selected palette variants, with one variant per session and at most three adjacent color families per cyclone
- select from ten expressive prepared source windows without immediately repeating the exact window
- keep runtime color calculations, atlas construction, and DOM growth at zero

## Verification

- pnpm prepare:cyclone
- pnpm test:cyclone (20/20)
- pnpm typecheck
- CSSCYCLONE_DEPLOY_BUILD=1 pnpm build:cyclone
- pnpm test:site (5/5)
- pnpm verify:source-only
- installed Chrome 151 local smoke: all ten prepared selections and twelve randomized reloads, stable 400 roots / 2400 leaves, maximum three visible hue families, no console errors or warnings