### PR TITLE
fix(cyclone): prebuffer playback horizon

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -36,8 +36,8 @@ first published frame. Its 10,800 states cover 216 seconds before repeating.
 Startup uses `crypto.getRandomValues` once to select an audited palette family,
 source window, and frame, excluding the previous exact window. Playback
 then follows the original source order. Each hash-bound
-gzip block prefetches its exact successor; only the active and lookahead blocks
-remain resident. The single terminal stream wrap is the only
+gzip block maintains a three-block prepared lookahead; only the active block
+and that bounded horizon remain resident. The single terminal stream wrap is the only
 non-source-continuous boundary.
 
 Source identity is pinned in `notes/references/source-lock.json`. Preparation
@@ -56,12 +56,14 @@ pnpm build:cyclone
 pnpm dev:cyclone
 ```
 
-The first published frame qualifies the prepared smooth-light field. During
-motion the highlight orientation stays attached to each particle while source
-color restarts remain exact; this is an explicit performance approximation.
-The complete dense scene is not pixel-identical because OpenGL also resolves
-intersecting particles with a per-fragment depth buffer while the retained CSS
-scene uses planar compositor ordering. The missing non-corner-shape triangle
-fallback keeps this first slice from being a release claim.
+The retained-DOM route is publication-qualified within its documented PolyCSS
+constraints. The first published frame qualifies the prepared smooth-light
+field. During motion the highlight orientation stays attached to each particle
+while source color restarts remain exact; this is an intentional performance
+adaptation. The complete dense scene is not claimed to be pixel-identical to
+OpenGL because OpenGL resolves intersecting particles with a per-fragment depth
+buffer while the retained CSS scene uses planar compositor ordering. The
+supported Chrome path renders all six CSS triangle leaves per particle with no
+alternate renderer or geometry fallback.
 
 The adapter is GPL-2.0-or-later; see [NOTICE.md](NOTICE.md).

--- a/src/adapters/cyclone/src/csscyclone/client.mjs
+++ b/src/adapters/cyclone/src/csscyclone/client.mjs
@@ -51,10 +51,15 @@ export async function mountCycloneClient(host) {
     const initialBlockIndex = Math.floor(initialStreamFrameIndex / catalog.blockFrameCount);
     const initialBlockFrameIndex = initialStreamFrameIndex % catalog.blockFrameCount;
     const blockLoader = createCyclonePreparedBlockLoader(catalog);
-    const nextBlockIndex = (initialBlockIndex + 1) % catalog.blockCount;
-    blockLoader.retain([initialBlockIndex, nextBlockIndex]);
-    const [initialBlock, loadedLightingAsset] = await Promise.all([
+    const lookaheadBlockIndices = Array.from(
+      { length: catalog.runtimeLookaheadBlockCount },
+      (unused, offset) => (initialBlockIndex + offset + 1) % catalog.blockCount,
+    );
+    const residentBlockIndices = [initialBlockIndex, ...lookaheadBlockIndices];
+    blockLoader.retain(residentBlockIndices);
+    const [initialBlock, initialLookaheadBlocks, loadedLightingAsset] = await Promise.all([
       blockLoader.load(initialBlockIndex),
+      Promise.all(lookaheadBlockIndices.map((streamBlockIndex) => blockLoader.load(streamBlockIndex))),
       loadCyclonePreparedLightingAsset(metadata.lighting, selection.paletteFamily),
     ]);
     lightingAsset = loadedLightingAsset;
@@ -67,14 +72,15 @@ export async function mountCycloneClient(host) {
       mounted,
       catalog,
       initialBlock,
+      initialLookaheadBlocks,
       initialFrameIndex: initialBlockFrameIndex,
       lighting: metadata.lighting,
       lightingAsset,
       loadBlock(streamBlockIndex) {
         return blockLoader.load(streamBlockIndex);
       },
-      onBlockWindow(activeBlockIndex, pendingBlockIndex) {
-        blockLoader.retain([activeBlockIndex, pendingBlockIndex]);
+      onBlockWindow(streamBlockIndices) {
+        blockLoader.retain(streamBlockIndices);
       },
     });
     player.resize();

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -22,6 +22,7 @@ export function createCyclonePreparedPlayer({
   mounted,
   catalog,
   initialBlock,
+  initialLookaheadBlocks = [],
   initialFrameIndex,
   lighting,
   lightingAsset,
@@ -34,7 +35,16 @@ export function createCyclonePreparedPlayer({
   requestDelay = (callback, delay) => setTimeout(callback, delay),
   cancelDelay = (delay) => clearTimeout(delay),
 }) {
-  validateBinding(mounted, catalog, initialBlock, initialFrameIndex, lighting, lightingAsset, loadBlock);
+  validateBinding(
+    mounted,
+    catalog,
+    initialBlock,
+    initialLookaheadBlocks,
+    initialFrameIndex,
+    lighting,
+    lightingAsset,
+    loadBlock,
+  );
   const shapeElements = mounted.model.render.shapes.map((shape) => mounted.shapeElements.get(shape.id));
   const leafElements = mounted.model.render.leaves.map((leaf) => mounted.leafHandles.get(leaf.id)?.element);
   if (shapeElements.some((element) => !element) || leafElements.some((element) => !element)) {
@@ -64,10 +74,10 @@ export function createCyclonePreparedPlayer({
   let playback = activeBlock.playback;
   let lightingFrames = activeBlock.lighting;
   let activeBlockIndex = activeBlock.streamBlockIndex;
-  let pendingBlock = null;
-  let pendingBlockIndex = null;
-  let pendingBlockPromise = null;
-  let pendingBlockError = null;
+  const pendingBlocks = new Map(initialLookaheadBlocks.map((block) => [
+    block.streamBlockIndex,
+    { block, promise: Promise.resolve(block), error: null },
+  ]));
   let paused = true;
   let destroyed = false;
   let frameRequest = null;
@@ -88,7 +98,7 @@ export function createCyclonePreparedPlayer({
   let lightingLeafAddressWrites = 0;
   let preparedChunkSwitchCount = 0;
   let preparedBlockSwitchCount = 0;
-  let preparedBlockPrefetchCount = 0;
+  let preparedBlockPrefetchCount = initialLookaheadBlocks.length;
   let runtimePreparedBlockWaitCount = 0;
   let preparedContinuousHandoffCount = 0;
   let preparedTerminalWrapCount = 0;
@@ -99,7 +109,7 @@ export function createCyclonePreparedPlayer({
   publishTransforms(playback.frames[initialFrameIndex]);
   publishLighting(initialFrameIndex, true);
   applyCount += 1;
-  queueNextBlock();
+  queueLookaheadBlocks();
 
   function publishTransforms(row) {
     for (let operation = 0; operation < row.length; operation += 2) {
@@ -136,45 +146,62 @@ export function createCyclonePreparedPlayer({
     applyCount += 1;
   }
 
-  function queueNextBlock() {
-    if (destroyed || pendingBlock || pendingBlockPromise) return pendingBlockPromise;
-    pendingBlockIndex = (activeBlockIndex + 1) % catalog.blockCount;
-    pendingBlockError = null;
-    preparedBlockPrefetchCount += 1;
-    onBlockWindow(activeBlockIndex, pendingBlockIndex);
-    pendingBlockPromise = Promise.resolve(loadBlock(pendingBlockIndex)).then((block) => {
-      if (destroyed) return null;
-      validateBlockBinding(block, catalog, mounted.model, lighting);
-      pendingBlock = block;
-      pendingBlockPromise = null;
-      return block;
-    }).catch((error) => {
-      pendingBlockError = error;
-      pendingBlockPromise = null;
-      onError(error);
-      return null;
-    });
-    return pendingBlockPromise;
+  function lookaheadBlockIndices() {
+    const indices = [];
+    for (let offset = 1; offset <= catalog.runtimeLookaheadBlockCount; offset += 1) {
+      const index = (activeBlockIndex + offset) % catalog.blockCount;
+      if (!indices.includes(index)) indices.push(index);
+    }
+    return indices;
+  }
+
+  function queueLookaheadBlocks() {
+    if (destroyed) return;
+    const indices = lookaheadBlockIndices();
+    const retainedIndices = new Set(indices);
+    onBlockWindow([activeBlockIndex, ...indices]);
+    for (const index of pendingBlocks.keys()) {
+      if (!retainedIndices.has(index)) pendingBlocks.delete(index);
+    }
+    for (const index of indices) {
+      if (pendingBlocks.has(index)) continue;
+      const pending = { block: null, promise: null, error: null };
+      preparedBlockPrefetchCount += 1;
+      pending.promise = Promise.resolve(loadBlock(index)).then((block) => {
+        if (destroyed || pendingBlocks.get(index) !== pending) return null;
+        validateBlockBinding(block, catalog, mounted.model, lighting);
+        pending.block = block;
+        return block;
+      }).catch((error) => {
+        if (pendingBlocks.get(index) === pending) pending.error = error;
+        onError(error);
+        return null;
+      });
+      pendingBlocks.set(index, pending);
+    }
   }
 
   async function activatePendingBlock() {
-    const waited = pendingBlock === null;
+    const nextBlockIndex = (activeBlockIndex + 1) % catalog.blockCount;
+    if (!pendingBlocks.has(nextBlockIndex)) queueLookaheadBlocks();
+    const pending = pendingBlocks.get(nextBlockIndex);
+    if (!pending) throw new Error(`Prepared Cyclone lookahead block ${nextBlockIndex} is unavailable`);
+    const waited = pending.block === null;
     if (waited) {
       runtimePreparedBlockWaitCount += 1;
-      if (pendingBlockError) throw pendingBlockError;
-      await (pendingBlockPromise ?? queueNextBlock());
+      if (pending.error) throw pending.error;
+      await pending.promise;
     }
-    if (!pendingBlock) throw pendingBlockError ?? new Error("Prepared Cyclone lookahead block is unavailable");
+    if (!pending.block) {
+      throw pending.error ?? new Error(`Prepared Cyclone lookahead block ${nextBlockIndex} is unavailable`);
+    }
     const previousBlockIndex = activeBlockIndex;
     const previousChunkIndex = activeBlock.chunkIndex;
-    activeBlock = pendingBlock;
-    activeBlockIndex = pendingBlockIndex;
+    activeBlock = pending.block;
+    activeBlockIndex = nextBlockIndex;
     playback = activeBlock.playback;
     lightingFrames = activeBlock.lighting;
-    pendingBlock = null;
-    pendingBlockIndex = null;
-    pendingBlockPromise = null;
-    pendingBlockError = null;
+    pendingBlocks.delete(nextBlockIndex);
     frameIndex = 0;
     publishTransforms(playback.frames[0]);
     publishLighting(0);
@@ -183,7 +210,7 @@ export function createCyclonePreparedPlayer({
     if (activeBlockIndex === previousBlockIndex + 1) preparedContinuousHandoffCount += 1;
     else preparedTerminalWrapCount += 1;
     if (activeBlock.chunkIndex !== previousChunkIndex) preparedChunkSwitchCount += 1;
-    queueNextBlock();
+    queueLookaheadBlocks();
     return waited;
   }
 
@@ -285,6 +312,8 @@ export function createCyclonePreparedPlayer({
 
   function snapshot() {
     target.assertStableDomIdentity();
+    const pendingBlockIndices = lookaheadBlockIndices();
+    const nextPendingBlock = pendingBlocks.get(pendingBlockIndices[0]);
     return Object.freeze({
       paused,
       frameIndex,
@@ -296,8 +325,10 @@ export function createCyclonePreparedPlayer({
       streamDurationMilliseconds: catalog.streamDurationMilliseconds,
       activeBlockIndex,
       activeChunkIndex: activeBlock.chunkIndex,
-      pendingBlockIndex,
-      pendingBlockReady: pendingBlock !== null,
+      pendingBlockIndex: pendingBlockIndices[0] ?? null,
+      pendingBlockReady: nextPendingBlock?.block !== null && nextPendingBlock?.block !== undefined,
+      pendingBlockIndices: Object.freeze(pendingBlockIndices),
+      pendingBlockReadyCount: pendingBlockIndices.filter((index) => pendingBlocks.get(index)?.block).length,
       schedulerLeadMilliseconds,
       schedulerFrameRequestCount,
       schedulerFrameCallbackCount,
@@ -357,12 +388,29 @@ export function createCyclonePreparedPlayer({
   });
 }
 
-function validateBinding(mounted, catalog, initialBlock, initialFrameIndex, lighting, lightingAsset, loadBlock) {
+function validateBinding(
+  mounted,
+  catalog,
+  initialBlock,
+  initialLookaheadBlocks,
+  initialFrameIndex,
+  lighting,
+  lightingAsset,
+  loadBlock,
+) {
   const lightingVariant = lighting?.variants?.find((variant) =>
     variant?.paletteFamily === lightingAsset?.paletteFamily);
   if (catalog?.schema !== CATALOG_SCHEMA ||
       catalog.blockCount !== catalog.entries?.length ||
-      catalog.runtimeLookaheadBlockCount !== 1 ||
+      !Number.isSafeInteger(catalog.runtimeLookaheadBlockCount) ||
+      catalog.runtimeLookaheadBlockCount < 1 ||
+      catalog.runtimeLookaheadBlockCount > catalog.blockCount ||
+      !Array.isArray(initialLookaheadBlocks) ||
+      initialLookaheadBlocks.length > catalog.runtimeLookaheadBlockCount ||
+      new Set(initialLookaheadBlocks.map((block) => block?.streamBlockIndex)).size !==
+        initialLookaheadBlocks.length ||
+      initialLookaheadBlocks.some((block, index) =>
+        block?.streamBlockIndex !== (initialBlock.streamBlockIndex + index + 1) % catalog.blockCount) ||
       lighting?.schema !== LIGHTING_SCHEMA ||
       lighting.streamId !== catalog.streamId ||
       lighting.chunkCount !== catalog.chunkCount ||
@@ -382,6 +430,9 @@ function validateBinding(mounted, catalog, initialBlock, initialFrameIndex, ligh
     throw new Error("Cyclone prepared stream binding drifted");
   }
   validateBlockBinding(initialBlock, catalog, mounted.model, lighting);
+  for (const block of initialLookaheadBlocks) {
+    validateBlockBinding(block, catalog, mounted.model, lighting);
+  }
 }
 
 function validateBlockBinding(block, catalog, model, lighting) {

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -2,6 +2,7 @@ const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@1";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@1";
 const PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@3";
 const LIGHTING_BLOCK_SCHEMA = "csscyclone-prepared-lighting-block@1";
+const RUNTIME_LOOKAHEAD_BLOCK_COUNT = 3;
 const STARTUP_HUE_SECTOR_NAMES = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
 const STARTUP_PALETTE_FAMILIES = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
 const STARTUP_SILHOUETTE_SAMPLING = "browser-reviewed-expressive-source-windows";
@@ -197,7 +198,7 @@ function validateCatalog(catalog) {
         !Number.isSafeInteger(frameOffset) || frameOffset < 0 ||
         catalog.startupSelections.some((selection) => frameOffset >= selection.frameCount)) ||
       catalog.selection !== STARTUP_SELECTION ||
-      catalog.runtimeLookaheadBlockCount !== 1 ||
+      catalog.runtimeLookaheadBlockCount !== RUNTIME_LOOKAHEAD_BLOCK_COUNT ||
       catalog.entries.some((entry, index) => entry?.index !== index ||
         entry.chunkIndex !== Math.floor(index / catalog.blocksPerChunk) ||
         entry.blockIndex !== index % catalog.blocksPerChunk ||

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -22,7 +22,11 @@ test.after(() => {
   else globalThis.HTMLElement = originalHTMLElement;
 });
 
-function fixture() {
+function fixture({
+  blockCount = 1,
+  runtimeLookaheadBlockCount = 1,
+  initialLookaheadBlockCount = 0,
+} = {}) {
   let now = 0;
   let nextRequestId = 0;
   const frames = new Map();
@@ -37,8 +41,8 @@ function fixture() {
     chunkIndex: 0,
     blockIndex: 0,
     chunkCount: 1,
-    blockCount: 1,
-    blocksPerChunk: 1,
+    blockCount,
+    blocksPerChunk: blockCount,
     startFrameIndex: 0,
     frameCount: 4,
     particleCount: 2,
@@ -58,7 +62,7 @@ function fixture() {
     schema: "csscyclone-prepared-smooth-lighting-atlas@6",
     streamId: "stream",
     chunkCount: 1,
-    chunkFrameCount: 4,
+    chunkFrameCount: blockCount * 4,
     leafCount: 2,
     facesPerParticle: 1,
     colorStateCount: 1,
@@ -74,39 +78,47 @@ function fixture() {
     variants: [{ paletteFamily: "blue", assetSha256: "hash" }],
     runtime: { lightingCalculations: 0, atlasConstruction: 0 },
   };
-  const block = {
-    schema: "csscyclone-prepared-stream-block@1",
-    streamId: "stream",
-    streamBlockIndex: 0,
-    chunkIndex: 0,
-    blockIndex: 0,
-    startFrameIndex: 0,
-    frameCount: 4,
-    playback,
-    lighting: {
-      schema: "csscyclone-prepared-lighting-block@1",
+  const blocks = Array.from({ length: blockCount }, (_, streamBlockIndex) => {
+    const blockPlayback = {
+      ...playback,
+      streamBlockIndex,
+      blockIndex: streamBlockIndex,
+      startFrameIndex: streamBlockIndex * 4,
+    };
+    return {
+      schema: "csscyclone-prepared-stream-block@1",
       streamId: "stream",
-      streamBlockIndex: 0,
+      streamBlockIndex,
       chunkIndex: 0,
-      blockIndex: 0,
-      startFrameIndex: 0,
+      blockIndex: streamBlockIndex,
+      startFrameIndex: streamBlockIndex * 4,
       frameCount: 4,
-      particleCount: 2,
-      frameParticleColorStateIndices: [[0, 0], [0, 0], [0, 0], [0, 0]],
-    },
-  };
+      playback: blockPlayback,
+      lighting: {
+        schema: "csscyclone-prepared-lighting-block@1",
+        streamId: "stream",
+        streamBlockIndex,
+        chunkIndex: 0,
+        blockIndex: streamBlockIndex,
+        startFrameIndex: streamBlockIndex * 4,
+        frameCount: 4,
+        particleCount: 2,
+        frameParticleColorStateIndices: [[0, 0], [0, 0], [0, 0], [0, 0]],
+      },
+    };
+  });
   const catalog = {
     schema: "csscyclone-prepared-stream-catalog@1",
     streamId: "stream",
     chunkCount: 1,
-    chunkFrameCount: 4,
-    blockCount: 1,
-    entries: [{}],
-    blocksPerChunk: 1,
+    chunkFrameCount: blockCount * 4,
+    blockCount,
+    entries: Array.from({ length: blockCount }, () => ({})),
+    blocksPerChunk: blockCount,
     blockFrameCount: 4,
-    runtimeLookaheadBlockCount: 1,
-    streamFrameCount: 4,
-    streamDurationMilliseconds: 80,
+    runtimeLookaheadBlockCount,
+    streamFrameCount: blockCount * 4,
+    streamDurationMilliseconds: blockCount * 80,
   };
   const mounted = {
     model: {
@@ -124,10 +136,12 @@ function fixture() {
     assertStableDomIdentity: identity,
     destroy: identity,
   };
+  const loadBlockCalls = [];
   const player = createCyclonePreparedPlayer({
     mounted,
     catalog,
-    initialBlock: block,
+    initialBlock: blocks[0],
+    initialLookaheadBlocks: blocks.slice(1, initialLookaheadBlockCount + 1),
     initialFrameIndex: 0,
     lighting,
     lightingAsset: {
@@ -138,7 +152,10 @@ function fixture() {
       hueSlots: [0.5, 2 / 3, 5 / 6],
       destroy: identity,
     },
-    loadBlock: async () => block,
+    loadBlock: async (streamBlockIndex) => {
+      loadBlockCalls.push(streamBlockIndex);
+      return blocks[streamBlockIndex];
+    },
     readNow: () => now,
     requestFrame(callback) {
       const id = ++nextRequestId;
@@ -158,6 +175,7 @@ function fixture() {
     shapeElements,
     frames,
     delays,
+    loadBlockCalls,
     setNow(value) { now = value; },
     fireDelay() {
       const [id, request] = delays.entries().next().value;
@@ -188,6 +206,30 @@ test("hands each prepared publication from its deadline timer to requestAnimatio
   assert.equal(stats.runtimeSchedulerTransport, "deadline-setTimeout-requestAnimationFrame-prepared-publication");
   assert.equal(stats.schedulerFrameCallbackCount, 1);
   assert.equal(stats.schedulerDelayCallbackCount, 1);
+});
+
+test("starts with and maintains a three-block prepared lookahead", async () => {
+  const state = fixture({
+    blockCount: 5,
+    runtimeLookaheadBlockCount: 3,
+    initialLookaheadBlockCount: 3,
+  });
+  assert.deepEqual(state.player.stats().pendingBlockIndices, [1, 2, 3]);
+  assert.equal(state.player.stats().pendingBlockReadyCount, 3);
+  assert.deepEqual(state.loadBlockCalls, []);
+
+  state.player.resume();
+  state.fireDelay();
+  state.setNow(81);
+  await state.fireFrame();
+  await Promise.resolve();
+
+  const stats = state.player.stats();
+  assert.equal(stats.activeBlockIndex, 1);
+  assert.deepEqual(stats.pendingBlockIndices, [2, 3, 4]);
+  assert.equal(stats.pendingBlockReadyCount, 3);
+  assert.equal(stats.runtimePreparedBlockWaitCount, 0);
+  assert.deepEqual(state.loadBlockCalls, [4]);
 });
 
 test("collapses missed prepared frames once at the next paint-aligned callback", async () => {

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -55,7 +55,7 @@ const catalog = Object.freeze({
       });
     })),
   }),
-  runtimeLookaheadBlockCount: 1,
+  runtimeLookaheadBlockCount: 3,
   entries: Object.freeze(Array.from({ length: 216 }, (_, index) => Object.freeze({
     index,
     chunkIndex: Math.floor(index / 9),

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -24,6 +24,7 @@ const outputRoot = join(repositoryRoot, "build/generated/public/csscyclone");
 const stagingRoot = join(repositoryRoot, `build/generated/.csscyclone-${process.pid}`);
 const sourceLock = JSON.parse(await readFile(join(adapterRoot, "notes/references/source-lock.json"), "utf8"));
 const blockFrameCount = 50;
+const runtimeLookaheadBlockCount = 3;
 const blocksPerChunk = CSSCYCLONE_BANK.frameCount / blockFrameCount;
 const blockCount = CSSCYCLONE_BANK.chunkCount * blocksPerChunk;
 const startupPaletteFamilies = CSSCYCLONE_PRESENTATION.startupPaletteFamilies;
@@ -48,9 +49,6 @@ let uniquePreparedTransformCount = 0;
 let shapeTransformSelections = 0;
 let preparedBlockEncodedBytes = 0;
 let preparedBlockDecodedBytes = 0;
-let maximumResidentBlockPairDecodedBytes = 0;
-let previousBlockDecodedBytes = 0;
-let firstBlockDecodedBytes = 0;
 for (const source of buildCycloneSourceChunks()) {
   if (preparedModel === null) {
     const result = buildCyclonePreparedModel({ source });
@@ -119,21 +117,16 @@ for (const source of buildCycloneSourceChunks()) {
     }));
     preparedBlockEncodedBytes += encoded.byteLength;
     preparedBlockDecodedBytes += decoded.byteLength;
-    if (streamBlockIndex === 0) firstBlockDecodedBytes = decoded.byteLength;
-    maximumResidentBlockPairDecodedBytes = Math.max(
-      maximumResidentBlockPairDecodedBytes,
-      previousBlockDecodedBytes + decoded.byteLength,
-    );
-    previousBlockDecodedBytes = decoded.byteLength;
   }
   preparedFrameCount += preparedPlayback.metrics.preparedFrameCount;
   uniquePreparedTransformCount += preparedPlayback.metrics.uniquePreparedTransformCount;
   shapeTransformSelections += preparedPlayback.metrics.shapeTransformSelections;
 }
-maximumResidentBlockPairDecodedBytes = Math.max(
-  maximumResidentBlockPairDecodedBytes,
-  previousBlockDecodedBytes + firstBlockDecodedBytes,
-);
+const residentBlockWindowCount = runtimeLookaheadBlockCount + 1;
+const maximumResidentBlockWindowDecodedBytes = Math.max(...blockEntries.map((_, startIndex) =>
+  Array.from({ length: residentBlockWindowCount }, (unused, offset) =>
+    blockEntries[(startIndex + offset) % blockEntries.length].decodedByteLength)
+    .reduce((total, byteLength) => total + byteLength, 0)));
 const startupColorProfile = buildStartupColorProfile(
   startupSelections.map((selection) => startupSelectionColorProfiles.get(selection.id)),
 );
@@ -159,7 +152,7 @@ const catalogBytes = Buffer.from(`${JSON.stringify({
   startupColorProfile,
   selection: "session-crypto-random-balanced-source-palette-window-no-immediate-repeat",
   playbackOrder: "source-continuous-ascending-chunks-with-one-terminal-stream-wrap",
-  runtimeLookaheadBlockCount: 1,
+  runtimeLookaheadBlockCount,
   entries: blockEntries,
 })}\n`);
 const catalogSha256 = sha256(catalogBytes);
@@ -230,7 +223,7 @@ await writeJson(join(stagingRoot, "prepared.json"), {
       maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
       startupColorProfile,
       startupSelection: "session-crypto-random-balanced-source-palette-window-no-immediate-repeat",
-      handoff: "source-continuous-next-block-with-one-block-lookahead",
+      handoff: "source-continuous-next-block-with-three-block-lookahead",
     },
     productParticleCount: CSSCYCLONE_BANK.particleCount,
     viewDistance: CSSCYCLONE_SOURCE.viewDistance,
@@ -253,8 +246,9 @@ await writeJson(join(stagingRoot, "prepared.json"), {
     shapeTransformSelections,
     preparedBlockEncodedBytes,
     preparedBlockDecodedBytes,
-    maximumResidentBlockPairDecodedBytes,
-    runtimeLookaheadBlockCount: 1,
+    residentBlockWindowCount,
+    maximumResidentBlockWindowDecodedBytes,
+    runtimeLookaheadBlockCount,
     runtimePreparedStateMaterialization: false,
   },
   lighting: preparedLighting.contract,
@@ -278,7 +272,8 @@ console.log(JSON.stringify({
   shapeTransformSelections,
   preparedBlockEncodedBytes,
   preparedBlockDecodedBytes,
-  maximumResidentBlockPairDecodedBytes,
+  residentBlockWindowCount,
+  maximumResidentBlockWindowDecodedBytes,
   ...preparedLighting.metrics,
 }, null, 2));
 


### PR DESCRIPTION
## What changed
- preload the active block plus three exact prepared successors before playback
- maintain the bounded four-block resident horizon during playback
- keep the same 400 roots, 2,400 leaves, 216 blocks, and 10,800 prepared frames
- correct the stale publication note

## Device evidence that prompted this
Pixel 9 Pro XL production trace: 21 waits across 25 handoffs; block requests averaged 1,149.98 ms for one-second blocks.

## Verification
- pnpm test:cyclone (21/21)
- pnpm prepare:cyclone
- pnpm build:cyclone
- 12-second prepared-route smoke: 12 handoffs, 0 waits, stable 400/2,400 DOM