### PR TITLE
fix(cyclone): ship lean mobile prepared profile

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -1,43 +1,51 @@
 # cssCyclone
 
-This first slice translates Really Slick Cyclone into one retained PolyCSS Morph
-graph. It mounts the source-default 400 particle roots with six solid triangle
-leaves each and plays 24 source-continuous logical chunks of 450 prepared 20 ms
+This adapter translates Really Slick Cyclone into one retained PolyCSS Morph
+graph. Desktop mounts the source-default 400 particle roots and mobile mounts a
+prepared prefix of 266 complete source particles. Every particle retains all six
+original solid-triangle leaves: 2,400 desktop leaves or 1,596 mobile leaves. The
+selected profile plays 24 source-continuous logical chunks of 450 prepared 20 ms
 transform states. The stream is transported as 216 one-second prepared blocks
 so decompression stays outside long animation frames. Source fixed-function
 smooth-vertex lighting is prepared at the first published frame into a verified
-lossless WebP atlas. The 2,400 initial leaf addresses are bound once. Later
-address writes are limited to the six leaves of a particle when the source
-restarts it with a new color.
+lossless WebP atlas. Initial leaf addresses are bound once. Later address writes
+are limited to the six leaves of a particle when the source restarts it with a
+new color. The mounted graph is camera, scene, particle roots, and leaves; the
+PolyCSS Morph model wrapper is removed after adoption and its fixed transform is
+composed onto the existing scene node.
 There is no Canvas, SVG, WebGL, runtime random walk, geometry construction,
 lighting calculation, matrix formatting, atlas rasterization, or DOM growth.
 The prepared presentation maps the source's random saturation samples into a
-0.55-1.0 range. The source's uniform random hue-target timing and its rule that
+0.55-1.0 range and lifts only the dark end of prepared HSV value to 0.65. The
+source's uniform random hue-target timing and its rule that
 particles change color only when they restart are preserved. At preparation,
 each source hue is assigned to one of three slots in the selected session palette.
 Five lossless lighting-atlas variants provide blue-, yellow-, red-, magenta-,
 and green-centered palettes; each variant spans at most three adjacent hue
 families for the entire playback. The browser selects one prepared atlas and
-performs no color calculation. The same source RNG draws preserve lightness,
-RNG cadence, geometry, restart timing, and coherent color bands, but prepared
-hue values are intentionally quantized and are not exact source colors.
+performs no color calculation. The same source RNG draws preserve RNG cadence,
+geometry, restart timing, and coherent color bands, but prepared hue values are
+intentionally quantized and low lightness is intentionally lifted; these are not
+exact source colors.
 Startup is prebaked to ten audited 40-frame source windows. The selector gives
-equal probability to the five prepared palette variants—blue, yellow, red,
-magenta, and green—then chooses between two expressive browser-reviewed source
-windows in that family. It never phases individual particles around a full hue
-wheel. This is an intentional presentation and startup-selection bias rather
-than an exact native-color or random-start claim.
-Viewports below 600px use a
-90-degree presentation field of view instead of the source-default 80 degrees
-so the cyclone fits narrow screens without changing prepared motion or geometry.
+each of the five prepared palette variants—blue, yellow, red, magenta, and
+green—exactly once per session-shuffled cycle before any family repeats, then
+chooses between two expressive browser-reviewed source windows in that family.
+It never phases individual particles around a full hue wheel. This is an
+intentional presentation rather than an exact native-color or random-start
+claim. Mobile/coarse-pointer devices and viewports below 600px select the
+266-particle prepared profile before mount and use a 90-degree presentation
+field of view instead of the source-default 80 degrees. Prepared motion and each
+particle's complete six-face topology are unchanged.
 
 The stream discards the source's dark startup by preparing 24 seconds before its
 first published frame. Its 10,800 states cover 216 seconds before repeating.
-Startup uses `crypto.getRandomValues` once to select an audited palette family,
-source window, and frame, excluding the previous exact window. Playback
+Startup uses `crypto.getRandomValues` to shuffle the five-family session bag and
+to select an audited source window and frame, excluding the previous exact
+window. Playback
 then follows the original source order. Each hash-bound
-gzip block maintains a three-block prepared lookahead; only the active block
-and that bounded horizon remain resident. The single terminal stream wrap is the only
+gzip block prefetches its exact successor; only the active and lookahead blocks
+remain resident. The single terminal stream wrap is the only
 non-source-continuous boundary.
 
 Source identity is pinned in `notes/references/source-lock.json`. Preparation

--- a/src/adapters/cyclone/src/csscyclone/client.mjs
+++ b/src/adapters/cyclone/src/csscyclone/client.mjs
@@ -8,8 +8,12 @@ import {
   loadCyclonePreparedCatalog,
   selectInitialCyclonePosition,
 } from "./preparedStream.mjs";
+import {
+  CSSCYCLONE_PREPARED_PROFILES,
+  selectCyclonePreparedProfile,
+} from "./profileSelection.mjs";
+import { selectCycloneStartupPaletteFamily } from "./startupPaletteSelection.mjs";
 
