### PR TITLE
fix(cyclone): decode full stream before playback

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -44,8 +44,9 @@ Startup uses `crypto.getRandomValues` to shuffle the five-family session bag and
 to select an audited source window and frame, excluding the previous exact
 window. Playback
 then follows the original source order. Each hash-bound
-gzip block prefetches its exact successor; only the active and lookahead blocks
-remain resident. The single terminal stream wrap is the only
+gzip transport fully fetches and decodes all 216 blocks behind the loading
+indicator before playback starts on both desktop and mobile. The single
+terminal stream wrap is the only
 non-source-continuous boundary.
 
 Source identity is pinned in `notes/references/source-lock.json`. Preparation

--- a/src/adapters/cyclone/src/csscyclone/client.mjs
+++ b/src/adapters/cyclone/src/csscyclone/client.mjs
@@ -68,10 +68,14 @@ export async function mountCycloneClient(host) {
     const initialBlockIndex = Math.floor(initialStreamFrameIndex / catalog.blockFrameCount);
     const initialBlockFrameIndex = initialStreamFrameIndex % catalog.blockFrameCount;
     const blockLoader = createCyclonePreparedBlockLoader(catalog);
-    const nextBlockIndex = (initialBlockIndex + 1) % catalog.blockCount;
-    blockLoader.retain([initialBlockIndex, nextBlockIndex]);
-    const [initialBlock, loadedLightingAsset] = await Promise.all([
+    const lookaheadBlockIndices = Array.from(
+      { length: catalog.runtimeLookaheadBlockCount },
+      (unused, offset) => (initialBlockIndex + offset + 1) % catalog.blockCount,
+    );
+    blockLoader.retain([initialBlockIndex, ...lookaheadBlockIndices]);
+    const [initialBlock, initialLookaheadBlocks, loadedLightingAsset] = await Promise.all([
       blockLoader.load(initialBlockIndex),
+      Promise.all(lookaheadBlockIndices.map((streamBlockIndex) => blockLoader.load(streamBlockIndex))),
       loadCyclonePreparedLightingAsset(profile.lighting, selection.paletteFamily),
     ]);
     lightingAsset = loadedLightingAsset;
@@ -85,14 +89,15 @@ export async function mountCycloneClient(host) {
       modelTransform,
       catalog,
       initialBlock,
+      initialLookaheadBlocks,
       initialFrameIndex: initialBlockFrameIndex,
       lighting: profile.lighting,
       lightingAsset,
       loadBlock(streamBlockIndex) {
         return blockLoader.load(streamBlockIndex);
       },
-      onBlockWindow(activeBlockIndex, pendingBlockIndex) {
-        blockLoader.retain([activeBlockIndex, pendingBlockIndex]);
+      onBlockWindow(streamBlockIndices) {
+        blockLoader.retain(streamBlockIndices);
       },
     });
     player.resize();

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -23,6 +23,7 @@ export function createCyclonePreparedPlayer({
   modelTransform,
   catalog,
   initialBlock,
+  initialLookaheadBlocks = [],
   initialFrameIndex,
   lighting,
   lightingAsset,
@@ -40,6 +41,7 @@ export function createCyclonePreparedPlayer({
     modelTransform,
     catalog,
     initialBlock,
+    initialLookaheadBlocks,
     initialFrameIndex,
     lighting,
     lightingAsset,
@@ -83,10 +85,10 @@ export function createCyclonePreparedPlayer({
   let playback = activeBlock.playback;
   let lightingFrames = activeBlock.lighting;
   let activeBlockIndex = activeBlock.streamBlockIndex;
-  let pendingBlock = null;
-  let pendingBlockIndex = null;
-  let pendingBlockPromise = null;
-  let pendingBlockError = null;
+  const pendingBlocks = new Map(initialLookaheadBlocks.map((block) => [
+    block.streamBlockIndex,
+    { block, promise: Promise.resolve(block), error: null },
+  ]));
   let paused = true;
   let destroyed = false;
   let frameRequest = null;
@@ -107,7 +109,7 @@ export function createCyclonePreparedPlayer({
   let lightingLeafAddressWrites = 0;
   let preparedChunkSwitchCount = 0;
   let preparedBlockSwitchCount = 0;
-  let preparedBlockPrefetchCount = 0;
+  let preparedBlockPrefetchCount = initialLookaheadBlocks.length;
   let runtimePreparedBlockWaitCount = 0;
   let preparedContinuousHandoffCount = 0;
   let preparedTerminalWrapCount = 0;
@@ -118,7 +120,7 @@ export function createCyclonePreparedPlayer({
   publishTransforms(playback.frames[initialFrameIndex]);
   publishLighting(initialFrameIndex, true);
   applyCount += 1;
-  queueNextBlock();
+  queueLookaheadBlocks();
 
   function publishTransforms(row) {
     for (let operation = 0; operation < row.length; operation += 2) {
@@ -155,45 +157,62 @@ export function createCyclonePreparedPlayer({
     applyCount += 1;
   }
 
-  function queueNextBlock() {
-    if (destroyed || pendingBlock || pendingBlockPromise) return pendingBlockPromise;
-    pendingBlockIndex = (activeBlockIndex + 1) % catalog.blockCount;
-    pendingBlockError = null;
-    preparedBlockPrefetchCount += 1;
-    onBlockWindow(activeBlockIndex, pendingBlockIndex);
-    pendingBlockPromise = Promise.resolve(loadBlock(pendingBlockIndex)).then((block) => {
-      if (destroyed) return null;
-      validateBlockBinding(block, catalog, mounted.model, lighting);
-      pendingBlock = block;
-      pendingBlockPromise = null;
-      return block;
-    }).catch((error) => {
-      pendingBlockError = error;
-      pendingBlockPromise = null;
-      onError(error);
-      return null;
-    });
-    return pendingBlockPromise;
+  function lookaheadBlockIndices() {
+    const indices = [];
+    for (let offset = 1; offset <= catalog.runtimeLookaheadBlockCount; offset += 1) {
+      const index = (activeBlockIndex + offset) % catalog.blockCount;
+      if (!indices.includes(index)) indices.push(index);
+    }
+    return indices;
+  }
+
+  function queueLookaheadBlocks() {
+    if (destroyed) return;
+    const indices = lookaheadBlockIndices();
+    const retainedIndices = new Set(indices);
+    onBlockWindow([activeBlockIndex, ...indices]);
+    for (const index of pendingBlocks.keys()) {
+      if (!retainedIndices.has(index)) pendingBlocks.delete(index);
+    }
+    for (const index of indices) {
+      if (pendingBlocks.has(index)) continue;
+      const pending = { block: null, promise: null, error: null };
+      preparedBlockPrefetchCount += 1;
+      pending.promise = Promise.resolve(loadBlock(index)).then((block) => {
+        if (destroyed || pendingBlocks.get(index) !== pending) return null;
+        validateBlockBinding(block, catalog, mounted.model, lighting);
+        pending.block = block;
+        return block;
+      }).catch((error) => {
+        if (pendingBlocks.get(index) === pending) pending.error = error;
+        onError(error);
+        return null;
+      });
+      pendingBlocks.set(index, pending);
+    }
   }
 
   async function activatePendingBlock() {
-    const waited = pendingBlock === null;
+    const nextBlockIndex = (activeBlockIndex + 1) % catalog.blockCount;
+    if (!pendingBlocks.has(nextBlockIndex)) queueLookaheadBlocks();
+    const pending = pendingBlocks.get(nextBlockIndex);
+    if (!pending) throw new Error(`Prepared Cyclone lookahead block ${nextBlockIndex} is unavailable`);
+    const waited = pending.block === null;
     if (waited) {
       runtimePreparedBlockWaitCount += 1;
-      if (pendingBlockError) throw pendingBlockError;
-      await (pendingBlockPromise ?? queueNextBlock());
+      if (pending.error) throw pending.error;
+      await pending.promise;
     }
-    if (!pendingBlock) throw pendingBlockError ?? new Error("Prepared Cyclone lookahead block is unavailable");
+    if (!pending.block) {
+      throw pending.error ?? new Error(`Prepared Cyclone lookahead block ${nextBlockIndex} is unavailable`);
+    }
     const previousBlockIndex = activeBlockIndex;
     const previousChunkIndex = activeBlock.chunkIndex;
-    activeBlock = pendingBlock;
-    activeBlockIndex = pendingBlockIndex;
+    activeBlock = pending.block;
+    activeBlockIndex = nextBlockIndex;
     playback = activeBlock.playback;
     lightingFrames = activeBlock.lighting;
-    pendingBlock = null;
-    pendingBlockIndex = null;
-    pendingBlockPromise = null;
-    pendingBlockError = null;
+    pendingBlocks.delete(nextBlockIndex);
     frameIndex = 0;
     publishTransforms(playback.frames[0]);
     publishLighting(0);
@@ -202,7 +221,7 @@ export function createCyclonePreparedPlayer({
     if (activeBlockIndex === previousBlockIndex + 1) preparedContinuousHandoffCount += 1;
     else preparedTerminalWrapCount += 1;
     if (activeBlock.chunkIndex !== previousChunkIndex) preparedChunkSwitchCount += 1;
-    queueNextBlock();
+    queueLookaheadBlocks();
     return waited;
   }
 
@@ -305,6 +324,8 @@ export function createCyclonePreparedPlayer({
 
   function snapshot() {
     target.assertStableDomIdentity();
+    const pendingBlockIndices = lookaheadBlockIndices();
+    const nextPendingBlock = pendingBlocks.get(pendingBlockIndices[0]);
     return Object.freeze({
       paused,
       frameIndex,
@@ -316,8 +337,10 @@ export function createCyclonePreparedPlayer({
       streamDurationMilliseconds: catalog.streamDurationMilliseconds,
       activeBlockIndex,
       activeChunkIndex: activeBlock.chunkIndex,
-      pendingBlockIndex,
-      pendingBlockReady: pendingBlock !== null,
+      pendingBlockIndex: pendingBlockIndices[0] ?? null,
+      pendingBlockReady: nextPendingBlock?.block !== null && nextPendingBlock?.block !== undefined,
+      pendingBlockIndices: Object.freeze(pendingBlockIndices),
+      pendingBlockReadyCount: pendingBlockIndices.filter((index) => pendingBlocks.get(index)?.block).length,
       schedulerLeadMilliseconds,
       schedulerFrameRequestCount,
       schedulerFrameCallbackCount,
@@ -383,6 +406,7 @@ function validateBinding(
   modelTransform,
   catalog,
   initialBlock,
+  initialLookaheadBlocks,
   initialFrameIndex,
   lighting,
   lightingAsset,
@@ -393,7 +417,15 @@ function validateBinding(
   if (typeof modelTransform !== "string" || !modelTransform.startsWith("matrix3d(") ||
       catalog?.schema !== CATALOG_SCHEMA ||
       catalog.blockCount !== catalog.entries?.length ||
-      catalog.runtimeLookaheadBlockCount !== 1 ||
+      !Number.isSafeInteger(catalog.runtimeLookaheadBlockCount) ||
+      catalog.runtimeLookaheadBlockCount < 1 ||
+      catalog.runtimeLookaheadBlockCount > catalog.blockCount ||
+      !Array.isArray(initialLookaheadBlocks) ||
+      initialLookaheadBlocks.length > catalog.runtimeLookaheadBlockCount ||
+      new Set(initialLookaheadBlocks.map((block) => block?.streamBlockIndex)).size !==
+        initialLookaheadBlocks.length ||
+      initialLookaheadBlocks.some((block, index) =>
+        block?.streamBlockIndex !== (initialBlock.streamBlockIndex + index + 1) % catalog.blockCount) ||
       lighting?.schema !== LIGHTING_SCHEMA ||
       lighting.streamId !== catalog.streamId ||
       lighting.chunkCount !== catalog.chunkCount ||
@@ -413,6 +445,9 @@ function validateBinding(
     throw new Error("Cyclone prepared stream binding drifted");
   }
   validateBlockBinding(initialBlock, catalog, mounted.model, lighting);
+  for (const block of initialLookaheadBlocks) {
+    validateBlockBinding(block, catalog, mounted.model, lighting);
+  }
 }
 
 function validateBlockBinding(block, catalog, model, lighting) {

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -206,7 +206,9 @@ function validateCatalog(catalog) {
         !Number.isSafeInteger(frameOffset) || frameOffset < 0 ||
         catalog.startupSelections.some((selection) => frameOffset >= selection.frameCount)) ||
       catalog.selection !== STARTUP_SELECTION ||
-      catalog.runtimeLookaheadBlockCount !== 1 ||
+      !Number.isSafeInteger(catalog.runtimeLookaheadBlockCount) ||
+      catalog.runtimeLookaheadBlockCount < 1 ||
+      catalog.runtimeLookaheadBlockCount >= catalog.blockCount ||
       catalog.entries.some((entry, index) => entry?.index !== index ||
         entry.chunkIndex !== Math.floor(index / catalog.blocksPerChunk) ||
         entry.blockIndex !== index % catalog.blocksPerChunk ||

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -22,7 +22,11 @@ test.after(() => {
   else globalThis.HTMLElement = originalHTMLElement;
 });
 
-function fixture() {
+function fixture({
+  blockCount = 1,
+  runtimeLookaheadBlockCount = 1,
+  initialLookaheadBlockCount = 0,
+} = {}) {
   let now = 0;
   let nextRequestId = 0;
   const frames = new Map();
@@ -37,8 +41,8 @@ function fixture() {
     chunkIndex: 0,
     blockIndex: 0,
     chunkCount: 1,
-    blockCount: 1,
-    blocksPerChunk: 1,
+    blockCount,
+    blocksPerChunk: blockCount,
     startFrameIndex: 0,
     frameCount: 4,
     particleCount: 2,
@@ -58,7 +62,7 @@ function fixture() {
     schema: "csscyclone-prepared-smooth-lighting-atlas@7",
     streamId: "stream",
     chunkCount: 1,
-    chunkFrameCount: 4,
+    chunkFrameCount: blockCount * 4,
     leafCount: 2,
     facesPerParticle: 1,
     colorStateCount: 1,
@@ -74,39 +78,47 @@ function fixture() {
     variants: [{ paletteFamily: "blue", assetSha256: "hash" }],
     runtime: { lightingCalculations: 0, atlasConstruction: 0 },
   };
-  const block = {
-    schema: "csscyclone-prepared-stream-block@1",
-    streamId: "stream",
-    streamBlockIndex: 0,
-    chunkIndex: 0,
-    blockIndex: 0,
-    startFrameIndex: 0,
-    frameCount: 4,
-    playback,
-    lighting: {
-      schema: "csscyclone-prepared-lighting-block@1",
+  const blocks = Array.from({ length: blockCount }, (_, streamBlockIndex) => {
+    const blockPlayback = {
+      ...playback,
+      streamBlockIndex,
+      blockIndex: streamBlockIndex,
+      startFrameIndex: streamBlockIndex * 4,
+    };
+    return {
+      schema: "csscyclone-prepared-stream-block@1",
       streamId: "stream",
-      streamBlockIndex: 0,
+      streamBlockIndex,
       chunkIndex: 0,
-      blockIndex: 0,
-      startFrameIndex: 0,
+      blockIndex: streamBlockIndex,
+      startFrameIndex: streamBlockIndex * 4,
       frameCount: 4,
-      particleCount: 2,
-      frameParticleColorStateIndices: [[0, 0], [0, 0], [0, 0], [0, 0]],
-    },
-  };
+      playback: blockPlayback,
+      lighting: {
+        schema: "csscyclone-prepared-lighting-block@1",
+        streamId: "stream",
+        streamBlockIndex,
+        chunkIndex: 0,
+        blockIndex: streamBlockIndex,
+        startFrameIndex: streamBlockIndex * 4,
+        frameCount: 4,
+        particleCount: 2,
+        frameParticleColorStateIndices: [[0, 0], [0, 0], [0, 0], [0, 0]],
+      },
+    };
+  });
   const catalog = {
     schema: "csscyclone-prepared-stream-catalog@1",
     streamId: "stream",
     chunkCount: 1,
-    chunkFrameCount: 4,
-    blockCount: 1,
-    entries: [{}],
-    blocksPerChunk: 1,
+    chunkFrameCount: blockCount * 4,
+    blockCount,
+    entries: Array.from({ length: blockCount }, () => ({})),
+    blocksPerChunk: blockCount,
     blockFrameCount: 4,
-    runtimeLookaheadBlockCount: 1,
-    streamFrameCount: 4,
-    streamDurationMilliseconds: 80,
+    runtimeLookaheadBlockCount,
+    streamFrameCount: blockCount * 4,
+    streamDurationMilliseconds: blockCount * 80,
   };
   const mounted = {
     model: {
@@ -124,11 +136,13 @@ function fixture() {
     assertStableDomIdentity: identity,
     destroy: identity,
   };
+  const loadBlockCalls = [];
   const player = createCyclonePreparedPlayer({
     mounted,
     modelTransform: "matrix3d(1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, -400, 1)",
     catalog,
-    initialBlock: block,
+    initialBlock: blocks[0],
+    initialLookaheadBlocks: blocks.slice(1, initialLookaheadBlockCount + 1),
     initialFrameIndex: 0,
     lighting,
     lightingAsset: {
@@ -139,7 +153,10 @@ function fixture() {
       hueSlots: [0.5, 2 / 3, 5 / 6],
       destroy: identity,
     },
-    loadBlock: async () => block,
+    loadBlock: async (streamBlockIndex) => {
+      loadBlockCalls.push(streamBlockIndex);
+      return blocks[streamBlockIndex];
+    },
     readNow: () => now,
     requestFrame(callback) {
       const id = ++nextRequestId;
@@ -159,6 +176,7 @@ function fixture() {
     shapeElements,
     frames,
     delays,
+    loadBlockCalls,
     setNow(value) { now = value; },
     fireDelay() {
       const [id, request] = delays.entries().next().value;
@@ -189,6 +207,30 @@ test("hands each prepared publication from its deadline timer to requestAnimatio
   assert.equal(stats.runtimeSchedulerTransport, "deadline-setTimeout-requestAnimationFrame-prepared-publication");
   assert.equal(stats.schedulerFrameCallbackCount, 1);
   assert.equal(stats.schedulerDelayCallbackCount, 1);
+});
+
+test("starts only after the complete prepared stream is decoded", async () => {
+  const state = fixture({
+    blockCount: 5,
+    runtimeLookaheadBlockCount: 4,
+    initialLookaheadBlockCount: 4,
+  });
+  assert.deepEqual(state.player.stats().pendingBlockIndices, [1, 2, 3, 4]);
+  assert.equal(state.player.stats().pendingBlockReadyCount, 4);
+  assert.deepEqual(state.loadBlockCalls, []);
+
+  state.player.resume();
+  state.fireDelay();
+  state.setNow(81);
+  await state.fireFrame();
+  await Promise.resolve();
+
+  const stats = state.player.stats();
+  assert.equal(stats.activeBlockIndex, 1);
+  assert.deepEqual(stats.pendingBlockIndices, [2, 3, 4, 0]);
+  assert.equal(stats.pendingBlockReadyCount, 4);
+  assert.equal(stats.runtimePreparedBlockWaitCount, 0);
+  assert.deepEqual(state.loadBlockCalls, [0]);
 });
 
 test("collapses missed prepared frames once at the next paint-aligned callback", async () => {

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -55,7 +55,7 @@ const catalog = Object.freeze({
       });
     })),
   }),
-  runtimeLookaheadBlockCount: 1,
+  runtimeLookaheadBlockCount: 3,
   entries: Object.freeze(Array.from({ length: 216 }, (_, index) => Object.freeze({
     index,
     chunkIndex: Math.floor(index / 9),

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -118,6 +118,7 @@ async function prepareProfile(profile) {
   const { bank, startupSelections } = profile;
   const blocksPerChunk = bank.frameCount / blockFrameCount;
   const blockCount = bank.chunkCount * blocksPerChunk;
+  const runtimeLookaheadBlockCount = blockCount - 1;
   if (!Number.isSafeInteger(blocksPerChunk)) {
     throw new Error(`Cyclone ${profile.id} prepared chunk must divide into exact transport blocks`);
   }
@@ -132,9 +133,6 @@ async function prepareProfile(profile) {
   let shapeTransformSelections = 0;
   let preparedBlockEncodedBytes = 0;
   let preparedBlockDecodedBytes = 0;
-  let maximumResidentBlockPairDecodedBytes = 0;
-  let previousBlockDecodedBytes = 0;
-  let firstBlockDecodedBytes = 0;
   for (const desktopSource of buildCycloneSourceChunks({ bank: CSSCYCLONE_BANKS.desktop })) {
     const source = profile.id === "mobile"
       ? selectCycloneSourceParticlePrefix(desktopSource, bank)
@@ -208,21 +206,16 @@ async function prepareProfile(profile) {
       }));
       preparedBlockEncodedBytes += encoded.byteLength;
       preparedBlockDecodedBytes += decoded.byteLength;
-      if (streamBlockIndex === 0) firstBlockDecodedBytes = decoded.byteLength;
-      maximumResidentBlockPairDecodedBytes = Math.max(
-        maximumResidentBlockPairDecodedBytes,
-        previousBlockDecodedBytes + decoded.byteLength,
-      );
-      previousBlockDecodedBytes = decoded.byteLength;
     }
     preparedFrameCount += preparedPlayback.metrics.preparedFrameCount;
     uniquePreparedTransformCount += preparedPlayback.metrics.uniquePreparedTransformCount;
     shapeTransformSelections += preparedPlayback.metrics.shapeTransformSelections;
   }
-  maximumResidentBlockPairDecodedBytes = Math.max(
-    maximumResidentBlockPairDecodedBytes,
-    previousBlockDecodedBytes + firstBlockDecodedBytes,
-  );
+  const residentBlockWindowCount = runtimeLookaheadBlockCount + 1;
+  const maximumResidentBlockWindowDecodedBytes = Math.max(...blockEntries.map((unused, startIndex) =>
+    Array.from({ length: residentBlockWindowCount }, (ignored, offset) =>
+      blockEntries[(startIndex + offset) % blockEntries.length].decodedByteLength)
+      .reduce((total, byteLength) => total + byteLength, 0)));
   const startupColorProfile = buildStartupColorProfile(
     startupSelections.map((selection) => startupSelectionColorProfiles.get(selection.id)),
     bank,
@@ -249,7 +242,7 @@ async function prepareProfile(profile) {
     startupColorProfile,
     selection: "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat",
     playbackOrder: "source-continuous-ascending-chunks-with-one-terminal-stream-wrap",
-    runtimeLookaheadBlockCount: 1,
+    runtimeLookaheadBlockCount,
     entries: blockEntries,
   })}\n`);
   const catalogSha256 = sha256(catalogBytes);
@@ -302,7 +295,7 @@ async function prepareProfile(profile) {
         maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
         startupColorProfile,
         startupSelection: "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat",
-        handoff: "source-continuous-next-block-with-one-block-lookahead",
+        handoff: "source-continuous-full-stream-decoded-before-playback",
       }),
       productParticleCount: bank.particleCount,
       productLeafCount: bank.particleCount * CSSCYCLONE_FACE_INDICES.length,
@@ -326,8 +319,9 @@ async function prepareProfile(profile) {
       shapeTransformSelections,
       preparedBlockEncodedBytes,
       preparedBlockDecodedBytes,
-      maximumResidentBlockPairDecodedBytes,
-      runtimeLookaheadBlockCount: 1,
+      residentBlockWindowCount,
+      maximumResidentBlockWindowDecodedBytes,
+      runtimeLookaheadBlockCount,
       runtimePreparedStateMaterialization: false,
     }),
     lighting: preparedLighting.contract,
@@ -344,7 +338,8 @@ async function prepareProfile(profile) {
       shapeTransformSelections,
       preparedBlockEncodedBytes,
       preparedBlockDecodedBytes,
-      maximumResidentBlockPairDecodedBytes,
+      residentBlockWindowCount,
+      maximumResidentBlockWindowDecodedBytes,
       ...preparedLighting.metrics,
     }),
   });


### PR DESCRIPTION
## Summary
- keep the loading state active until all 216 prepared blocks are fetched, verified, decoded, parsed, and resident
- start playback only with the complete 216-second prepared stream available on desktop and mobile
- maintain source-continuous handoffs without runtime block-boundary waits
- keep topology unchanged: desktop 400/2,400; mobile 166/996

## Evidence
- production Pixel baseline after the 996-leaf deploy: ~59 FPS, but 15 decode waits across 28 block transitions
- `pnpm test:cyclone` (28/28), including full-stream residency and zero-wait handoff
- `pnpm prepare:cyclone`
- `CSSCYCLONE_DEPLOY_BUILD=1 pnpm build:cyclone`
- generated resident window: 216/216 blocks for both profiles