### PR TITLE
fix(cyclone): deduplicate and square lighting atlas

### DIFF
--- a/src/adapters/cyclone/src/csscyclone/preparedLightingAsset.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedLightingAsset.mjs
@@ -1,6 +1,6 @@
 export async function loadCyclonePreparedLightingAsset(lighting, paletteFamily) {
   const variant = lighting?.variants?.find((entry) => entry?.paletteFamily === paletteFamily);
-  if (lighting?.schema !== "csscyclone-prepared-smooth-lighting-atlas@5" ||
+  if (lighting?.schema !== "csscyclone-prepared-smooth-lighting-atlas@6" ||
       lighting.maximumColorFamilyCount !== 3 ||
       lighting.paletteHueSlotCount !== 3 ||
       !Array.isArray(lighting.paletteFamilies) ||
@@ -11,7 +11,13 @@ export async function loadCyclonePreparedLightingAsset(lighting, paletteFamily) 
       !Number.isSafeInteger(variant.byteLength) || variant.byteLength < 1 ||
       variant.hueSlots?.length !== lighting.maximumColorFamilyCount ||
       !Number.isSafeInteger(lighting.width) || lighting.width < 1 ||
-      !Number.isSafeInteger(lighting.height) || lighting.height < 1) {
+      !Number.isSafeInteger(lighting.height) || lighting.height < 1 ||
+      !Number.isSafeInteger(lighting.tileCount) || lighting.tileCount < 1 ||
+      !Number.isSafeInteger(lighting.uniqueTileCount) || lighting.uniqueTileCount < 1 ||
+      lighting.uniqueTileCount > lighting.tileCount ||
+      lighting.deduplicatedTileCount !== lighting.tileCount - lighting.uniqueTileCount ||
+      lighting.tileDeduplication !== "exact-cross-palette-rgba8-slot-content" ||
+      lighting.packing !== "near-square-row-major-unique-slots") {
     throw new Error("Prepared Cyclone lighting asset contract is invalid");
   }
   const response = await fetch(variant.assetUrl, { cache: "force-cache" });

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -4,7 +4,7 @@ import { createPolyMorphPreparedDomTarget } from "@layoutit/polycss-morph";
 const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@1";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@1";
 const PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@3";
-const LIGHTING_SCHEMA = "csscyclone-prepared-smooth-lighting-atlas@5";
+const LIGHTING_SCHEMA = "csscyclone-prepared-smooth-lighting-atlas@6";
 const LIGHTING_BLOCK_SCHEMA = "csscyclone-prepared-lighting-block@1";
 const SOURCE_FIELD_OF_VIEW_DEGREES = 80;
 const MOBILE_FIELD_OF_VIEW_DEGREES = 90;

--- a/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
@@ -9,7 +9,7 @@ import { CSSCYCLONE_PRESENTATION } from "./sourceModel.mjs";
 const CONTENT_SIZE = 2;
 const GUTTER = 1;
 const SLOT_SIZE = CONTENT_SIZE + GUTTER * 2;
-const MAXIMUM_COLUMNS = 1_200;
+const UNPACKED_MAXIMUM_COLUMNS = 1_200;
 const MAXIMUM_TEXTURE_DIMENSION = 8_192;
 const DISPLAY_SCALE = 16;
 const PALETTE_CENTER_HUES = Object.freeze({
@@ -138,23 +138,20 @@ async function buildPreparedLightingAsset({
 }) {
   const leafCount = particleCount * CSSCYCLONE_FACE_INDICES.length;
   const tileCount = colorStates.length * CSSCYCLONE_FACE_INDICES.length;
-  const columns = Math.min(MAXIMUM_COLUMNS, tileCount);
-  const rows = Math.ceil(tileCount / columns);
-  const width = columns * SLOT_SIZE;
-  const height = rows * SLOT_SIZE;
-  if (width > MAXIMUM_TEXTURE_DIMENSION || height > MAXIMUM_TEXTURE_DIMENSION) {
-    throw new Error(`Prepared Cyclone lighting atlas ${width}x${height} exceeds the image contract`);
-  }
   if (CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount !== 3 ||
       CSSCYCLONE_PRESENTATION.maximumColorFamilyCount !== 3 ||
       CSSCYCLONE_PRESENTATION.startupPaletteFamilies.some((family) =>
         !Object.hasOwn(PALETTE_CENTER_HUES, family))) {
     throw new Error("Cyclone prepared three-family palette configuration drifted");
   }
-  const assets = [];
+  const unpackedColumns = Math.min(UNPACKED_MAXIMUM_COLUMNS, tileCount);
+  const unpackedRows = Math.ceil(tileCount / unpackedColumns);
+  const unpackedWidth = unpackedColumns * SLOT_SIZE;
+  const unpackedHeight = unpackedRows * SLOT_SIZE;
+  const unpackedVariants = [];
   for (const paletteFamily of CSSCYCLONE_PRESENTATION.startupPaletteFamilies) {
     const hueSlots = preparedPaletteHues(paletteFamily);
-    const rgba = Buffer.alloc(width * height * 4);
+    const rgba = Buffer.alloc(unpackedWidth * unpackedHeight * 4);
     for (let stateIndex = 0; stateIndex < colorStates.length; stateIndex += 1) {
       const state = colorStates[stateIndex];
       const baseColor = preparedPaletteColor(state.baseColor, paletteFamily);
@@ -165,36 +162,61 @@ async function buildPreparedLightingAsset({
       for (let faceIndex = 0; faceIndex < CSSCYCLONE_FACE_INDICES.length; faceIndex += 1) {
         writeAffineTriangleTile({
           rgba,
-          width,
-          columns,
+          width: unpackedWidth,
+          columns: unpackedColumns,
           tileIndex: stateIndex * CSSCYCLONE_FACE_INDICES.length + faceIndex,
           vertexColors,
           vertexIndices: CSSCYCLONE_FACE_INDICES[faceIndex],
         });
       }
     }
+    unpackedVariants.push(Object.freeze({ paletteFamily, hueSlots, rgba }));
+  }
+  const deduplication = deduplicateExactCrossVariantTiles(
+    unpackedVariants.map((variant) => variant.rgba),
+    { width: unpackedWidth, columns: unpackedColumns, tileCount },
+  );
+  const uniqueTileCount = deduplication.uniqueSourceTileIndices.length;
+  const columns = Math.ceil(Math.sqrt(uniqueTileCount));
+  const rows = Math.ceil(uniqueTileCount / columns);
+  const width = columns * SLOT_SIZE;
+  const height = rows * SLOT_SIZE;
+  if (width > MAXIMUM_TEXTURE_DIMENSION || height > MAXIMUM_TEXTURE_DIMENSION) {
+    throw new Error(`Prepared Cyclone lighting atlas ${width}x${height} exceeds the image contract`);
+  }
+  const assets = [];
+  for (const variant of unpackedVariants) {
+    const rgba = packUniqueTiles(variant.rgba, {
+      sourceWidth: unpackedWidth,
+      sourceColumns: unpackedColumns,
+      uniqueSourceTileIndices: deduplication.uniqueSourceTileIndices,
+      targetWidth: width,
+      targetColumns: columns,
+      targetHeight: height,
+    });
     const bytes = await sharp(rgba, {
       raw: { width, height, channels: 4 },
       limitInputPixels: false,
     }).webp({ lossless: true, effort: 6 }).toBuffer();
     const assetSha256 = createHash("sha256").update(bytes).digest("hex");
     assets.push(Object.freeze({
-      paletteFamily,
-      assetUrl: `/csscyclone/assets/lighting-${paletteFamily}-${assetSha256}.webp`,
+      paletteFamily: variant.paletteFamily,
+      assetUrl: `/csscyclone/assets/lighting-${variant.paletteFamily}-${assetSha256}.webp`,
       assetSha256,
       byteLength: bytes.byteLength,
-      hueSlots,
+      hueSlots: variant.hueSlots,
       bytes,
     }));
   }
   const tileBackgroundPositions = Object.freeze(Array.from({ length: tileCount }, (_, tileIndex) => {
-    const contentX = tileIndex % columns * SLOT_SIZE + GUTTER;
-    const contentY = Math.floor(tileIndex / columns) * SLOT_SIZE + GUTTER;
+    const slotIndex = deduplication.tileSlotIndices[tileIndex];
+    const contentX = slotIndex % columns * SLOT_SIZE + GUTTER;
+    const contentY = Math.floor(slotIndex / columns) * SLOT_SIZE + GUTTER;
     return `${-contentX * DISPLAY_SCALE}px ${-contentY * DISPLAY_SCALE}px`;
   }));
   const contract = deepFreeze({
-    schema: "csscyclone-prepared-smooth-lighting-atlas@5",
-    technique: "prepared-session-three-family-lighting-variants-with-sparse-source-color-restarts",
+    schema: "csscyclone-prepared-smooth-lighting-atlas@6",
+    technique: "prepared-session-three-family-lighting-variants-with-sparse-source-color-restarts-and-exact-tile-deduplication",
     source: "src/cyclone/cyclone.cpp#particle::update+initSaver",
     streamId,
     encoding: "WebP-lossless-RGBA8",
@@ -215,6 +237,10 @@ async function buildPreparedLightingAsset({
     columns,
     rows,
     tileCount,
+    uniqueTileCount,
+    deduplicatedTileCount: tileCount - uniqueTileCount,
+    tileDeduplication: "exact-cross-palette-rgba8-slot-content",
+    packing: "near-square-row-major-unique-slots",
     leafCount,
     sourceFaceCount: leafCount,
     sourceFaceCoverageCount: leafCount,
@@ -267,6 +293,9 @@ async function buildPreparedLightingAsset({
       preparedLightingStreamFrameCount: sourceStreamFrameCount,
       preparedLightingColorStateCount: colorStates.length,
       preparedLightingColorRestartCount: colorRestartCount,
+      preparedLightingLogicalTileCount: tileCount,
+      preparedLightingUniqueTileCount: uniqueTileCount,
+      preparedLightingDeduplicatedTileCount: tileCount - uniqueTileCount,
       preparedLightingPaletteVariantCount: assets.length,
       preparedLightingAtlasBytes: assets.reduce((sum, asset) => sum + asset.byteLength, 0),
       preparedLightingMaximumVariantAtlasBytes: Math.max(...assets.map((asset) => asset.byteLength)),
@@ -277,6 +306,102 @@ async function buildPreparedLightingAsset({
       runtimeLightingWritesPerSample: 0,
     }),
   });
+}
+
+function deduplicateExactCrossVariantTiles(variantRgba, { width, columns, tileCount }) {
+  if (!Array.isArray(variantRgba) || variantRgba.length < 1) {
+    throw new Error("Cyclone lighting tile deduplication requires every palette variant");
+  }
+  const tileByteLength = SLOT_SIZE * SLOT_SIZE * 4;
+  const signatureBytes = Buffer.alloc(tileByteLength * variantRgba.length);
+  const slotBySignature = new Map();
+  const tileSlotIndices = new Uint32Array(tileCount);
+  const uniqueSourceTileIndices = [];
+  for (let tileIndex = 0; tileIndex < tileCount; tileIndex += 1) {
+    for (let variantIndex = 0; variantIndex < variantRgba.length; variantIndex += 1) {
+      copyTileToLinear(
+        variantRgba[variantIndex],
+        width,
+        columns,
+        tileIndex,
+        signatureBytes,
+        variantIndex * tileByteLength,
+      );
+    }
+    const signature = signatureBytes.toString("base64");
+    let slotIndex = slotBySignature.get(signature);
+    if (slotIndex === undefined) {
+      slotIndex = uniqueSourceTileIndices.length;
+      slotBySignature.set(signature, slotIndex);
+      uniqueSourceTileIndices.push(tileIndex);
+    }
+    tileSlotIndices[tileIndex] = slotIndex;
+  }
+  return Object.freeze({
+    tileSlotIndices,
+    uniqueSourceTileIndices: Object.freeze(uniqueSourceTileIndices),
+  });
+}
+
+function packUniqueTiles(source, {
+  sourceWidth,
+  sourceColumns,
+  uniqueSourceTileIndices,
+  targetWidth,
+  targetColumns,
+  targetHeight,
+}) {
+  const target = Buffer.alloc(targetWidth * targetHeight * 4);
+  for (let slotIndex = 0; slotIndex < uniqueSourceTileIndices.length; slotIndex += 1) {
+    copyAtlasTile({
+      source,
+      sourceWidth,
+      sourceColumns,
+      sourceTileIndex: uniqueSourceTileIndices[slotIndex],
+      target,
+      targetWidth,
+      targetColumns,
+      targetTileIndex: slotIndex,
+    });
+  }
+  return target;
+}
+
+function copyTileToLinear(source, sourceWidth, sourceColumns, sourceTileIndex, target, targetOffset) {
+  const sourceX = sourceTileIndex % sourceColumns * SLOT_SIZE;
+  const sourceY = Math.floor(sourceTileIndex / sourceColumns) * SLOT_SIZE;
+  const rowByteLength = SLOT_SIZE * 4;
+  for (let localY = 0; localY < SLOT_SIZE; localY += 1) {
+    const sourceOffset = ((sourceY + localY) * sourceWidth + sourceX) * 4;
+    source.copy(
+      target,
+      targetOffset + localY * rowByteLength,
+      sourceOffset,
+      sourceOffset + rowByteLength,
+    );
+  }
+}
+
+function copyAtlasTile({
+  source,
+  sourceWidth,
+  sourceColumns,
+  sourceTileIndex,
+  target,
+  targetWidth,
+  targetColumns,
+  targetTileIndex,
+}) {
+  const sourceX = sourceTileIndex % sourceColumns * SLOT_SIZE;
+  const sourceY = Math.floor(sourceTileIndex / sourceColumns) * SLOT_SIZE;
+  const targetX = targetTileIndex % targetColumns * SLOT_SIZE;
+  const targetY = Math.floor(targetTileIndex / targetColumns) * SLOT_SIZE;
+  const rowByteLength = SLOT_SIZE * 4;
+  for (let localY = 0; localY < SLOT_SIZE; localY += 1) {
+    const sourceOffset = ((sourceY + localY) * sourceWidth + sourceX) * 4;
+    const targetOffset = ((targetY + localY) * targetWidth + targetX) * 4;
+    source.copy(target, targetOffset, sourceOffset, sourceOffset + rowByteLength);
+  }
 }
 
 function validateSourceChunk(source) {

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -55,7 +55,7 @@ function fixture() {
     ],
   };
   const lighting = {
-    schema: "csscyclone-prepared-smooth-lighting-atlas@5",
+    schema: "csscyclone-prepared-smooth-lighting-atlas@6",
     streamId: "stream",
     chunkCount: 1,
     chunkFrameCount: 4,
@@ -64,6 +64,10 @@ function fixture() {
     colorStateCount: 1,
     colorRestartCount: 0,
     tileCount: 1,
+    uniqueTileCount: 1,
+    deduplicatedTileCount: 0,
+    tileDeduplication: "exact-cross-palette-rgba8-slot-content",
+    packing: "near-square-row-major-unique-slots",
     tileBackgroundPositions: ["0 0"],
     paletteHueSlotCount: 3,
     maximumColorFamilyCount: 3,

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -91,13 +91,20 @@ test("prepares smooth reference lighting without a runtime lighting timeline", a
   const bank = { ...CSSCYCLONE_BANK, particleCount: 3, warmupFrames: 20, frameCount: 4 };
   const source = buildCycloneSourceSequence({ bank });
   const prepared = await buildCyclonePreparedLighting({ source });
-  assert.equal(prepared.contract.schema, "csscyclone-prepared-smooth-lighting-atlas@5");
+  assert.equal(prepared.contract.schema, "csscyclone-prepared-smooth-lighting-atlas@6");
   assert.equal(prepared.contract.contentSize, 2);
   assert.equal(prepared.contract.gutterPixels, 1);
   assert.equal(prepared.contract.leafCount, 18);
   assert.equal(prepared.contract.colorStateCount, 3);
   assert.equal(prepared.contract.colorRestartCount, 0);
   assert.equal(prepared.contract.tileCount, 18);
+  assert.ok(prepared.contract.uniqueTileCount <= prepared.contract.tileCount);
+  assert.equal(
+    prepared.contract.deduplicatedTileCount,
+    prepared.contract.tileCount - prepared.contract.uniqueTileCount,
+  );
+  assert.equal(prepared.contract.tileDeduplication, "exact-cross-palette-rgba8-slot-content");
+  assert.equal(prepared.contract.packing, "near-square-row-major-unique-slots");
   assert.equal(prepared.contract.tileBackgroundPositions.length, 18);
   assert.equal(prepared.contract.paletteFamilyCount, 5);
   assert.equal(prepared.contract.paletteHueSlotCount, 3);
@@ -108,7 +115,7 @@ test("prepares smooth reference lighting without a runtime lighting timeline", a
   assert.equal(prepared.contract.chunkCount, 1);
   assert.equal(prepared.chunk.frameParticleColorStateIndices.length, 4);
   assert.equal(prepared.contract.displayScale, 16);
-  assert.equal(prepared.contract.height, 4);
+  assert.ok(Math.abs(prepared.contract.width - prepared.contract.height) <= prepared.contract.slotSize);
   assert.equal(prepared.contract.runtime.rootLightingRowWritesPerSample, 0);
   assert.equal(prepared.contract.runtime.lightingCalculations, 0);
   assert.equal(prepared.contract.runtime.atlasConstruction, 0);


### PR DESCRIPTION
## Summary

- deduplicate exact 4x4 RGBA lighting slots across all five prepared palette variants
- repack the 40,677 unique slots into a near-square 202x202 layout while preserving 49,680 logical tile addresses
- bump and validate the prepared lighting contract as schema @6

## Result

- atlas dimensions: 4,800x168 -> 808x808
- exact duplicates removed: 9,003 / 49,680 (18.12%)
- total lossless WebP bytes: 4,104,488 -> 3,177,888 (-22.57%)
- decoded atlas bytes: 3,225,600 -> 2,611,456 (-19.04%)
- exhaustive decoded proof: 248,400 logical tile/variant comparisons, zero RGBA differences
- fixed browser frame: 0 / 518,400 mismatched pixels; DOM remains 400 retained roots / 2,400 leaves

## Verification

- `pnpm test:cyclone` (20/20)
- `pnpm build:cyclone`
- 3x5-second deployed-vs-local Chrome trace at 4x CPU, all contracts healthy