-const MODEL_ID = "cyclone";
 const LAST_START_SELECTION_STORAGE_KEY = "csscyclone:last-start-selection";
 
 export async function mountCycloneClient(host) {
@@ -17,6 +21,7 @@ export async function mountCycloneClient(host) {
     ready: false,
     errors: [],
     metadata: null,
+    profile: null,
     catalog: null,
     selection: null,
     blockLoader: null,
@@ -26,67 +31,75 @@ export async function mountCycloneClient(host) {
   let lightingAsset = null;
   installDebugApi(state);
   try {
+    const profileId = selectCyclonePreparedProfile({
+      width: host.clientWidth || innerWidth,
+      height: host.clientHeight || innerHeight,
+    });
+    const profileBinding = CSSCYCLONE_PREPARED_PROFILES[profileId];
     const [loaded, metadata] = await Promise.all([
-      loadPolyMorphPackage("/csscyclone/model/", { modelId: MODEL_ID }),
+      loadPolyMorphPackage("/csscyclone/model/", { modelId: profileBinding.modelId }),
       fetchJson("/csscyclone/prepared.json", { cache: "no-store" }),
     ]);
-    const catalog = await loadCyclonePreparedCatalog(metadata?.playback);
-    if (metadata?.schema !== "csscyclone-prepared-scene@1" ||
+    const profile = metadata?.profiles?.[profileId];
+    const catalog = await loadCyclonePreparedCatalog(profile?.playback);
+    if (metadata?.schema !== "csscyclone-prepared-scene@2" ||
         metadata.status !== "ready" ||
-        loaded.model.identity.id !== MODEL_ID ||
-        metadata.model?.id !== MODEL_ID ||
-        metadata.presentation?.preparedStream?.id !== catalog.streamId ||
-        metadata.playback?.chunkCount !== catalog.chunkCount ||
-        metadata.playback?.preparedBlockCount !== catalog.blockCount ||
-        metadata.lighting?.maximumColorFamilyCount !== catalog.maximumColorFamilyCount ||
-        metadata.lighting?.paletteFamilies?.some((family, index) =>
+        profile?.id !== profileId ||
+        profile.model?.id !== profileBinding.modelId ||
+        loaded.model.identity.id !== profileBinding.modelId ||
+        profile.presentation?.preparedStream?.id !== catalog.streamId ||
+        profile.playback?.chunkCount !== catalog.chunkCount ||
+        profile.playback?.preparedBlockCount !== catalog.blockCount ||
+        profile.lighting?.maximumColorFamilyCount !== catalog.maximumColorFamilyCount ||
+        profile.lighting?.paletteFamilies?.some((family, index) =>
           family !== catalog.startupPaletteFamilies[index])) {
       throw new Error("Cyclone prepared model binding drifted");
     }
+    const route = new URLSearchParams(globalThis.location?.search ?? "");
+    const paletteSelection = route.has("chunk") || route.has("frame")
+      ? null
+      : selectCycloneStartupPaletteFamily(catalog.startupPaletteFamilies);
     const selection = selectInitialCyclonePosition(catalog, {
       previousSelectionId: readPreviousStartSelection(catalog.startupSelections),
+      preferredPaletteFamily: paletteSelection?.paletteFamily ?? null,
     });
     rememberStartSelection(selection.selectionId);
     const initialStreamFrameIndex = selection.chunkIndex * catalog.chunkFrameCount + selection.frameIndex;
     const initialBlockIndex = Math.floor(initialStreamFrameIndex / catalog.blockFrameCount);
     const initialBlockFrameIndex = initialStreamFrameIndex % catalog.blockFrameCount;
     const blockLoader = createCyclonePreparedBlockLoader(catalog);
-    const lookaheadBlockIndices = Array.from(
-      { length: catalog.runtimeLookaheadBlockCount },
-      (unused, offset) => (initialBlockIndex + offset + 1) % catalog.blockCount,
-    );
-    const residentBlockIndices = [initialBlockIndex, ...lookaheadBlockIndices];
-    blockLoader.retain(residentBlockIndices);
-    const [initialBlock, initialLookaheadBlocks, loadedLightingAsset] = await Promise.all([
+    const nextBlockIndex = (initialBlockIndex + 1) % catalog.blockCount;
+    blockLoader.retain([initialBlockIndex, nextBlockIndex]);
+    const [initialBlock, loadedLightingAsset] = await Promise.all([
       blockLoader.load(initialBlockIndex),
-      Promise.all(lookaheadBlockIndices.map((streamBlockIndex) => blockLoader.load(streamBlockIndex))),
-      loadCyclonePreparedLightingAsset(metadata.lighting, selection.paletteFamily),
+      loadCyclonePreparedLightingAsset(profile.lighting, selection.paletteFamily),
     ]);
     lightingAsset = loadedLightingAsset;
     const mounted = mountPolyMorphModel(host, loaded.model, {
       resources: loaded.resources,
       camera: createPolyPerspectiveCamera({ perspective: 800, target: [0, 0, 0], rotX: 0, rotY: 0, zoom: 50 }),
     });
-    cleanPreparedDom(mounted);
+    const modelTransform = cleanPreparedDom(mounted);
     const player = createCyclonePreparedPlayer({
       mounted,
+      modelTransform,
       catalog,
       initialBlock,
-      initialLookaheadBlocks,
       initialFrameIndex: initialBlockFrameIndex,
-      lighting: metadata.lighting,
+      lighting: profile.lighting,
       lightingAsset,
       loadBlock(streamBlockIndex) {
         return blockLoader.load(streamBlockIndex);
       },
-      onBlockWindow(streamBlockIndices) {
-        blockLoader.retain(streamBlockIndices);
+      onBlockWindow(activeBlockIndex, pendingBlockIndex) {
+        blockLoader.retain([activeBlockIndex, pendingBlockIndex]);
       },
     });
     player.resize();
     addEventListener("resize", player.resize, { passive: true });
     state.ready = true;
     state.metadata = metadata;
+    state.profile = profile;
     state.catalog = catalog;
     state.selection = selection;
     state.blockLoader = blockLoader;
@@ -128,6 +141,18 @@ function cleanPreparedDom(mounted) {
     element.style.removeProperty("transform-origin");
     element.style.removeProperty("visibility");
   }
+  if (mounted.modelElement.parentElement !== mounted.sceneElement ||
+      [...mounted.shapeElements.values()].some((element) =>
+        element.parentElement !== mounted.modelElement)) {
+    throw new Error("Cyclone prepared model wrapper binding drifted");
+  }
+  const modelTransform = mounted.modelElement.style.transform;
+  for (const element of mounted.shapeElements.values()) mounted.sceneElement.append(element);
+  if (mounted.modelElement.childElementCount !== 0) {
+    throw new Error("Cyclone prepared model wrapper contains unexpected retained nodes");
+  }
+  mounted.modelElement.remove();
+  return modelTransform;
 }
 
 function installDebugApi(state) {
@@ -145,6 +170,8 @@ function installDebugApi(state) {
         return Object.freeze({
           retainedParticleRootCount: state.mounted.shapeElements.size,
           retainedPolygonLeafCount: state.mounted.leafHandles.size,
+          preparedProfileId: state.profile.id,
+          preparedProfileParticleCount: state.profile.presentation.productParticleCount,
           initialChunkIndex: state.selection.chunkIndex,
           initialFrameIndex: state.selection.frameIndex,
           startupSelectionId: state.selection.selectionId ?? null,

--- a/src/adapters/cyclone/src/csscyclone/preparedLightingAsset.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedLightingAsset.mjs
@@ -1,8 +1,10 @@
 export async function loadCyclonePreparedLightingAsset(lighting, paletteFamily) {
   const variant = lighting?.variants?.find((entry) => entry?.paletteFamily === paletteFamily);
-  if (lighting?.schema !== "csscyclone-prepared-smooth-lighting-atlas@6" ||
+  if (lighting?.schema !== "csscyclone-prepared-smooth-lighting-atlas@7" ||
       lighting.maximumColorFamilyCount !== 3 ||
       lighting.paletteHueSlotCount !== 3 ||
+      lighting.preparedMinimumSaturation !== 0.55 ||
+      lighting.preparedMinimumValue !== 0.65 ||
       !Array.isArray(lighting.paletteFamilies) ||
       !lighting.paletteFamilies.includes(paletteFamily) ||
       lighting.variants?.length !== lighting.paletteFamilies.length ||

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -4,7 +4,7 @@ import { createPolyMorphPreparedDomTarget } from "@layoutit/polycss-morph";
 const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@1";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@1";
 const PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@3";
-const LIGHTING_SCHEMA = "csscyclone-prepared-smooth-lighting-atlas@6";
+const LIGHTING_SCHEMA = "csscyclone-prepared-smooth-lighting-atlas@7";
 const LIGHTING_BLOCK_SCHEMA = "csscyclone-prepared-lighting-block@1";
 const SOURCE_FIELD_OF_VIEW_DEGREES = 80;
 const MOBILE_FIELD_OF_VIEW_DEGREES = 90;
@@ -20,9 +20,9 @@ export function resolveCyclonePerspective(viewportWidth, viewportHeight) {
 
 export function createCyclonePreparedPlayer({
   mounted,
+  modelTransform,
   catalog,
   initialBlock,
-  initialLookaheadBlocks = [],
   initialFrameIndex,
   lighting,
   lightingAsset,
@@ -37,9 +37,9 @@ export function createCyclonePreparedPlayer({
 }) {
   validateBinding(
     mounted,
+    modelTransform,
     catalog,
     initialBlock,
-    initialLookaheadBlocks,
     initialFrameIndex,
     lighting,
     lightingAsset,
@@ -50,34 +50,43 @@ export function createCyclonePreparedPlayer({
   if (shapeElements.some((element) => !element) || leafElements.some((element) => !element)) {
     throw new Error("Cyclone retained DOM binding is incomplete");
   }
-  let publishedModelTransform = mounted.modelElement.style.transform;
+  let publishedModelTransform = modelTransform;
+  let publishedProjectionTransform = mounted.sceneElement.style.transform;
+  let publishedSceneTransform = "";
+  const publishSceneTransform = () => {
+    const transform = `${publishedProjectionTransform} ${publishedModelTransform}`.trim();
+    if (transform === publishedSceneTransform) return false;
+    mounted.sceneElement.style.transform = transform;
+    publishedSceneTransform = transform;
+    return true;
+  };
+  publishSceneTransform();
   const target = createPolyMorphPreparedDomTarget({
     model: {
-      element: mounted.modelElement,
+      element: mounted.sceneElement,
       writeTransform(transform) {
         if (transform === publishedModelTransform) return false;
-        mounted.modelElement.style.transform = transform;
         publishedModelTransform = transform;
-        return true;
+        return publishSceneTransform();
       },
     },
     shapes: shapeElements.map((element) => ({ element })),
     leaves: leafElements.map((element) => ({ element })),
   });
-  mounted.modelElement.style.setProperty(
+  mounted.sceneElement.style.setProperty(
     "--cyclone-lighting-atlas",
     `url("${lightingAsset.url.replace(/"/gu, "%22")}")`,
   );
-  mounted.modelElement.style.setProperty("--cyclone-lighting-size", lighting.backgroundSize);
+  mounted.sceneElement.style.setProperty("--cyclone-lighting-size", lighting.backgroundSize);
 
   let activeBlock = initialBlock;
   let playback = activeBlock.playback;
   let lightingFrames = activeBlock.lighting;
   let activeBlockIndex = activeBlock.streamBlockIndex;
-  const pendingBlocks = new Map(initialLookaheadBlocks.map((block) => [
-    block.streamBlockIndex,
-    { block, promise: Promise.resolve(block), error: null },
-  ]));
+  let pendingBlock = null;
+  let pendingBlockIndex = null;
+  let pendingBlockPromise = null;
+  let pendingBlockError = null;
   let paused = true;
   let destroyed = false;
   let frameRequest = null;
@@ -98,7 +107,7 @@ export function createCyclonePreparedPlayer({
   let lightingLeafAddressWrites = 0;
   let preparedChunkSwitchCount = 0;
   let preparedBlockSwitchCount = 0;
-  let preparedBlockPrefetchCount = initialLookaheadBlocks.length;
+  let preparedBlockPrefetchCount = 0;
   let runtimePreparedBlockWaitCount = 0;
   let preparedContinuousHandoffCount = 0;
   let preparedTerminalWrapCount = 0;
@@ -109,7 +118,7 @@ export function createCyclonePreparedPlayer({
   publishTransforms(playback.frames[initialFrameIndex]);
   publishLighting(initialFrameIndex, true);
   applyCount += 1;
-  queueLookaheadBlocks();
+  queueNextBlock();
 
   function publishTransforms(row) {
     for (let operation = 0; operation < row.length; operation += 2) {
@@ -146,62 +155,45 @@ export function createCyclonePreparedPlayer({
     applyCount += 1;
   }
 
-  function lookaheadBlockIndices() {
-    const indices = [];
-    for (let offset = 1; offset <= catalog.runtimeLookaheadBlockCount; offset += 1) {
-      const index = (activeBlockIndex + offset) % catalog.blockCount;
-      if (!indices.includes(index)) indices.push(index);
-    }
-    return indices;
-  }
-
-  function queueLookaheadBlocks() {
-    if (destroyed) return;
-    const indices = lookaheadBlockIndices();
-    const retainedIndices = new Set(indices);
-    onBlockWindow([activeBlockIndex, ...indices]);
-    for (const index of pendingBlocks.keys()) {
-      if (!retainedIndices.has(index)) pendingBlocks.delete(index);
-    }
-    for (const index of indices) {
-      if (pendingBlocks.has(index)) continue;
-      const pending = { block: null, promise: null, error: null };
-      preparedBlockPrefetchCount += 1;
-      pending.promise = Promise.resolve(loadBlock(index)).then((block) => {
-        if (destroyed || pendingBlocks.get(index) !== pending) return null;
-        validateBlockBinding(block, catalog, mounted.model, lighting);
-        pending.block = block;
-        return block;
-      }).catch((error) => {
-        if (pendingBlocks.get(index) === pending) pending.error = error;
-        onError(error);
-        return null;
-      });
-      pendingBlocks.set(index, pending);
-    }
+  function queueNextBlock() {
+    if (destroyed || pendingBlock || pendingBlockPromise) return pendingBlockPromise;
+    pendingBlockIndex = (activeBlockIndex + 1) % catalog.blockCount;
+    pendingBlockError = null;
+    preparedBlockPrefetchCount += 1;
+    onBlockWindow(activeBlockIndex, pendingBlockIndex);
+    pendingBlockPromise = Promise.resolve(loadBlock(pendingBlockIndex)).then((block) => {
+      if (destroyed) return null;
+      validateBlockBinding(block, catalog, mounted.model, lighting);
+      pendingBlock = block;
+      pendingBlockPromise = null;
+      return block;
+    }).catch((error) => {
+      pendingBlockError = error;
+      pendingBlockPromise = null;
+      onError(error);
+      return null;
+    });
+    return pendingBlockPromise;
   }
 
   async function activatePendingBlock() {
-    const nextBlockIndex = (activeBlockIndex + 1) % catalog.blockCount;
-    if (!pendingBlocks.has(nextBlockIndex)) queueLookaheadBlocks();
-    const pending = pendingBlocks.get(nextBlockIndex);
-    if (!pending) throw new Error(`Prepared Cyclone lookahead block ${nextBlockIndex} is unavailable`);
-    const waited = pending.block === null;
+    const waited = pendingBlock === null;
     if (waited) {
       runtimePreparedBlockWaitCount += 1;
-      if (pending.error) throw pending.error;
-      await pending.promise;
+      if (pendingBlockError) throw pendingBlockError;
+      await (pendingBlockPromise ?? queueNextBlock());
     }
-    if (!pending.block) {
-      throw pending.error ?? new Error(`Prepared Cyclone lookahead block ${nextBlockIndex} is unavailable`);
-    }
+    if (!pendingBlock) throw pendingBlockError ?? new Error("Prepared Cyclone lookahead block is unavailable");
     const previousBlockIndex = activeBlockIndex;
     const previousChunkIndex = activeBlock.chunkIndex;
-    activeBlock = pending.block;
-    activeBlockIndex = nextBlockIndex;
+    activeBlock = pendingBlock;
+    activeBlockIndex = pendingBlockIndex;
     playback = activeBlock.playback;
     lightingFrames = activeBlock.lighting;
-    pendingBlocks.delete(nextBlockIndex);
+    pendingBlock = null;
+    pendingBlockIndex = null;
+    pendingBlockPromise = null;
+    pendingBlockError = null;
     frameIndex = 0;
     publishTransforms(playback.frames[0]);
     publishLighting(0);
@@ -210,7 +202,7 @@ export function createCyclonePreparedPlayer({
     if (activeBlockIndex === previousBlockIndex + 1) preparedContinuousHandoffCount += 1;
     else preparedTerminalWrapCount += 1;
     if (activeBlock.chunkIndex !== previousChunkIndex) preparedChunkSwitchCount += 1;
-    queueLookaheadBlocks();
+    queueNextBlock();
     return waited;
   }
 
@@ -307,13 +299,12 @@ export function createCyclonePreparedPlayer({
   function resize() {
     const perspective = resolveCyclonePerspective(innerWidth, innerHeight);
     mounted.cameraElement.style.perspective = `${perspective}px`;
-    mounted.sceneElement.style.transform = `translateZ(${perspective}px)`;
+    publishedProjectionTransform = `translateZ(${perspective}px)`;
+    publishSceneTransform();
   }
 
   function snapshot() {
     target.assertStableDomIdentity();
-    const pendingBlockIndices = lookaheadBlockIndices();
-    const nextPendingBlock = pendingBlocks.get(pendingBlockIndices[0]);
     return Object.freeze({
       paused,
       frameIndex,
@@ -325,10 +316,8 @@ export function createCyclonePreparedPlayer({
       streamDurationMilliseconds: catalog.streamDurationMilliseconds,
       activeBlockIndex,
       activeChunkIndex: activeBlock.chunkIndex,
-      pendingBlockIndex: pendingBlockIndices[0] ?? null,
-      pendingBlockReady: nextPendingBlock?.block !== null && nextPendingBlock?.block !== undefined,
-      pendingBlockIndices: Object.freeze(pendingBlockIndices),
-      pendingBlockReadyCount: pendingBlockIndices.filter((index) => pendingBlocks.get(index)?.block).length,
+      pendingBlockIndex,
+      pendingBlockReady: pendingBlock !== null,
       schedulerLeadMilliseconds,
       schedulerFrameRequestCount,
       schedulerFrameCallbackCount,
@@ -362,6 +351,7 @@ export function createCyclonePreparedPlayer({
       runtimeIdLookupCount: 0,
       runtimePreparedStateMaterializationCount: 0,
       runtimeDomGrowth: false,
+      retainedModelWrapperCount: 0,
       retainedDomStable: true,
     });
   }
@@ -390,9 +380,9 @@ export function createCyclonePreparedPlayer({
 
 function validateBinding(
   mounted,
+  modelTransform,
   catalog,
   initialBlock,
-  initialLookaheadBlocks,
   initialFrameIndex,
   lighting,
   lightingAsset,
@@ -400,17 +390,10 @@ function validateBinding(
 ) {
   const lightingVariant = lighting?.variants?.find((variant) =>
     variant?.paletteFamily === lightingAsset?.paletteFamily);
-  if (catalog?.schema !== CATALOG_SCHEMA ||
+  if (typeof modelTransform !== "string" || !modelTransform.startsWith("matrix3d(") ||
+      catalog?.schema !== CATALOG_SCHEMA ||
       catalog.blockCount !== catalog.entries?.length ||
-      !Number.isSafeInteger(catalog.runtimeLookaheadBlockCount) ||
-      catalog.runtimeLookaheadBlockCount < 1 ||
-      catalog.runtimeLookaheadBlockCount > catalog.blockCount ||
-      !Array.isArray(initialLookaheadBlocks) ||
-      initialLookaheadBlocks.length > catalog.runtimeLookaheadBlockCount ||
-      new Set(initialLookaheadBlocks.map((block) => block?.streamBlockIndex)).size !==
-        initialLookaheadBlocks.length ||
-      initialLookaheadBlocks.some((block, index) =>
-        block?.streamBlockIndex !== (initialBlock.streamBlockIndex + index + 1) % catalog.blockCount) ||
+      catalog.runtimeLookaheadBlockCount !== 1 ||
       lighting?.schema !== LIGHTING_SCHEMA ||
       lighting.streamId !== catalog.streamId ||
       lighting.chunkCount !== catalog.chunkCount ||
@@ -430,9 +413,6 @@ function validateBinding(
     throw new Error("Cyclone prepared stream binding drifted");
   }
   validateBlockBinding(initialBlock, catalog, mounted.model, lighting);
-  for (const block of initialLookaheadBlocks) {
-    validateBlockBinding(block, catalog, mounted.model, lighting);
-  }
 }
 
 function validateBlockBinding(block, catalog, model, lighting) {

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -2,11 +2,10 @@ const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@1";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@1";
 const PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@3";
 const LIGHTING_BLOCK_SCHEMA = "csscyclone-prepared-lighting-block@1";
-const RUNTIME_LOOKAHEAD_BLOCK_COUNT = 3;
 const STARTUP_HUE_SECTOR_NAMES = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
 const STARTUP_PALETTE_FAMILIES = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
 const STARTUP_SILHOUETTE_SAMPLING = "browser-reviewed-expressive-source-windows";
-const STARTUP_SELECTION = "session-crypto-random-balanced-source-palette-window-no-immediate-repeat";
+const STARTUP_SELECTION = "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat";
 
 export async function loadCyclonePreparedCatalog(descriptor) {
   if (typeof descriptor?.catalogUrl !== "string" ||
@@ -24,6 +23,7 @@ export async function loadCyclonePreparedCatalog(descriptor) {
 export function selectInitialCyclonePosition(catalog, {
   search = globalThis.location?.search ?? "",
   previousSelectionId = null,
+  preferredPaletteFamily = null,
   randomUint32Pair = cryptoRandomUint32Pair,
 } = {}) {
   validateCatalog(catalog);
@@ -46,16 +46,22 @@ export function selectInitialCyclonePosition(catalog, {
         !catalog.startupSelections.some((selection) => selection.id === previousSelectionId))) {
     throw new RangeError("Previous Cyclone start selection is invalid");
   }
+  if (preferredPaletteFamily !== null &&
+      !catalog.startupPaletteFamilies.includes(preferredPaletteFamily)) {
+    throw new RangeError("Preferred Cyclone palette family is invalid");
+  }
   const values = randomUint32Pair();
   if (!Array.isArray(values) || values.length !== 2 ||
       values.some((value) => !Number.isSafeInteger(value) || value < 0 || value > 0xffffffff)) {
     throw new RangeError("Cyclone startup random values must be two uint32 values");
   }
   const paletteFamilyIndex = values[0] % catalog.startupPaletteFamilies.length;
-  const paletteFamily = catalog.startupPaletteFamilies[paletteFamilyIndex];
+  const paletteFamily = preferredPaletteFamily ?? catalog.startupPaletteFamilies[paletteFamilyIndex];
   const familySelections = catalog.startupSelections.filter((selection) =>
     selection.paletteFamily === paletteFamily);
-  let selectionIndex = Math.floor(values[0] / catalog.startupPaletteFamilies.length) % familySelections.length;
+  let selectionIndex = (preferredPaletteFamily === null
+    ? Math.floor(values[0] / catalog.startupPaletteFamilies.length)
+    : values[0]) % familySelections.length;
   if (familySelections[selectionIndex].id === previousSelectionId && familySelections.length > 1) {
     selectionIndex = (selectionIndex + 1) % familySelections.length;
   }
@@ -66,7 +72,9 @@ export function selectInitialCyclonePosition(catalog, {
     paletteFamily,
     chunkIndex: selection.chunkIndex,
     frameIndex,
-    mode: previousSelectionId === null
+    mode: preferredPaletteFamily !== null
+      ? "session-shuffled-palette-crypto-random-source-window"
+      : previousSelectionId === null
       ? "crypto-random-balanced-source-palette"
       : "crypto-random-balanced-source-palette-no-repeat",
   });
@@ -198,7 +206,7 @@ function validateCatalog(catalog) {
         !Number.isSafeInteger(frameOffset) || frameOffset < 0 ||
         catalog.startupSelections.some((selection) => frameOffset >= selection.frameCount)) ||
       catalog.selection !== STARTUP_SELECTION ||
-      catalog.runtimeLookaheadBlockCount !== RUNTIME_LOOKAHEAD_BLOCK_COUNT ||
+      catalog.runtimeLookaheadBlockCount !== 1 ||
       catalog.entries.some((entry, index) => entry?.index !== index ||
         entry.chunkIndex !== Math.floor(index / catalog.blocksPerChunk) ||
         entry.blockIndex !== index % catalog.blocksPerChunk ||

--- a/src/adapters/cyclone/src/csscyclone/profileSelection.mjs
+++ b/src/adapters/cyclone/src/csscyclone/profileSelection.mjs
@@ -1,0 +1,24 @@
+const MOBILE_USER_AGENT = /Android|iPhone|iPad|iPod|Mobile/u;
+
+export const CSSCYCLONE_MOBILE_BREAKPOINT_WIDTH = 600;
+export const CSSCYCLONE_MOBILE_CAPABILITY_QUERY = "(hover: none) and (pointer: coarse)";
+export const CSSCYCLONE_PREPARED_PROFILES = Object.freeze({
+  desktop: Object.freeze({ id: "desktop", modelId: "cyclone" }),
+  mobile: Object.freeze({ id: "mobile", modelId: "cyclone-mobile" }),
+});
+
+export function selectCyclonePreparedProfile({
+  width = globalThis.innerWidth,
+  height = globalThis.innerHeight,
+  mediaMatches = (query) => globalThis.matchMedia(query).matches,
+  userAgentDataMobile = globalThis.navigator?.userAgentData?.mobile === true,
+  userAgent = globalThis.navigator?.userAgent ?? "",
+} = {}) {
+  if (!Number.isFinite(width) || width <= 0 || !Number.isFinite(height) || height <= 0) {
+    throw new TypeError("Prepared Cyclone viewport drifted");
+  }
+  return userAgentDataMobile || MOBILE_USER_AGENT.test(userAgent) ||
+    mediaMatches(CSSCYCLONE_MOBILE_CAPABILITY_QUERY) || width < CSSCYCLONE_MOBILE_BREAKPOINT_WIDTH
+    ? "mobile"
+    : "desktop";
+}

--- a/src/adapters/cyclone/src/csscyclone/startupPaletteSelection.mjs
+++ b/src/adapters/cyclone/src/csscyclone/startupPaletteSelection.mjs
@@ -1,0 +1,92 @@
+const STORAGE_KEY = "csscyclone:startup-palette-shuffle@1";
+const STORAGE_SCHEMA = "csscyclone-startup-palette-shuffle@1";
+
+export function selectCycloneStartupPaletteFamily(paletteFamilies, options = {}) {
+  const families = [...(paletteFamilies ?? [])];
+  if (families.length < 2 || new Set(families).size !== families.length ||
+      families.some((family) => typeof family !== "string" || family.length < 1)) {
+    throw new Error("Cyclone startup palette shuffle requires distinct prepared families");
+  }
+  const signature = families.join("\n");
+  const storage = options.storage ?? safeSessionStorage();
+  const randomUint32 = options.randomUint32 ?? cryptoRandomUint32;
+  const restored = readState(storage, signature, families);
+  let remaining = restored?.remainingPaletteFamilies ?? [];
+  const lastPaletteFamily = restored?.lastPaletteFamily ?? null;
+
+  if (remaining.length === 0) {
+    remaining = [...families];
+    for (let index = remaining.length - 1; index > 0; index -= 1) {
+      const value = randomUint32();
+      if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
+        throw new RangeError("Cyclone startup palette shuffle value must be uint32");
+      }
+      const swapIndex = value % (index + 1);
+      [remaining[index], remaining[swapIndex]] = [remaining[swapIndex], remaining[index]];
+    }
+    if (lastPaletteFamily && remaining.at(-1) === lastPaletteFamily) {
+      [remaining[0], remaining[remaining.length - 1]] =
+        [remaining[remaining.length - 1], remaining[0]];
+    }
+  }
+
+  const paletteFamily = remaining.pop();
+  if (!paletteFamily || paletteFamily === lastPaletteFamily) {
+    throw new Error("Cyclone startup palette shuffle repeated its previous family");
+  }
+  writeState(storage, {
+    schema: STORAGE_SCHEMA,
+    paletteSignature: signature,
+    lastPaletteFamily: paletteFamily,
+    remainingPaletteFamilies: remaining,
+  });
+  return Object.freeze({
+    paletteFamily,
+    remainingPaletteFamilyCount: remaining.length,
+    sessionPersistence: Boolean(storage),
+  });
+}
+
+function readState(storage, signature, families) {
+  if (!storage) return null;
+  try {
+    const value = JSON.parse(storage.getItem(STORAGE_KEY));
+    const remaining = value?.remainingPaletteFamilies;
+    const allowed = new Set(families);
+    if (value?.schema !== STORAGE_SCHEMA || value.paletteSignature !== signature ||
+        (value.lastPaletteFamily !== null && !allowed.has(value.lastPaletteFamily)) ||
+        !Array.isArray(remaining) || new Set(remaining).size !== remaining.length ||
+        remaining.some((family) => !allowed.has(family) || family === value.lastPaletteFamily)) {
+      return null;
+    }
+    return Object.freeze({
+      lastPaletteFamily: value.lastPaletteFamily,
+      remainingPaletteFamilies: [...remaining],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function writeState(storage, value) {
+  if (!storage) return;
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // Selection remains balanced within this load when browser storage is unavailable.
+  }
+}
+
+function safeSessionStorage() {
+  try {
+    return globalThis.sessionStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function cryptoRandomUint32() {
+  const values = new Uint32Array(1);
+  globalThis.crypto.getRandomValues(values);
+  return values[0];
+}

--- a/src/adapters/cyclone/src/csscyclone/styles.css
+++ b/src/adapters/cyclone/src/csscyclone/styles.css
@@ -146,8 +146,7 @@ body > .polycss-camera {
 }
 
 body > .polycss-camera > .polycss-scene,
-body > .polycss-camera > .polycss-scene > div,
-body > .polycss-camera > .polycss-scene > div > div {
+body > .polycss-camera > .polycss-scene > div {
   position: absolute;
   transform-style: preserve-3d;
   transform-origin: 0 0 0;

--- a/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
@@ -9,7 +9,11 @@ import {
   buildCycloneSourceSequence,
 } from "./sourceModel.mjs";
 
-export const CSSCYCLONE_MODEL_ID = "cyclone";
+export const CSSCYCLONE_MODEL_IDS = Object.freeze({
+  desktop: "cyclone",
+  mobile: "cyclone-mobile",
+});
+export const CSSCYCLONE_MODEL_ID = CSSCYCLONE_MODEL_IDS.desktop;
 const PARTICLE_RADIUS = CSSCYCLONE_SOURCE.particleSize / 4;
 const EQUATOR = Object.freeze(Array.from({ length: 3 }, (_, index) => {
   const angle = index * Math.PI * 2 / 3;
@@ -29,7 +33,10 @@ export const CSSCYCLONE_FACE_INDICES = Object.freeze([
   Object.freeze([4, 1, 3]),
 ]);
 
-export function buildCyclonePreparedModel({ source = buildCycloneSourceSequence() } = {}) {
+export function buildCyclonePreparedModel({
+  source = buildCycloneSourceSequence(),
+  modelId = CSSCYCLONE_MODEL_ID,
+} = {}) {
   const vertices = [];
   const normals = [];
   const polygons = [];
@@ -70,7 +77,7 @@ export function buildCyclonePreparedModel({ source = buildCycloneSourceSequence(
   }
   const model = deepFreeze({
     schema: "polycss-morph.model@1",
-    identity: Object.freeze({ id: CSSCYCLONE_MODEL_ID, name: source.bank.name, revision: "0.1.0" }),
+    identity: Object.freeze({ id: modelId, name: source.bank.name, revision: "0.1.0" }),
     profile: "static-prepared",
     capabilities: Object.freeze(["retained-render"]),
     budgets: Object.freeze({
@@ -125,7 +132,10 @@ export function buildCyclonePreparedModel({ source = buildCycloneSourceSequence(
   });
 }
 
-export function buildCyclonePreparedPlayback({ source = buildCycloneSourceSequence() } = {}) {
+export function buildCyclonePreparedPlayback({
+  source = buildCycloneSourceSequence(),
+  modelId = CSSCYCLONE_MODEL_ID,
+} = {}) {
   const transforms = [];
   const transformIndices = new Map();
   const internTransform = (matrix) => {
@@ -156,7 +166,7 @@ export function buildCyclonePreparedPlayback({ source = buildCycloneSourceSequen
     chunkIndex: source.bank.chunkIndex,
     chunkCount: source.bank.chunkCount,
     startFrameIndex: source.bank.startFrameIndex,
-    modelId: CSSCYCLONE_MODEL_ID,
+    modelId,
     frameMilliseconds: source.bank.frameMilliseconds,
     durationMilliseconds: source.durationMilliseconds,
     frameCount: frames.length,

--- a/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
@@ -12,6 +12,8 @@ const SLOT_SIZE = CONTENT_SIZE + GUTTER * 2;
 const UNPACKED_MAXIMUM_COLUMNS = 1_200;
 const MAXIMUM_TEXTURE_DIMENSION = 8_192;
 const DISPLAY_SCALE = 16;
+const PREPARED_MINIMUM_SATURATION = CSSCYCLONE_PRESENTATION.minimumSaturation;
+const PREPARED_MINIMUM_VALUE = 0.65;
 const PALETTE_CENTER_HUES = Object.freeze({
   blue: 2 / 3,
   yellow: 1 / 6,
@@ -26,7 +28,9 @@ const HALF_VECTOR = normalize([
   LIGHT_DIRECTION[2] + 1,
 ]);
 
-export function createCyclonePreparedLightingStream() {
+export function createCyclonePreparedLightingStream({
+  assetRoot = "/csscyclone/assets",
+} = {}) {
   let particleCount = null;
   let expectedChunkCount = null;
   let chunkFrameCount = null;
@@ -91,6 +95,7 @@ export function createCyclonePreparedLightingStream() {
       throw new Error(`Prepared Cyclone lighting stream has ${nextChunkIndex}/${expectedChunkCount} chunks`);
     }
     return buildPreparedLightingAsset({
+      assetRoot,
       particleCount,
       chunkCount: nextChunkIndex,
       chunkFrameCount,
@@ -119,14 +124,15 @@ export function createCyclonePreparedLightingStream() {
   return Object.freeze({ add, finalize });
 }
 
-export async function buildCyclonePreparedLighting({ source }) {
-  const stream = createCyclonePreparedLightingStream();
+export async function buildCyclonePreparedLighting({ source, assetRoot }) {
+  const stream = createCyclonePreparedLightingStream({ assetRoot });
   const chunk = stream.add(source);
   const prepared = await stream.finalize({ allowPartial: true });
   return Object.freeze({ ...prepared, chunk });
 }
 
 async function buildPreparedLightingAsset({
+  assetRoot,
   particleCount,
   chunkCount,
   chunkFrameCount,
@@ -154,7 +160,7 @@ async function buildPreparedLightingAsset({
     const rgba = Buffer.alloc(unpackedWidth * unpackedHeight * 4);
     for (let stateIndex = 0; stateIndex < colorStates.length; stateIndex += 1) {
       const state = colorStates[stateIndex];
-      const baseColor = preparedPaletteColor(state.baseColor, paletteFamily);
+      const baseColor = prepareCyclonePaletteColor(state.baseColor, paletteFamily);
       const vertexColors = frozenVertexNormals[state.particleIndex].map((normal) => shadeVertex({
         baseColor,
         normal,
@@ -201,7 +207,7 @@ async function buildPreparedLightingAsset({
     const assetSha256 = createHash("sha256").update(bytes).digest("hex");
     assets.push(Object.freeze({
       paletteFamily: variant.paletteFamily,
-      assetUrl: `/csscyclone/assets/lighting-${variant.paletteFamily}-${assetSha256}.webp`,
+      assetUrl: `${assetRoot}/lighting-${variant.paletteFamily}-${assetSha256}.webp`,
       assetSha256,
       byteLength: bytes.byteLength,
       hueSlots: variant.hueSlots,
@@ -215,8 +221,8 @@ async function buildPreparedLightingAsset({
     return `${-contentX * DISPLAY_SCALE}px ${-contentY * DISPLAY_SCALE}px`;
   }));
   const contract = deepFreeze({
-    schema: "csscyclone-prepared-smooth-lighting-atlas@6",
-    technique: "prepared-session-three-family-lighting-variants-with-sparse-source-color-restarts-and-exact-tile-deduplication",
+    schema: "csscyclone-prepared-smooth-lighting-atlas@7",
+    technique: "prepared-session-three-family-lighting-variants-with-dark-color-floor-sparse-source-color-restarts-and-exact-tile-deduplication",
     source: "src/cyclone/cyclone.cpp#particle::update+initSaver",
     streamId,
     encoding: "WebP-lossless-RGBA8",
@@ -229,6 +235,8 @@ async function buildPreparedLightingAsset({
     paletteFamilies: CSSCYCLONE_PRESENTATION.startupPaletteFamilies,
     paletteHueSlotCount: CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount,
     paletteAssignment: CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
+    preparedMinimumSaturation: PREPARED_MINIMUM_SATURATION,
+    preparedMinimumValue: PREPARED_MINIMUM_VALUE,
     maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
     variants: Object.freeze(assets.map(({ bytes: ignored, ...asset }) => Object.freeze(asset))),
     contentSize: CONTENT_SIZE,
@@ -421,11 +429,14 @@ function preparedPaletteHues(paletteFamily) {
   }));
 }
 
-function preparedPaletteColor(baseColor, paletteFamily) {
+export function prepareCyclonePaletteColor(baseColor, paletteFamily) {
   const maximum = Math.max(...baseColor);
   const minimum = Math.min(...baseColor);
   const chroma = maximum - minimum;
-  const saturation = maximum > 0 ? chroma / maximum : 0;
+  const saturation = Math.max(
+    PREPARED_MINIMUM_SATURATION,
+    maximum > 0 ? chroma / maximum : 0,
+  );
   let hue = 0;
   if (chroma > 1e-12) {
     if (maximum === baseColor[0]) hue = ((baseColor[1] - baseColor[2]) / chroma) % 6;
@@ -437,7 +448,11 @@ function preparedPaletteColor(baseColor, paletteFamily) {
     CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount - 1,
     Math.floor(hue * CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount),
   );
-  return hsvToRgb(preparedPaletteHues(paletteFamily)[hueSlotIndex], saturation, maximum);
+  return hsvToRgb(
+    preparedPaletteHues(paletteFamily)[hueSlotIndex],
+    saturation,
+    Math.max(PREPARED_MINIMUM_VALUE, maximum),
+  );
 }
 
 function hsvToRgb(hue, saturation, value) {

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -20,7 +20,7 @@ export const CSSCYCLONE_SOURCE = Object.freeze({
   stretch: true,
 });
 
-export const CSSCYCLONE_BANK = Object.freeze({
+const CSSCYCLONE_DESKTOP_BANK = Object.freeze({
   id: "desktop-stream",
   name: "Cyclone",
   seed: 1,
@@ -30,6 +30,18 @@ export const CSSCYCLONE_BANK = Object.freeze({
   frameCount: 450,
   chunkCount: 24,
 });
+
+export const CSSCYCLONE_BANKS = Object.freeze({
+  desktop: CSSCYCLONE_DESKTOP_BANK,
+  mobile: Object.freeze({
+    ...CSSCYCLONE_DESKTOP_BANK,
+    id: "mobile-stream",
+    name: "Cyclone Mobile",
+    particleCount: 266,
+  }),
+});
+
+export const CSSCYCLONE_BANK = CSSCYCLONE_BANKS.desktop;
 
 export const CSSCYCLONE_PRESENTATION = Object.freeze({
   saturationSampling: "floor-0.55-plus-0.45-sqrt-uniform",
@@ -42,6 +54,18 @@ export const CSSCYCLONE_PRESENTATION = Object.freeze({
   startupPaletteFamilies: Object.freeze(["blue", "yellow", "red", "magenta", "green"]),
   startupSelections: Object.freeze([
     Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 20, frameCount: 40 }),
+    Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 190, frameCount: 40 }),
+    Object.freeze({ id: "yellow-a", paletteFamily: "yellow", chunkIndex: 1, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "yellow-b", paletteFamily: "yellow", chunkIndex: 7, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "red-a", paletteFamily: "red", chunkIndex: 5, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "red-b", paletteFamily: "red", chunkIndex: 9, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "magenta-a", paletteFamily: "magenta", chunkIndex: 4, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "magenta-b", paletteFamily: "magenta", chunkIndex: 11, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "green-a", paletteFamily: "green", chunkIndex: 17, startFrameIndex: 55, frameCount: 40 }),
+    Object.freeze({ id: "green-b", paletteFamily: "green", chunkIndex: 19, startFrameIndex: 55, frameCount: 40 }),
+  ]),
+  mobileStartupSelections: Object.freeze([
+    Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 75, frameCount: 40 }),
     Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 190, frameCount: 40 }),
     Object.freeze({ id: "yellow-a", paletteFamily: "yellow", chunkIndex: 1, startFrameIndex: 55, frameCount: 40 }),
     Object.freeze({ id: "yellow-b", paletteFamily: "yellow", chunkIndex: 7, startFrameIndex: 55, frameCount: 40 }),
@@ -103,6 +127,34 @@ export function* buildCycloneSourceChunks({ bank = CSSCYCLONE_BANK } = {}) {
       streamDurationMilliseconds: bank.chunkCount * bank.frameCount * bank.frameMilliseconds,
     });
   }
+}
+
+export function selectCycloneSourceParticlePrefix(source, bank = CSSCYCLONE_BANKS.mobile) {
+  validateBank(bank);
+  if (source?.schema !== "csscyclone-source-sequence@2" ||
+      !Array.isArray(source.frames) || source.frames.length !== source.bank?.frameCount ||
+      bank.particleCount > source.bank.particleCount ||
+      bank.seed !== source.bank.seed ||
+      bank.frameMilliseconds !== source.bank.frameMilliseconds ||
+      bank.warmupFrames !== source.bank.warmupFrames ||
+      bank.frameCount !== source.bank.frameCount ||
+      bank.chunkCount !== source.bank.chunkCount) {
+    throw new Error("Cyclone mobile particle-prefix source binding drifted");
+  }
+  return deepFreeze({
+    ...source,
+    bank: Object.freeze({
+      ...bank,
+      id: source.bank.id,
+      streamId: bank.id,
+      chunkIndex: source.bank.chunkIndex,
+      startFrameIndex: source.bank.startFrameIndex,
+    }),
+    frames: Object.freeze(source.frames.map((frame) => Object.freeze({
+      ...frame,
+      particles: Object.freeze(frame.particles.slice(0, bank.particleCount)),
+    }))),
+  });
 }
 
 function validateBank(bank) {

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -22,11 +22,7 @@ test.after(() => {
   else globalThis.HTMLElement = originalHTMLElement;
 });
 
-function fixture({
-  blockCount = 1,
-  runtimeLookaheadBlockCount = 1,
-  initialLookaheadBlockCount = 0,
-} = {}) {
+function fixture() {
   let now = 0;
   let nextRequestId = 0;
   const frames = new Map();
@@ -41,8 +37,8 @@ function fixture({
     chunkIndex: 0,
     blockIndex: 0,
     chunkCount: 1,
-    blockCount,
-    blocksPerChunk: blockCount,
+    blockCount: 1,
+    blocksPerChunk: 1,
     startFrameIndex: 0,
     frameCount: 4,
     particleCount: 2,
@@ -59,10 +55,10 @@ function fixture({
     ],
   };
   const lighting = {
-    schema: "csscyclone-prepared-smooth-lighting-atlas@6",
+    schema: "csscyclone-prepared-smooth-lighting-atlas@7",
     streamId: "stream",
     chunkCount: 1,
-    chunkFrameCount: blockCount * 4,
+    chunkFrameCount: 4,
     leafCount: 2,
     facesPerParticle: 1,
     colorStateCount: 1,
@@ -78,47 +74,39 @@ function fixture({
     variants: [{ paletteFamily: "blue", assetSha256: "hash" }],
     runtime: { lightingCalculations: 0, atlasConstruction: 0 },
   };
-  const blocks = Array.from({ length: blockCount }, (_, streamBlockIndex) => {
-    const blockPlayback = {
-      ...playback,
-      streamBlockIndex,
-      blockIndex: streamBlockIndex,
-      startFrameIndex: streamBlockIndex * 4,
-    };
-    return {
-      schema: "csscyclone-prepared-stream-block@1",
+  const block = {
+    schema: "csscyclone-prepared-stream-block@1",
+    streamId: "stream",
+    streamBlockIndex: 0,
+    chunkIndex: 0,
+    blockIndex: 0,
+    startFrameIndex: 0,
+    frameCount: 4,
+    playback,
+    lighting: {
+      schema: "csscyclone-prepared-lighting-block@1",
       streamId: "stream",
-      streamBlockIndex,
+      streamBlockIndex: 0,
       chunkIndex: 0,
-      blockIndex: streamBlockIndex,
-      startFrameIndex: streamBlockIndex * 4,
+      blockIndex: 0,
+      startFrameIndex: 0,
       frameCount: 4,
-      playback: blockPlayback,
-      lighting: {
-        schema: "csscyclone-prepared-lighting-block@1",
-        streamId: "stream",
-        streamBlockIndex,
-        chunkIndex: 0,
-        blockIndex: streamBlockIndex,
-        startFrameIndex: streamBlockIndex * 4,
-        frameCount: 4,
-        particleCount: 2,
-        frameParticleColorStateIndices: [[0, 0], [0, 0], [0, 0], [0, 0]],
-      },
-    };
-  });
+      particleCount: 2,
+      frameParticleColorStateIndices: [[0, 0], [0, 0], [0, 0], [0, 0]],
+    },
+  };
   const catalog = {
     schema: "csscyclone-prepared-stream-catalog@1",
     streamId: "stream",
     chunkCount: 1,
-    chunkFrameCount: blockCount * 4,
-    blockCount,
-    entries: Array.from({ length: blockCount }, () => ({})),
-    blocksPerChunk: blockCount,
+    chunkFrameCount: 4,
+    blockCount: 1,
+    entries: [{}],
+    blocksPerChunk: 1,
     blockFrameCount: 4,
-    runtimeLookaheadBlockCount,
-    streamFrameCount: blockCount * 4,
-    streamDurationMilliseconds: blockCount * 80,
+    runtimeLookaheadBlockCount: 1,
+    streamFrameCount: 4,
+    streamDurationMilliseconds: 80,
   };
   const mounted = {
     model: {
@@ -136,12 +124,11 @@ function fixture({
     assertStableDomIdentity: identity,
     destroy: identity,
   };
-  const loadBlockCalls = [];
   const player = createCyclonePreparedPlayer({
     mounted,
+    modelTransform: "matrix3d(1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, -400, 1)",
     catalog,
-    initialBlock: blocks[0],
-    initialLookaheadBlocks: blocks.slice(1, initialLookaheadBlockCount + 1),
+    initialBlock: block,
     initialFrameIndex: 0,
     lighting,
     lightingAsset: {
@@ -152,10 +139,7 @@ function fixture({
       hueSlots: [0.5, 2 / 3, 5 / 6],
       destroy: identity,
     },
-    loadBlock: async (streamBlockIndex) => {
-      loadBlockCalls.push(streamBlockIndex);
-      return blocks[streamBlockIndex];
-    },
+    loadBlock: async () => block,
     readNow: () => now,
     requestFrame(callback) {
       const id = ++nextRequestId;
@@ -175,7 +159,6 @@ function fixture({
     shapeElements,
     frames,
     delays,
-    loadBlockCalls,
     setNow(value) { now = value; },
     fireDelay() {
       const [id, request] = delays.entries().next().value;
@@ -206,30 +189,6 @@ test("hands each prepared publication from its deadline timer to requestAnimatio
   assert.equal(stats.runtimeSchedulerTransport, "deadline-setTimeout-requestAnimationFrame-prepared-publication");
   assert.equal(stats.schedulerFrameCallbackCount, 1);
   assert.equal(stats.schedulerDelayCallbackCount, 1);
-});
-
-test("starts with and maintains a three-block prepared lookahead", async () => {
-  const state = fixture({
-    blockCount: 5,
-    runtimeLookaheadBlockCount: 3,
-    initialLookaheadBlockCount: 3,
-  });
-  assert.deepEqual(state.player.stats().pendingBlockIndices, [1, 2, 3]);
-  assert.equal(state.player.stats().pendingBlockReadyCount, 3);
-  assert.deepEqual(state.loadBlockCalls, []);
-
-  state.player.resume();
-  state.fireDelay();
-  state.setNow(81);
-  await state.fireFrame();
-  await Promise.resolve();
-
-  const stats = state.player.stats();
-  assert.equal(stats.activeBlockIndex, 1);
-  assert.deepEqual(stats.pendingBlockIndices, [2, 3, 4]);
-  assert.equal(stats.pendingBlockReadyCount, 3);
-  assert.equal(stats.runtimePreparedBlockWaitCount, 0);
-  assert.deepEqual(state.loadBlockCalls, [4]);
 });
 
 test("collapses missed prepared frames once at the next paint-aligned callback", async () => {

--- a/src/adapters/cyclone/test/csscyclone-profile-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-profile-selection.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CSSCYCLONE_PREPARED_PROFILES,
+  selectCyclonePreparedProfile,
+} from "../src/csscyclone/profileSelection.mjs";
+
+const noCapabilities = () => false;
+
+test("selects the prepared mobile particle bank before mount", () => {
+  assert.equal(selectCyclonePreparedProfile({
+    width: 448,
+    height: 827,
+    mediaMatches: noCapabilities,
+    userAgent: "desktop-test",
+  }), "mobile");
+  assert.equal(selectCyclonePreparedProfile({
+    width: 1_280,
+    height: 800,
+    mediaMatches: (query) => query.includes("pointer: coarse"),
+    userAgent: "desktop-test",
+  }), "mobile");
+  assert.equal(selectCyclonePreparedProfile({
+    width: 1_280,
+    height: 800,
+    mediaMatches: noCapabilities,
+    userAgent: "Mozilla/5.0 Android Mobile",
+  }), "mobile");
+});
+
+test("preserves the prepared desktop particle bank for desktop devices", () => {
+  assert.equal(selectCyclonePreparedProfile({
+    width: 1_280,
+    height: 800,
+    mediaMatches: noCapabilities,
+    userAgent: "desktop-test",
+  }), "desktop");
+  assert.deepEqual(CSSCYCLONE_PREPARED_PROFILES, {
+    desktop: { id: "desktop", modelId: "cyclone" },
+    mobile: { id: "mobile", modelId: "cyclone-mobile" },
+  });
+});
+
+test("rejects invalid prepared profile viewports", () => {
+  assert.throws(() => selectCyclonePreparedProfile({
+    width: 0,
+    height: 800,
+    mediaMatches: noCapabilities,
+  }), /viewport drifted/u);
+});

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -2,18 +2,22 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   CSSCYCLONE_BANK,
+  CSSCYCLONE_BANKS,
   CSSCYCLONE_PRESENTATION,
   CSSCYCLONE_SOURCE,
   buildCycloneSourceChunks,
   buildCycloneSourceSequence,
+  selectCycloneSourceParticlePrefix,
 } from "../src/prepare/csscyclone/sourceModel.mjs";
 import {
+  CSSCYCLONE_MODEL_IDS,
   buildCyclonePreparedModel,
   buildCyclonePreparedPlayback,
 } from "../src/prepare/csscyclone/modelBuilder.mjs";
 import {
   buildCyclonePreparedLighting,
   createCyclonePreparedLightingStream,
+  prepareCyclonePaletteColor,
 } from "../src/prepare/csscyclone/preparedLighting.mjs";
 import { resolveCyclonePerspective } from "../src/csscyclone/preparedPlayback.mjs";
 
@@ -42,6 +46,11 @@ test("pins the current Really Slick Cyclone source profile", () => {
     ["blue", "yellow", "red", "magenta", "green"],
   );
   assert.equal(CSSCYCLONE_PRESENTATION.startupSelections.length, 10);
+  assert.equal(CSSCYCLONE_PRESENTATION.mobileStartupSelections.length, 10);
+  assert.deepEqual(
+    CSSCYCLONE_PRESENTATION.mobileStartupSelections.find(({ id }) => id === "blue-a"),
+    { id: "blue-a", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 75, frameCount: 40 },
+  );
   assert.deepEqual(
     CSSCYCLONE_PRESENTATION.startupSelections.map(({ id, paletteFamily, chunkIndex }) =>
       [id, paletteFamily, chunkIndex]),
@@ -60,6 +69,40 @@ test("pins the current Really Slick Cyclone source profile", () => {
   assert.deepEqual(CSSCYCLONE_PRESENTATION.startupSilhouetteSampleFrameOffsets, [0, 10, 20, 30, 39]);
   assert.equal(CSSCYCLONE_PRESENTATION.startupMinimumMeanSaturation, 0.68);
   assert.equal(CSSCYCLONE_PRESENTATION.startupMinimumDominantHueShare, 0.25);
+});
+
+test("prepares the mobile bank with fewer complete source particles", () => {
+  assert.equal(CSSCYCLONE_BANKS.desktop.particleCount, 400);
+  assert.equal(CSSCYCLONE_BANKS.mobile.particleCount, 266);
+  const desktopBank = {
+    ...CSSCYCLONE_BANKS.desktop,
+    warmupFrames: 2,
+    frameCount: 2,
+    chunkCount: 1,
+  };
+  const mobileBank = {
+    ...CSSCYCLONE_BANKS.mobile,
+    warmupFrames: desktopBank.warmupFrames,
+    frameCount: desktopBank.frameCount,
+    chunkCount: desktopBank.chunkCount,
+  };
+  const desktopSource = buildCycloneSourceSequence({ bank: desktopBank });
+  const source = selectCycloneSourceParticlePrefix(desktopSource, mobileBank);
+  const preparedModel = buildCyclonePreparedModel({
+    source,
+    modelId: CSSCYCLONE_MODEL_IDS.mobile,
+  });
+  const preparedPlayback = buildCyclonePreparedPlayback({
+    source,
+    modelId: CSSCYCLONE_MODEL_IDS.mobile,
+  });
+  assert.equal(preparedModel.model.identity.id, "cyclone-mobile");
+  assert.equal(preparedModel.model.render.shapes.length, 266);
+  assert.equal(preparedModel.model.render.leaves.length, 1_596);
+  assert.equal(preparedModel.metrics.polygonsPerParticle, 6);
+  assert.equal(preparedPlayback.playback.particleCount, 266);
+  assert.equal(preparedPlayback.playback.leafCount, 1_596);
+  assert.deepEqual(source.frames[0].particles, desktopSource.frames[0].particles.slice(0, 266));
 });
 
 test("widens only the mobile presentation field of view", () => {
@@ -91,7 +134,7 @@ test("prepares smooth reference lighting without a runtime lighting timeline", a
   const bank = { ...CSSCYCLONE_BANK, particleCount: 3, warmupFrames: 20, frameCount: 4 };
   const source = buildCycloneSourceSequence({ bank });
   const prepared = await buildCyclonePreparedLighting({ source });
-  assert.equal(prepared.contract.schema, "csscyclone-prepared-smooth-lighting-atlas@6");
+  assert.equal(prepared.contract.schema, "csscyclone-prepared-smooth-lighting-atlas@7");
   assert.equal(prepared.contract.contentSize, 2);
   assert.equal(prepared.contract.gutterPixels, 1);
   assert.equal(prepared.contract.leafCount, 18);
@@ -109,6 +152,8 @@ test("prepares smooth reference lighting without a runtime lighting timeline", a
   assert.equal(prepared.contract.paletteFamilyCount, 5);
   assert.equal(prepared.contract.paletteHueSlotCount, 3);
   assert.equal(prepared.contract.maximumColorFamilyCount, 3);
+  assert.equal(prepared.contract.preparedMinimumSaturation, 0.55);
+  assert.equal(prepared.contract.preparedMinimumValue, 0.65);
   assert.equal(prepared.contract.variants.length, 5);
   assert.ok(prepared.contract.variants.every((variant) => variant.hueSlots.length === 3));
   assert.equal(prepared.contract.sourceStreamFrameCount, 4);
@@ -122,6 +167,9 @@ test("prepares smooth reference lighting without a runtime lighting timeline", a
   assert.equal(prepared.assets.length, 5);
   assert.ok(prepared.assets.every((asset) => asset.bytes.byteLength > 0));
   assert.ok(prepared.contract.variants.every((variant) => /^[a-f0-9]{64}$/u.test(variant.assetSha256)));
+  const liftedBlack = prepareCyclonePaletteColor([0, 0, 0], "yellow");
+  assert.equal(Math.max(...liftedBlack), 0.65);
+  assert.equal(Number((1 - Math.min(...liftedBlack) / Math.max(...liftedBlack)).toFixed(2)), 0.55);
 });
 
 test("publishes only exact source color restarts through sparse leaf addresses", async () => {

--- a/src/adapters/cyclone/test/csscyclone-startup-palette-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-startup-palette-selection.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { selectCycloneStartupPaletteFamily } from "../src/csscyclone/startupPaletteSelection.mjs";
+
+const families = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
+
+test("visits every prepared three-family palette once before repeating across reloads", () => {
+  const storage = fixtureStorage();
+  let randomValue = 0;
+  const options = { storage, randomUint32: () => randomValue++ };
+  const firstCycle = Array.from({ length: families.length }, () =>
+    selectCycloneStartupPaletteFamily(families, options).paletteFamily);
+  const secondCycle = Array.from({ length: families.length }, () =>
+    selectCycloneStartupPaletteFamily(families, options).paletteFamily);
+  assert.equal(new Set(firstCycle).size, families.length);
+  assert.equal(new Set(secondCycle).size, families.length);
+  assert.notEqual(secondCycle[0], firstCycle.at(-1));
+});
+
+test("rejects a broken palette bank or random source", () => {
+  assert.throws(() => selectCycloneStartupPaletteFamily(["red", "red"]), /distinct prepared families/u);
+  assert.throws(() => selectCycloneStartupPaletteFamily(families, {
+    storage: fixtureStorage(),
+    randomUint32: () => -1,
+  }), /must be uint32/u);
+});
+
+function fixtureStorage() {
+  const values = new Map();
+  return {
+    getItem(key) { return values.get(key) ?? null; },
+    setItem(key, value) { values.set(key, value); },
+  };
+}

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -33,7 +33,7 @@ const catalog = Object.freeze({
   startupSilhouetteSampling: "browser-reviewed-expressive-source-windows",
   startupSilhouetteSampleFrameOffsets: Object.freeze([0, 10, 20, 30, 39]),
   maximumColorFamilyCount: 3,
-  selection: "session-crypto-random-balanced-source-palette-window-no-immediate-repeat",
+  selection: "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat",
   startupColorProfile: Object.freeze({
     schema: "csscyclone-prepared-startup-color-profile@2",
     metric: "prepared-source-particle-rgb-hsv-dominant-family-per-curated-window",
@@ -55,7 +55,7 @@ const catalog = Object.freeze({
       });
     })),
   }),
-  runtimeLookaheadBlockCount: 3,
+  runtimeLookaheadBlockCount: 1,
   entries: Object.freeze(Array.from({ length: 216 }, (_, index) => Object.freeze({
     index,
     chunkIndex: Math.floor(index / 9),
@@ -94,6 +94,19 @@ test("does not immediately repeat the previous prepared window", () => {
     chunkIndex: 5,
     frameIndex: 76,
     mode: "crypto-random-balanced-source-palette-no-repeat",
+  });
+});
+
+test("uses the session-shuffled family while retaining a random curated source window", () => {
+  assert.deepEqual(selectInitialCyclonePosition(catalog, {
+    preferredPaletteFamily: "green",
+    randomUint32Pair: () => [7, 901],
+  }), {
+    selectionId: "green-b",
+    paletteFamily: "green",
+    chunkIndex: 19,
+    frameIndex: 76,
+    mode: "session-shuffled-palette-crypto-random-source-window",
   });
 });
 

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -6,16 +6,18 @@ import { fileURLToPath } from "node:url";
 import { gzipSync } from "node:zlib";
 import { buildPolyMorphCatalog, buildPolyMorphPackage } from "@layoutit/polycss-morph/prepare";
 import {
-  CSSCYCLONE_MODEL_ID,
+  CSSCYCLONE_FACE_INDICES,
+  CSSCYCLONE_MODEL_IDS,
   buildCyclonePreparedModel,
   buildCyclonePreparedPlayback,
 } from "../src/prepare/csscyclone/modelBuilder.mjs";
 import { createCyclonePreparedLightingStream } from "../src/prepare/csscyclone/preparedLighting.mjs";
 import {
-  CSSCYCLONE_BANK,
+  CSSCYCLONE_BANKS,
   CSSCYCLONE_PRESENTATION,
   CSSCYCLONE_SOURCE,
   buildCycloneSourceChunks,
+  selectCycloneSourceParticlePrefix,
 } from "../src/prepare/csscyclone/sourceModel.mjs";
 
 const adapterRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -24,161 +26,49 @@ const outputRoot = join(repositoryRoot, "build/generated/public/csscyclone");
 const stagingRoot = join(repositoryRoot, `build/generated/.csscyclone-${process.pid}`);
 const sourceLock = JSON.parse(await readFile(join(adapterRoot, "notes/references/source-lock.json"), "utf8"));
 const blockFrameCount = 50;
-const runtimeLookaheadBlockCount = 3;
-const blocksPerChunk = CSSCYCLONE_BANK.frameCount / blockFrameCount;
-const blockCount = CSSCYCLONE_BANK.chunkCount * blocksPerChunk;
 const startupPaletteFamilies = CSSCYCLONE_PRESENTATION.startupPaletteFamilies;
-const startupSelections = CSSCYCLONE_PRESENTATION.startupSelections;
 const startupSilhouetteSampleFrameOffsets = CSSCYCLONE_PRESENTATION.startupSilhouetteSampleFrameOffsets;
 const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
-
-if (!Number.isSafeInteger(blocksPerChunk)) {
-  throw new Error("Cyclone prepared chunk must divide into exact transport blocks");
-}
+const profileConfigs = Object.freeze([
+  Object.freeze({
+    id: "desktop",
+    bank: CSSCYCLONE_BANKS.desktop,
+    modelId: CSSCYCLONE_MODEL_IDS.desktop,
+    catalogUrl: "/csscyclone/catalog.json",
+    blockRoot: "/csscyclone/blocks",
+    lightingAssetRoot: "/csscyclone/assets",
+    particleSelection: "source-default-all-particles",
+    startupSelections: CSSCYCLONE_PRESENTATION.startupSelections,
+  }),
+  Object.freeze({
+    id: "mobile",
+    bank: CSSCYCLONE_BANKS.mobile,
+    modelId: CSSCYCLONE_MODEL_IDS.mobile,
+    catalogUrl: "/csscyclone/mobile/catalog.json",
+    blockRoot: "/csscyclone/mobile/blocks",
+    lightingAssetRoot: "/csscyclone/mobile/assets",
+    particleSelection: "prepared-source-particle-prefix",
+    startupSelections: CSSCYCLONE_PRESENTATION.mobileStartupSelections,
+  }),
+]);
 
 await assertSourceIdentity();
 await rm(stagingRoot, { recursive: true, force: true });
 await mkdir(stagingRoot, { recursive: true });
 
-const lightingStream = createCyclonePreparedLightingStream();
-const blockEntries = [];
-const startupSelectionColorProfiles = new Map();
-let preparedModel = null;
-let preparedFrameCount = 0;
-let uniquePreparedTransformCount = 0;
-let shapeTransformSelections = 0;
-let preparedBlockEncodedBytes = 0;
-let preparedBlockDecodedBytes = 0;
-for (const source of buildCycloneSourceChunks()) {
-  if (preparedModel === null) {
-    const result = buildCyclonePreparedModel({ source });
-    preparedModel = Object.freeze({ model: result.model, metrics: result.metrics });
-  }
-  const preparedPlayback = buildCyclonePreparedPlayback({ source });
-  const lighting = lightingStream.add(source);
-  for (const selection of startupSelections.filter((entry) =>
-    entry.chunkIndex === source.bank.chunkIndex)) {
-    startupSelectionColorProfiles.set(selection.id, analyzeStartupSelectionColors(source, selection));
-  }
-  for (let blockIndex = 0; blockIndex < blocksPerChunk; blockIndex += 1) {
-    const streamBlockIndex = source.bank.chunkIndex * blocksPerChunk + blockIndex;
-    const localStartFrameIndex = blockIndex * blockFrameCount;
-    const startFrameIndex = source.bank.startFrameIndex + localStartFrameIndex;
-    const blockPlayback = slicePreparedPlayback({
-      playback: preparedPlayback.playback,
-      blockIndex,
-      streamBlockIndex,
-      startFrameIndex,
-      localStartFrameIndex,
-    });
-    const blockLighting = Object.freeze({
-      schema: "csscyclone-prepared-lighting-block@1",
-      streamId: source.bank.streamId,
-      chunkIndex: source.bank.chunkIndex,
-      blockIndex,
-      streamBlockIndex,
-      startFrameIndex,
-      frameCount: blockFrameCount,
-      particleCount: source.bank.particleCount,
-      frameParticleColorStateIndices: lighting.frameParticleColorStateIndices.slice(
-        localStartFrameIndex,
-        localStartFrameIndex + blockFrameCount,
-      ),
-    });
-    const decoded = Buffer.from(`${JSON.stringify({
-      schema: "csscyclone-prepared-stream-block@1",
-      streamId: source.bank.streamId,
-      chunkIndex: source.bank.chunkIndex,
-      blockIndex,
-      streamBlockIndex,
-      startFrameIndex,
-      frameCount: blockFrameCount,
-      playback: blockPlayback,
-      lighting: blockLighting,
-    })}\n`);
-    const encoded = gzipSync(decoded, { level: 9 });
-    const encodedSha256 = sha256(encoded);
-    const decodedSha256 = sha256(decoded);
-    const assetUrl = `/csscyclone/blocks/block-${String(streamBlockIndex).padStart(3, "0")}-${encodedSha256}.bin`;
-    await writeBytes(join(stagingRoot, assetUrl.replace(/^\/csscyclone\//u, "")), encoded);
-    blockEntries.push(Object.freeze({
-      index: streamBlockIndex,
-      chunkIndex: source.bank.chunkIndex,
-      blockIndex,
-      startFrameIndex,
-      frameCount: blockFrameCount,
-      sourceContinuousFromPrevious: streamBlockIndex > 0,
-      assetUrl,
-      encoding: "gzip-newline-json",
-      byteLength: encoded.byteLength,
-      sha256: encodedSha256,
-      decodedByteLength: decoded.byteLength,
-      decodedSha256,
-    }));
-    preparedBlockEncodedBytes += encoded.byteLength;
-    preparedBlockDecodedBytes += decoded.byteLength;
-  }
-  preparedFrameCount += preparedPlayback.metrics.preparedFrameCount;
-  uniquePreparedTransformCount += preparedPlayback.metrics.uniquePreparedTransformCount;
-  shapeTransformSelections += preparedPlayback.metrics.shapeTransformSelections;
-}
-const residentBlockWindowCount = runtimeLookaheadBlockCount + 1;
-const maximumResidentBlockWindowDecodedBytes = Math.max(...blockEntries.map((_, startIndex) =>
-  Array.from({ length: residentBlockWindowCount }, (unused, offset) =>
-    blockEntries[(startIndex + offset) % blockEntries.length].decodedByteLength)
-    .reduce((total, byteLength) => total + byteLength, 0)));
-const startupColorProfile = buildStartupColorProfile(
-  startupSelections.map((selection) => startupSelectionColorProfiles.get(selection.id)),
+const preparedProfiles = [];
+for (const profile of profileConfigs) preparedProfiles.push(await prepareProfile(profile));
+const modelCatalog = await buildPolyMorphCatalog(
+  CSSCYCLONE_MODEL_IDS.desktop,
+  preparedProfiles.map(({ profile, built }) => ({
+    manifest: built.manifest,
+    manifestPath: `${profile.modelId}/manifest.json`,
+    manifestSha256: built.manifestSha256,
+  })),
 );
-const preparedLighting = await lightingStream.finalize();
-const catalogBytes = Buffer.from(`${JSON.stringify({
-  schema: "csscyclone-prepared-stream-catalog@1",
-  streamId: CSSCYCLONE_BANK.id,
-  seed: CSSCYCLONE_BANK.seed,
-  chunkCount: CSSCYCLONE_BANK.chunkCount,
-  chunkFrameCount: CSSCYCLONE_BANK.frameCount,
-  blockCount,
-  blocksPerChunk,
-  blockFrameCount,
-  frameMilliseconds: CSSCYCLONE_BANK.frameMilliseconds,
-  streamFrameCount: CSSCYCLONE_BANK.chunkCount * CSSCYCLONE_BANK.frameCount,
-  streamDurationMilliseconds:
-    CSSCYCLONE_BANK.chunkCount * CSSCYCLONE_BANK.frameCount * CSSCYCLONE_BANK.frameMilliseconds,
-  startupPaletteFamilies,
-  startupSelections,
-  startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
-  startupSilhouetteSampleFrameOffsets,
-  maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
-  startupColorProfile,
-  selection: "session-crypto-random-balanced-source-palette-window-no-immediate-repeat",
-  playbackOrder: "source-continuous-ascending-chunks-with-one-terminal-stream-wrap",
-  runtimeLookaheadBlockCount,
-  entries: blockEntries,
-})}\n`);
-const catalogSha256 = sha256(catalogBytes);
-await writeBytes(join(stagingRoot, "catalog.json"), catalogBytes);
-
-if (preparedModel === null) throw new Error("Cyclone source stream produced no prepared model");
-const built = await buildPolyMorphPackage(preparedModel.model);
-const packageRoot = join(stagingRoot, "model", CSSCYCLONE_MODEL_ID);
-await mkdir(packageRoot, { recursive: true });
-for (const [path, bytes] of built.files) await writeBytes(join(packageRoot, path), bytes);
-await writeBytes(join(packageRoot, "manifest.json"), built.manifestBytes);
-const catalog = await buildPolyMorphCatalog(CSSCYCLONE_MODEL_ID, [{
-  manifest: built.manifest,
-  manifestPath: `${CSSCYCLONE_MODEL_ID}/manifest.json`,
-  manifestSha256: built.manifestSha256,
-}]);
-await writeBytes(join(stagingRoot, "model", "catalog.json"), catalog.bytes);
-for (const asset of preparedLighting.assets) {
-  await writeBytes(
-    join(stagingRoot, asset.assetUrl.replace(/^\/csscyclone\//u, "")),
-    asset.bytes,
-  );
-}
-
+await writeBytes(join(stagingRoot, "model", "catalog.json"), modelCatalog.bytes);
 await writeJson(join(stagingRoot, "prepared.json"), {
-  schema: "csscyclone-prepared-scene@1",
+  schema: "csscyclone-prepared-scene@2",
   status: "ready",
   source: sourceLock,
   renderer: {
@@ -192,66 +82,17 @@ await writeJson(join(stagingRoot, "prepared.json"), {
     runtimeMatrixFormatting: false,
     runtimeIdLookup: false
   },
-  presentation: {
-    sourceDefaults: {
-      cyclones: 1,
-      particles: 400,
-      size: CSSCYCLONE_SOURCE.particleSize,
-      complexity: CSSCYCLONE_SOURCE.complexity,
-      speed: CSSCYCLONE_SOURCE.speed,
-      stretch: CSSCYCLONE_SOURCE.stretch,
-      saturationSampling: CSSCYCLONE_PRESENTATION.saturationSampling,
-      minimumSaturation: CSSCYCLONE_PRESENTATION.minimumSaturation,
-      hueSampling: CSSCYCLONE_PRESENTATION.hueSampling,
-      particleColorAssignment: CSSCYCLONE_PRESENTATION.particleColorAssignment,
-      preparedPaletteHueSlotCount: CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount,
-      preparedPaletteAssignment: CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
-      maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
-    },
-    preparedStream: {
-      id: CSSCYCLONE_BANK.id,
-      seed: CSSCYCLONE_BANK.seed,
-      chunkCount: CSSCYCLONE_BANK.chunkCount,
-      chunkFrameCount: CSSCYCLONE_BANK.frameCount,
-      streamFrameCount: CSSCYCLONE_BANK.chunkCount * CSSCYCLONE_BANK.frameCount,
-      streamDurationMilliseconds:
-        CSSCYCLONE_BANK.chunkCount * CSSCYCLONE_BANK.frameCount * CSSCYCLONE_BANK.frameMilliseconds,
-      startupPaletteFamilies,
-      startupSelections,
-      startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
-      startupSilhouetteSampleFrameOffsets,
-      maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
-      startupColorProfile,
-      startupSelection: "session-crypto-random-balanced-source-palette-window-no-immediate-repeat",
-      handoff: "source-continuous-next-block-with-three-block-lookahead",
-    },
-    productParticleCount: CSSCYCLONE_BANK.particleCount,
-    viewDistance: CSSCYCLONE_SOURCE.viewDistance,
-    fieldOfViewDegrees: CSSCYCLONE_SOURCE.fieldOfViewDegrees,
-    startupWarmupMilliseconds: CSSCYCLONE_BANK.warmupFrames * CSSCYCLONE_BANK.frameMilliseconds
+  profileSelection: {
+    startupOnly: true,
+    desktopProfileId: "desktop",
+    mobileProfileId: "mobile",
+    mobileParticleBudget: CSSCYCLONE_BANKS.mobile.particleCount,
+    mobileLeafBudget: CSSCYCLONE_BANKS.mobile.particleCount * CSSCYCLONE_FACE_INDICES.length,
+    mobileCapabilityQuery: "(hover: none) and (pointer: coarse)",
+    mobileMaximumViewportWidth: 599,
   },
-  model: {
-    id: CSSCYCLONE_MODEL_ID,
-    manifestSha256: built.manifestSha256,
-    ...preparedModel.metrics
-  },
-  playback: {
-    catalogUrl: "/csscyclone/catalog.json",
-    catalogSha256,
-    catalogBytes: catalogBytes.byteLength,
-    chunkCount: CSSCYCLONE_BANK.chunkCount,
-    preparedBlockCount: blockEntries.length,
-    preparedFrameCount,
-    uniquePreparedTransformCount,
-    shapeTransformSelections,
-    preparedBlockEncodedBytes,
-    preparedBlockDecodedBytes,
-    residentBlockWindowCount,
-    maximumResidentBlockWindowDecodedBytes,
-    runtimeLookaheadBlockCount,
-    runtimePreparedStateMaterialization: false,
-  },
-  lighting: preparedLighting.contract,
+  profiles: Object.freeze(Object.fromEntries(preparedProfiles.map(({ profile, metadata }) =>
+    [profile.id, metadata]))),
   oracle: {
     sourceState: "pinned-continuous-source-translation-with-fixed-mt19937-authoring-seed",
     visual: "frame-zero-lighting-qualified-moving-highlight-approximate-full-scene-not-pixel-qualified"
@@ -263,19 +104,251 @@ await mkdir(dirname(outputRoot), { recursive: true });
 await rename(stagingRoot, outputRoot);
 console.log(JSON.stringify({
   outputRoot,
-  manifestSha256: built.manifestSha256,
-  ...preparedModel.metrics,
-  preparedChunkCount: CSSCYCLONE_BANK.chunkCount,
-  preparedBlockCount: blockEntries.length,
-  preparedFrameCount,
-  uniquePreparedTransformCount,
-  shapeTransformSelections,
-  preparedBlockEncodedBytes,
-  preparedBlockDecodedBytes,
-  residentBlockWindowCount,
-  maximumResidentBlockWindowDecodedBytes,
-  ...preparedLighting.metrics,
+  profiles: preparedProfiles.map(({ profile, built, metadata, metrics }) => ({
+    id: profile.id,
+    modelId: profile.modelId,
+    manifestSha256: built.manifestSha256,
+    retainedParticleRootCount: metadata.model.retainedParticleRootCount,
+    retainedPolygonLeafCount: metadata.model.retainedPolygonLeafCount,
+    ...metrics,
+  })),
 }, null, 2));
+
+async function prepareProfile(profile) {
+  const { bank, startupSelections } = profile;
+  const blocksPerChunk = bank.frameCount / blockFrameCount;
+  const blockCount = bank.chunkCount * blocksPerChunk;
+  if (!Number.isSafeInteger(blocksPerChunk)) {
+    throw new Error(`Cyclone ${profile.id} prepared chunk must divide into exact transport blocks`);
+  }
+  const lightingStream = createCyclonePreparedLightingStream({
+    assetRoot: profile.lightingAssetRoot,
+  });
+  const blockEntries = [];
+  const startupSelectionColorProfiles = new Map();
+  let preparedModel = null;
+  let preparedFrameCount = 0;
+  let uniquePreparedTransformCount = 0;
+  let shapeTransformSelections = 0;
+  let preparedBlockEncodedBytes = 0;
+  let preparedBlockDecodedBytes = 0;
+  let maximumResidentBlockPairDecodedBytes = 0;
+  let previousBlockDecodedBytes = 0;
+  let firstBlockDecodedBytes = 0;
+  for (const desktopSource of buildCycloneSourceChunks({ bank: CSSCYCLONE_BANKS.desktop })) {
+    const source = profile.id === "mobile"
+      ? selectCycloneSourceParticlePrefix(desktopSource, bank)
+      : desktopSource;
+    if (preparedModel === null) {
+      const result = buildCyclonePreparedModel({ source, modelId: profile.modelId });
+      preparedModel = Object.freeze({ model: result.model, metrics: result.metrics });
+    }
+    const preparedPlayback = buildCyclonePreparedPlayback({ source, modelId: profile.modelId });
+    const lighting = lightingStream.add(source);
+    for (const selection of startupSelections.filter((entry) =>
+      entry.chunkIndex === source.bank.chunkIndex)) {
+      startupSelectionColorProfiles.set(selection.id, analyzeStartupSelectionColors(source, selection));
+    }
+    for (let blockIndex = 0; blockIndex < blocksPerChunk; blockIndex += 1) {
+      const streamBlockIndex = source.bank.chunkIndex * blocksPerChunk + blockIndex;
+      const localStartFrameIndex = blockIndex * blockFrameCount;
+      const startFrameIndex = source.bank.startFrameIndex + localStartFrameIndex;
+      const blockPlayback = slicePreparedPlayback({
+        playback: preparedPlayback.playback,
+        blockIndex,
+        streamBlockIndex,
+        startFrameIndex,
+        localStartFrameIndex,
+        blockCount,
+        blocksPerChunk,
+      });
+      const blockLighting = Object.freeze({
+        schema: "csscyclone-prepared-lighting-block@1",
+        streamId: source.bank.streamId,
+        chunkIndex: source.bank.chunkIndex,
+        blockIndex,
+        streamBlockIndex,
+        startFrameIndex,
+        frameCount: blockFrameCount,
+        particleCount: source.bank.particleCount,
+        frameParticleColorStateIndices: lighting.frameParticleColorStateIndices.slice(
+          localStartFrameIndex,
+          localStartFrameIndex + blockFrameCount,
+        ),
+      });
+      const decoded = Buffer.from(`${JSON.stringify({
+        schema: "csscyclone-prepared-stream-block@1",
+        streamId: source.bank.streamId,
+        chunkIndex: source.bank.chunkIndex,
+        blockIndex,
+        streamBlockIndex,
+        startFrameIndex,
+        frameCount: blockFrameCount,
+        playback: blockPlayback,
+        lighting: blockLighting,
+      })}\n`);
+      const encoded = gzipSync(decoded, { level: 9 });
+      const encodedSha256 = sha256(encoded);
+      const decodedSha256 = sha256(decoded);
+      const assetUrl = `${profile.blockRoot}/block-${String(streamBlockIndex).padStart(3, "0")}-${encodedSha256}.bin`;
+      await writeBytes(join(stagingRoot, assetUrl.replace(/^\/csscyclone\//u, "")), encoded);
+      blockEntries.push(Object.freeze({
+        index: streamBlockIndex,
+        chunkIndex: source.bank.chunkIndex,
+        blockIndex,
+        startFrameIndex,
+        frameCount: blockFrameCount,
+        sourceContinuousFromPrevious: streamBlockIndex > 0,
+        assetUrl,
+        encoding: "gzip-newline-json",
+        byteLength: encoded.byteLength,
+        sha256: encodedSha256,
+        decodedByteLength: decoded.byteLength,
+        decodedSha256,
+      }));
+      preparedBlockEncodedBytes += encoded.byteLength;
+      preparedBlockDecodedBytes += decoded.byteLength;
+      if (streamBlockIndex === 0) firstBlockDecodedBytes = decoded.byteLength;
+      maximumResidentBlockPairDecodedBytes = Math.max(
+        maximumResidentBlockPairDecodedBytes,
+        previousBlockDecodedBytes + decoded.byteLength,
+      );
+      previousBlockDecodedBytes = decoded.byteLength;
+    }
+    preparedFrameCount += preparedPlayback.metrics.preparedFrameCount;
+    uniquePreparedTransformCount += preparedPlayback.metrics.uniquePreparedTransformCount;
+    shapeTransformSelections += preparedPlayback.metrics.shapeTransformSelections;
+  }
+  maximumResidentBlockPairDecodedBytes = Math.max(
+    maximumResidentBlockPairDecodedBytes,
+    previousBlockDecodedBytes + firstBlockDecodedBytes,
+  );
+  const startupColorProfile = buildStartupColorProfile(
+    startupSelections.map((selection) => startupSelectionColorProfiles.get(selection.id)),
+    bank,
+    startupSelections,
+  );
+  const preparedLighting = await lightingStream.finalize();
+  const catalogBytes = Buffer.from(`${JSON.stringify({
+    schema: "csscyclone-prepared-stream-catalog@1",
+    streamId: bank.id,
+    seed: bank.seed,
+    chunkCount: bank.chunkCount,
+    chunkFrameCount: bank.frameCount,
+    blockCount,
+    blocksPerChunk,
+    blockFrameCount,
+    frameMilliseconds: bank.frameMilliseconds,
+    streamFrameCount: bank.chunkCount * bank.frameCount,
+    streamDurationMilliseconds: bank.chunkCount * bank.frameCount * bank.frameMilliseconds,
+    startupPaletteFamilies,
+    startupSelections,
+    startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
+    startupSilhouetteSampleFrameOffsets,
+    maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
+    startupColorProfile,
+    selection: "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat",
+    playbackOrder: "source-continuous-ascending-chunks-with-one-terminal-stream-wrap",
+    runtimeLookaheadBlockCount: 1,
+    entries: blockEntries,
+  })}\n`);
+  const catalogSha256 = sha256(catalogBytes);
+  await writeBytes(
+    join(stagingRoot, profile.catalogUrl.replace(/^\/csscyclone\//u, "")),
+    catalogBytes,
+  );
+  if (preparedModel === null) throw new Error(`Cyclone ${profile.id} stream produced no prepared model`);
+  const built = await buildPolyMorphPackage(preparedModel.model);
+  const packageRoot = join(stagingRoot, "model", profile.modelId);
+  await mkdir(packageRoot, { recursive: true });
+  for (const [path, bytes] of built.files) await writeBytes(join(packageRoot, path), bytes);
+  await writeBytes(join(packageRoot, "manifest.json"), built.manifestBytes);
+  for (const asset of preparedLighting.assets) {
+    await writeBytes(
+      join(stagingRoot, asset.assetUrl.replace(/^\/csscyclone\//u, "")),
+      asset.bytes,
+    );
+  }
+  const metadata = Object.freeze({
+    id: profile.id,
+    particleSelection: profile.particleSelection,
+    presentation: Object.freeze({
+      sourceDefaults: Object.freeze({
+        cyclones: 1,
+        particles: CSSCYCLONE_BANKS.desktop.particleCount,
+        size: CSSCYCLONE_SOURCE.particleSize,
+        complexity: CSSCYCLONE_SOURCE.complexity,
+        speed: CSSCYCLONE_SOURCE.speed,
+        stretch: CSSCYCLONE_SOURCE.stretch,
+        saturationSampling: CSSCYCLONE_PRESENTATION.saturationSampling,
+        minimumSaturation: CSSCYCLONE_PRESENTATION.minimumSaturation,
+        hueSampling: CSSCYCLONE_PRESENTATION.hueSampling,
+        particleColorAssignment: CSSCYCLONE_PRESENTATION.particleColorAssignment,
+        preparedPaletteHueSlotCount: CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount,
+        preparedPaletteAssignment: CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
+        maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
+      }),
+      preparedStream: Object.freeze({
+        id: bank.id,
+        seed: bank.seed,
+        chunkCount: bank.chunkCount,
+        chunkFrameCount: bank.frameCount,
+        streamFrameCount: bank.chunkCount * bank.frameCount,
+        streamDurationMilliseconds: bank.chunkCount * bank.frameCount * bank.frameMilliseconds,
+        startupPaletteFamilies,
+        startupSelections,
+        startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
+        startupSilhouetteSampleFrameOffsets,
+        maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
+        startupColorProfile,
+        startupSelection: "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat",
+        handoff: "source-continuous-next-block-with-one-block-lookahead",
+      }),
+      productParticleCount: bank.particleCount,
+      productLeafCount: bank.particleCount * CSSCYCLONE_FACE_INDICES.length,
+      viewDistance: CSSCYCLONE_SOURCE.viewDistance,
+      fieldOfViewDegrees: CSSCYCLONE_SOURCE.fieldOfViewDegrees,
+      startupWarmupMilliseconds: bank.warmupFrames * bank.frameMilliseconds,
+    }),
+    model: Object.freeze({
+      id: profile.modelId,
+      manifestSha256: built.manifestSha256,
+      ...preparedModel.metrics,
+    }),
+    playback: Object.freeze({
+      catalogUrl: profile.catalogUrl,
+      catalogSha256,
+      catalogBytes: catalogBytes.byteLength,
+      chunkCount: bank.chunkCount,
+      preparedBlockCount: blockEntries.length,
+      preparedFrameCount,
+      uniquePreparedTransformCount,
+      shapeTransformSelections,
+      preparedBlockEncodedBytes,
+      preparedBlockDecodedBytes,
+      maximumResidentBlockPairDecodedBytes,
+      runtimeLookaheadBlockCount: 1,
+      runtimePreparedStateMaterialization: false,
+    }),
+    lighting: preparedLighting.contract,
+  });
+  return Object.freeze({
+    profile,
+    built,
+    metadata,
+    metrics: Object.freeze({
+      preparedChunkCount: bank.chunkCount,
+      preparedBlockCount: blockEntries.length,
+      preparedFrameCount,
+      uniquePreparedTransformCount,
+      shapeTransformSelections,
+      preparedBlockEncodedBytes,
+      preparedBlockDecodedBytes,
+      maximumResidentBlockPairDecodedBytes,
+      ...preparedLighting.metrics,
+    }),
+  });
+}
 
 function slicePreparedPlayback({
   playback,
@@ -283,6 +356,8 @@ function slicePreparedPlayback({
   streamBlockIndex,
   startFrameIndex,
   localStartFrameIndex,
+  blockCount,
+  blocksPerChunk,
 }) {
   const sourceRows = playback.frames.slice(
     localStartFrameIndex,
@@ -357,7 +432,7 @@ function analyzeStartupSelectionColors(source, selection) {
   });
 }
 
-function buildStartupColorProfile(selectionProfiles) {
+function buildStartupColorProfile(selectionProfiles, bank, startupSelections) {
   const familySelectionCounts = new Map(startupPaletteFamilies.map((family) => [family, 0]));
   const selectionIds = new Set();
   for (const selection of startupSelections) {
@@ -376,10 +451,10 @@ function buildStartupColorProfile(selectionProfiles) {
         typeof selection.id !== "string" || selection.id.length < 1 ||
         !startupPaletteFamilies.includes(selection.paletteFamily) ||
         !Number.isSafeInteger(selection.chunkIndex) || selection.chunkIndex < 0 ||
-        selection.chunkIndex >= CSSCYCLONE_BANK.chunkCount ||
+        selection.chunkIndex >= bank.chunkCount ||
         !Number.isSafeInteger(selection.startFrameIndex) || selection.startFrameIndex < 0 ||
         !Number.isSafeInteger(selection.frameCount) || selection.frameCount < 1 ||
-        selection.startFrameIndex + selection.frameCount > CSSCYCLONE_BANK.frameCount) ||
+        selection.startFrameIndex + selection.frameCount > bank.frameCount) ||
       !Number.isSafeInteger(familySelectionCount) || familySelectionCount < 1 ||
       [...familySelectionCounts.values()].some((count) => count !== familySelectionCount) ||
       new Set(startupSilhouetteSampleFrameOffsets).size !== startupSilhouetteSampleFrameOffsets.length ||


### PR DESCRIPTION
## Summary
- revert the three-block playback horizon and restore the original one-block handoff
- select a prepared 266-particle / 1,596-leaf mobile bank before mount while desktop remains 400 / 2,400
- remove the redundant Morph model wrapper after adoption and compose its fixed transform onto the existing PolyCSS scene
- lift only dark prepared colors, retain the three-family limit, and shuffle all five palette variants without replacement per session

## Verification
- pnpm test:cyclone (27/27)
- pnpm prepare:cyclone
- pnpm build:cyclone
- generated contracts: desktop 400/2,400; mobile 266/1,596; 216 blocks each; one-block lookahead; lighting atlas schema 7