### PR TITLE
fix(cyclone): cap mobile profile near 1000 leaves

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -2,8 +2,8 @@
 
 This adapter translates Really Slick Cyclone into one retained PolyCSS Morph
 graph. Desktop mounts the source-default 400 particle roots and mobile mounts a
-prepared prefix of 266 complete source particles. Every particle retains all six
-original solid-triangle leaves: 2,400 desktop leaves or 1,596 mobile leaves. The
+prepared prefix of 166 complete source particles. Every particle retains all six
+original solid-triangle leaves: 2,400 desktop leaves or 996 mobile leaves. The
 selected profile plays 24 source-continuous logical chunks of 450 prepared 20 ms
 transform states. The stream is transported as 216 one-second prepared blocks
 so decompression stays outside long animation frames. Source fixed-function
@@ -34,7 +34,7 @@ chooses between two expressive browser-reviewed source windows in that family.
 It never phases individual particles around a full hue wheel. This is an
 intentional presentation rather than an exact native-color or random-start
 claim. Mobile/coarse-pointer devices and viewports below 600px select the
-266-particle prepared profile before mount and use a 90-degree presentation
+166-particle prepared profile before mount and use a 90-degree presentation
 field of view instead of the source-default 80 degrees. Prepared motion and each
 particle's complete six-face topology are unchanged.
 

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -37,7 +37,7 @@ export const CSSCYCLONE_BANKS = Object.freeze({
     ...CSSCYCLONE_DESKTOP_BANK,
     id: "mobile-stream",
     name: "Cyclone Mobile",
-    particleCount: 266,
+    particleCount: 166,
   }),
 });
 

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -73,7 +73,7 @@ test("pins the current Really Slick Cyclone source profile", () => {
 
 test("prepares the mobile bank with fewer complete source particles", () => {
   assert.equal(CSSCYCLONE_BANKS.desktop.particleCount, 400);
-  assert.equal(CSSCYCLONE_BANKS.mobile.particleCount, 266);
+  assert.equal(CSSCYCLONE_BANKS.mobile.particleCount, 166);
   const desktopBank = {
     ...CSSCYCLONE_BANKS.desktop,
     warmupFrames: 2,
@@ -97,12 +97,12 @@ test("prepares the mobile bank with fewer complete source particles", () => {
     modelId: CSSCYCLONE_MODEL_IDS.mobile,
   });
   assert.equal(preparedModel.model.identity.id, "cyclone-mobile");
-  assert.equal(preparedModel.model.render.shapes.length, 266);
-  assert.equal(preparedModel.model.render.leaves.length, 1_596);
+  assert.equal(preparedModel.model.render.shapes.length, 166);
+  assert.equal(preparedModel.model.render.leaves.length, 996);
   assert.equal(preparedModel.metrics.polygonsPerParticle, 6);
-  assert.equal(preparedPlayback.playback.particleCount, 266);
-  assert.equal(preparedPlayback.playback.leafCount, 1_596);
-  assert.deepEqual(source.frames[0].particles, desktopSource.frames[0].particles.slice(0, 266));
+  assert.equal(preparedPlayback.playback.particleCount, 166);
+  assert.equal(preparedPlayback.playback.leafCount, 996);
+  assert.deepEqual(source.frames[0].particles, desktopSource.frames[0].particles.slice(0, 166));
 });
 
 test("widens only the mobile presentation field of view", () => {


### PR DESCRIPTION
## Summary
- reduce only the prepared mobile Cyclone prefix from 266 to 166 complete particles
- retain all six source faces per particle for 996 mobile DOM leaves
- keep desktop unchanged at 400 particles / 2,400 leaves

## Verification
- `pnpm test:cyclone` (27/27)
- `pnpm prepare:cyclone`
- `CSSCYCLONE_DEPLOY_BUILD=1 pnpm build:cyclone`
- generated mobile census: 166 roots / 996 leaves / 10,800 frames