### PR TITLE
fix(cyclone): compact prepared motion transport

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -44,9 +44,13 @@ Startup uses `crypto.getRandomValues` to shuffle the five-family session bag and
 to select an audited source window and frame, excluding the previous exact
 window. Playback
 then follows the original source order. Each hash-bound
-gzip transport fully fetches and decodes all 216 blocks behind the loading
-indicator before playback starts on both desktop and mobile. The single
-terminal stream wrap is the only
+gzip transport stores shared source control points and widths, one initial
+state per particle, sparse reset events, and flat `Uint16` lighting indices;
+it does not store repeated CSS transform strings. It fetches and decodes the active block plus 11 successors behind
+the loading indicator on both desktop and mobile. Playback maintains that
+12-second bounded resident window, so each replacement block starts loading
+11 seconds before use and uses the established incremental decode pattern to
+keep preparation slices bounded during playback. The single terminal stream wrap is the only
 non-source-continuous boundary.
 
 Source identity is pinned in `notes/references/source-lock.json`. Preparation

--- a/src/adapters/cyclone/src/csscyclone/client.mjs
+++ b/src/adapters/cyclone/src/csscyclone/client.mjs
@@ -94,7 +94,7 @@ export async function mountCycloneClient(host) {
       lighting: profile.lighting,
       lightingAsset,
       loadBlock(streamBlockIndex) {
-        return blockLoader.load(streamBlockIndex);
+        return blockLoader.load(streamBlockIndex, { incremental: true });
       },
       onBlockWindow(streamBlockIndices) {
         blockLoader.retain(streamBlockIndices);

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 import { createPolyMorphPreparedDomTarget } from "@layoutit/polycss-morph";
+import {
+  CSSCYCLONE_LIGHTING_BLOCK_SCHEMA,
+  CSSCYCLONE_PLAYBACK_SCHEMA,
+} from "../shared/csscyclone/preparedBlockTransport.mjs";
 
 const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@1";
-const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@1";
-const PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@3";
+const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@2";
 const LIGHTING_SCHEMA = "csscyclone-prepared-smooth-lighting-atlas@7";
-const LIGHTING_BLOCK_SCHEMA = "csscyclone-prepared-lighting-block@1";
 const SOURCE_FIELD_OF_VIEW_DEGREES = 80;
 const MOBILE_FIELD_OF_VIEW_DEGREES = 90;
 const MOBILE_MAX_WIDTH = 600;
@@ -117,23 +119,24 @@ export function createCyclonePreparedPlayer({
   const lightingLeafBindingWrites = leafElements.length;
   let currentParticleColorStateIndices = [];
 
-  publishTransforms(playback.frames[initialFrameIndex]);
+  publishTransforms(initialFrameIndex);
   publishLighting(initialFrameIndex, true);
   applyCount += 1;
   queueLookaheadBlocks();
 
-  function publishTransforms(row) {
-    for (let operation = 0; operation < row.length; operation += 2) {
-      const particleIndex = row[operation];
-      const transformIndex = row[operation + 1];
-      shapeTransformWrites += Number(target.shapes[particleIndex].writeTransform(playback.transforms[transformIndex]));
+  function publishTransforms(nextFrameIndex) {
+    const frameOffset = nextFrameIndex * playback.particleCount;
+    for (let particleIndex = 0; particleIndex < playback.particleCount; particleIndex += 1) {
+      shapeTransformWrites += Number(target.shapes[particleIndex].writeTransform(
+        playback.transforms[frameOffset + particleIndex],
+      ));
     }
   }
 
   function publishLighting(nextFrameIndex, force = false) {
-    const nextStateIndices = lightingFrames.frameParticleColorStateIndices[nextFrameIndex];
-    for (let particleIndex = 0; particleIndex < nextStateIndices.length; particleIndex += 1) {
-      const nextStateIndex = nextStateIndices[particleIndex];
+    const frameOffset = nextFrameIndex * playback.particleCount;
+    for (let particleIndex = 0; particleIndex < playback.particleCount; particleIndex += 1) {
+      const nextStateIndex = lightingFrames.frameParticleColorStateIndices[frameOffset + particleIndex];
       if (!force && nextStateIndex === currentParticleColorStateIndices[particleIndex]) continue;
       const leafOffset = particleIndex * lighting.facesPerParticle;
       const tileOffset = nextStateIndex * lighting.facesPerParticle;
@@ -142,15 +145,15 @@ export function createCyclonePreparedPlayer({
           lighting.tileBackgroundPositions[tileOffset + faceIndex];
         if (!force) lightingLeafAddressWrites += 1;
       }
+      currentParticleColorStateIndices[particleIndex] = nextStateIndex;
     }
-    currentParticleColorStateIndices = [...nextStateIndices];
   }
 
   function advanceTo(nextFrameIndex) {
     if (frameIndex === nextFrameIndex) return;
     const distance = nextFrameIndex - frameIndex;
     if (distance < 1) throw new RangeError("Cyclone cannot rewind across a prepared block boundary");
-    publishTransforms(playback.frames[nextFrameIndex]);
+    publishTransforms(nextFrameIndex);
     publishLighting(nextFrameIndex);
     if (distance > 1) collapsedFrameCount += distance - 1;
     frameIndex = nextFrameIndex;
@@ -214,7 +217,7 @@ export function createCyclonePreparedPlayer({
     lightingFrames = activeBlock.lighting;
     pendingBlocks.delete(nextBlockIndex);
     frameIndex = 0;
-    publishTransforms(playback.frames[0]);
+    publishTransforms(0);
     publishLighting(0);
     applyCount += 1;
     preparedBlockSwitchCount += 1;
@@ -305,7 +308,7 @@ export function createCyclonePreparedPlayer({
     const wasPaused = paused;
     if (!wasPaused) pause();
     if (nextFrameIndex !== frameIndex) {
-      publishTransforms(playback.frames[nextFrameIndex]);
+      publishTransforms(nextFrameIndex);
       publishLighting(nextFrameIndex);
       frameIndex = nextFrameIndex;
       applyCount += 1;
@@ -370,9 +373,8 @@ export function createCyclonePreparedPlayer({
       runtimeAtlasRasterizationCount: 0,
       runtimeLightingCalculationCount: 0,
       runtimeLightingAtlasConstructionCount: 0,
-      runtimeMatrixFormattingCount: 0,
+      runtimeFrameMatrixFormattingCount: 0,
       runtimeIdLookupCount: 0,
-      runtimePreparedStateMaterializationCount: 0,
       runtimeDomGrowth: false,
       retainedModelWrapperCount: 0,
       retainedDomStable: true,
@@ -461,7 +463,7 @@ function validateBlockBinding(block, catalog, model, lighting) {
       block.blockIndex !== block.streamBlockIndex % catalog.blocksPerChunk ||
       block.startFrameIndex !== block.streamBlockIndex * catalog.blockFrameCount ||
       block.frameCount !== catalog.blockFrameCount ||
-      playback?.schema !== PLAYBACK_SCHEMA ||
+      playback?.schema !== CSSCYCLONE_PLAYBACK_SCHEMA ||
       playback.modelId !== model.identity.id ||
       playback.streamId !== catalog.streamId ||
       playback.streamBlockIndex !== block.streamBlockIndex ||
@@ -472,12 +474,11 @@ function validateBlockBinding(block, catalog, model, lighting) {
       playback.blocksPerChunk !== catalog.blocksPerChunk ||
       playback.startFrameIndex !== block.startFrameIndex ||
       playback.frameCount !== block.frameCount ||
-      playback.frames?.length !== playback.frameCount ||
       playback.particleCount !== model.render.shapes.length ||
       playback.leafCount !== model.render.leaves.length ||
-      playback.mounted?.shapeTransformIndices?.length !== playback.particleCount ||
-      playback.frames.some((row) => row?.length !== playback.particleCount * 2) ||
-      lightingFrames?.schema !== LIGHTING_BLOCK_SCHEMA ||
+      playback.transforms?.length !== playback.frameCount * playback.particleCount ||
+      playback.transforms.some((transform) => typeof transform !== "string") ||
+      lightingFrames?.schema !== CSSCYCLONE_LIGHTING_BLOCK_SCHEMA ||
       lightingFrames.streamId !== catalog.streamId ||
       lightingFrames.streamBlockIndex !== block.streamBlockIndex ||
       lightingFrames.chunkIndex !== block.chunkIndex ||
@@ -485,10 +486,10 @@ function validateBlockBinding(block, catalog, model, lighting) {
       lightingFrames.startFrameIndex !== block.startFrameIndex ||
       lightingFrames.frameCount !== playback.frameCount ||
       lightingFrames.particleCount !== playback.particleCount ||
-      lightingFrames.frameParticleColorStateIndices?.length !== playback.frameCount ||
-      lightingFrames.frameParticleColorStateIndices.some((row) => row?.length !== playback.particleCount ||
-        row.some((stateIndex) => !Number.isSafeInteger(stateIndex) || stateIndex < 0 ||
-          stateIndex >= lighting.colorStateCount))) {
+      !(lightingFrames.frameParticleColorStateIndices instanceof Uint16Array) ||
+      lightingFrames.frameParticleColorStateIndices.length !== playback.frameCount * playback.particleCount ||
+      lightingFrames.frameParticleColorStateIndices.some((stateIndex) =>
+        stateIndex < 0 || stateIndex >= lighting.colorStateCount)) {
     throw new Error(`Cyclone prepared block ${block?.streamBlockIndex ?? "unknown"} binding drifted`);
   }
 }

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -1,7 +1,14 @@
+import {
+  CSSCYCLONE_BLOCK_ENCODING,
+  CSSCYCLONE_LIGHTING_BLOCK_SCHEMA,
+  CSSCYCLONE_PLAYBACK_SCHEMA,
+  decodeCyclonePreparedBlock,
+  decodeCyclonePreparedBlockIncrementally,
+} from "../shared/csscyclone/preparedBlockTransport.mjs";
+
 const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@1";
-const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@1";
-const PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@3";
-const LIGHTING_BLOCK_SCHEMA = "csscyclone-prepared-lighting-block@1";
+const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@2";
+const RUNTIME_LOOKAHEAD_BLOCK_COUNT = 11;
 const STARTUP_HUE_SECTOR_NAMES = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
 const STARTUP_PALETTE_FAMILIES = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
 const STARTUP_SILHOUETTE_SAMPLING = "browser-reviewed-expressive-source-windows";
@@ -88,9 +95,17 @@ export function createCyclonePreparedBlockLoader(catalog) {
   let releaseCount = 0;
   let residentDecodedBytes = 0;
   let peakResidentDecodedBytes = 0;
+  let residentPreparedCssStringBytes = 0;
+  let peakResidentPreparedCssStringBytes = 0;
+  let preparedMatrixExpansionCount = 0;
+  let incrementalDecodeRequestCount = 0;
+  let incrementalDecodeCompletedBlockCount = 0;
+  let incrementalDecodeSliceCount = 0;
+  let incrementalDecodeOperationCount = 0;
+  let incrementalDecodeMaximumSliceMilliseconds = 0;
   let destroyed = false;
 
-  async function load(streamBlockIndex) {
+  async function load(streamBlockIndex, { incremental = false } = {}) {
     if (destroyed) throw new Error("Prepared Cyclone block loader is destroyed");
     const descriptor = catalog.entries[streamBlockIndex];
     if (!descriptor || descriptor.index !== streamBlockIndex) {
@@ -109,13 +124,40 @@ export function createCyclonePreparedBlockLoader(catalog) {
         descriptor.decodedSha256,
         `decoded block ${streamBlockIndex}`,
       );
-      const block = JSON.parse(new TextDecoder().decode(decoded));
+      if (incremental) incrementalDecodeRequestCount += 1;
+      const block = incremental
+        ? await decodeCyclonePreparedBlockIncrementally(decoded, descriptor, catalog, {
+          isCurrent: () => !destroyed && desiredBlockIndices.has(streamBlockIndex),
+          onSlice(operationCount, durationMilliseconds) {
+            incrementalDecodeSliceCount += 1;
+            incrementalDecodeOperationCount += operationCount;
+            incrementalDecodeMaximumSliceMilliseconds = Math.max(
+              incrementalDecodeMaximumSliceMilliseconds,
+              durationMilliseconds,
+            );
+          },
+        })
+        : decodeCyclonePreparedBlock(decoded, descriptor, catalog);
+      if (block === null) {
+        throw new Error(`Prepared Cyclone block ${streamBlockIndex} incremental decode was cancelled`);
+      }
       validateBlock(block, descriptor, catalog);
-      const record = Object.freeze({ block, decodedByteLength: decoded.byteLength });
+      const record = Object.freeze({
+        block,
+        decodedByteLength: decoded.byteLength,
+        preparedCssStringByteLength: block.preparedCssStringByteLength,
+      });
       records.set(streamBlockIndex, record);
       loadCount += 1;
+      if (incremental) incrementalDecodeCompletedBlockCount += 1;
+      preparedMatrixExpansionCount += block.preparedMatrixExpansionCount;
       residentDecodedBytes += decoded.byteLength;
       peakResidentDecodedBytes = Math.max(peakResidentDecodedBytes, residentDecodedBytes);
+      residentPreparedCssStringBytes += block.preparedCssStringByteLength;
+      peakResidentPreparedCssStringBytes = Math.max(
+        peakResidentPreparedCssStringBytes,
+        residentPreparedCssStringBytes,
+      );
       if (!desiredBlockIndices.has(streamBlockIndex)) release(streamBlockIndex, record);
       return block;
     })();
@@ -143,6 +185,7 @@ export function createCyclonePreparedBlockLoader(catalog) {
     if (!record?.block || records.get(streamBlockIndex) !== record) return;
     records.delete(streamBlockIndex);
     residentDecodedBytes -= record.decodedByteLength;
+    residentPreparedCssStringBytes -= record.preparedCssStringByteLength;
     releaseCount += 1;
   }
 
@@ -157,6 +200,14 @@ export function createCyclonePreparedBlockLoader(catalog) {
         residentBlockCount: [...records.values()].filter((record) => record?.block).length,
         residentDecodedBytes,
         peakResidentDecodedBytes,
+        residentPreparedCssStringBytes,
+        peakResidentPreparedCssStringBytes,
+        preparedMatrixExpansionCount,
+        incrementalDecodeRequestCount,
+        incrementalDecodeCompletedBlockCount,
+        incrementalDecodeSliceCount,
+        incrementalDecodeOperationCount,
+        incrementalDecodeMaximumSliceMilliseconds,
         desiredBlockIndices: Object.freeze([...desiredBlockIndices].sort((left, right) => left - right)),
       });
     },
@@ -170,6 +221,17 @@ export function createCyclonePreparedBlockLoader(catalog) {
 function validateCatalog(catalog) {
   if (catalog?.schema !== CATALOG_SCHEMA ||
       typeof catalog.streamId !== "string" ||
+      typeof catalog.modelId !== "string" || catalog.modelId.length < 1 ||
+      !Number.isSafeInteger(catalog.particleCount) || catalog.particleCount < 1 ||
+      !Number.isSafeInteger(catalog.leafCount) || catalog.leafCount !== catalog.particleCount * 6 ||
+      catalog.playbackSchema !== CSSCYCLONE_PLAYBACK_SCHEMA ||
+      catalog.lightingBlockSchema !== CSSCYCLONE_LIGHTING_BLOCK_SCHEMA ||
+      catalog.sourceTransformProfile?.controlPointCount !== 6 ||
+      !Number.isFinite(catalog.sourceTransformProfile?.speed) || catalog.sourceTransformProfile.speed <= 0 ||
+      !Number.isSafeInteger(catalog.sourceTransformProfile?.complexity) ||
+      catalog.sourceTransformProfile.complexity < 1 ||
+      !Number.isFinite(catalog.sourceTransformProfile?.particleSize) ||
+      catalog.sourceTransformProfile.particleSize <= 0 ||
       catalog.chunkCount !== 24 ||
       !Number.isSafeInteger(catalog.chunkFrameCount) || catalog.chunkFrameCount < 1 ||
       !Number.isSafeInteger(catalog.blockCount) || catalog.blockCount < catalog.chunkCount ||
@@ -206,16 +268,14 @@ function validateCatalog(catalog) {
         !Number.isSafeInteger(frameOffset) || frameOffset < 0 ||
         catalog.startupSelections.some((selection) => frameOffset >= selection.frameCount)) ||
       catalog.selection !== STARTUP_SELECTION ||
-      !Number.isSafeInteger(catalog.runtimeLookaheadBlockCount) ||
-      catalog.runtimeLookaheadBlockCount < 1 ||
-      catalog.runtimeLookaheadBlockCount >= catalog.blockCount ||
+      catalog.runtimeLookaheadBlockCount !== RUNTIME_LOOKAHEAD_BLOCK_COUNT ||
       catalog.entries.some((entry, index) => entry?.index !== index ||
         entry.chunkIndex !== Math.floor(index / catalog.blocksPerChunk) ||
         entry.blockIndex !== index % catalog.blocksPerChunk ||
         entry.startFrameIndex !== index * catalog.blockFrameCount ||
         entry.frameCount !== catalog.blockFrameCount ||
         entry.sourceContinuousFromPrevious !== (index > 0) ||
-        entry.encoding !== "gzip-newline-json" ||
+        entry.encoding !== CSSCYCLONE_BLOCK_ENCODING ||
         typeof entry.assetUrl !== "string" ||
         !Number.isSafeInteger(entry.byteLength) || entry.byteLength < 1 ||
         !Number.isSafeInteger(entry.decodedByteLength) || entry.decodedByteLength < 1 ||
@@ -282,7 +342,8 @@ function validateBlock(block, descriptor, catalog) {
       block.blockIndex !== descriptor.blockIndex ||
       block.startFrameIndex !== descriptor.startFrameIndex ||
       block.frameCount !== descriptor.frameCount ||
-      playback?.schema !== PLAYBACK_SCHEMA ||
+      playback?.schema !== CSSCYCLONE_PLAYBACK_SCHEMA ||
+      playback.modelId !== catalog.modelId ||
       playback.streamId !== catalog.streamId ||
       playback.streamBlockIndex !== descriptor.index ||
       playback.chunkIndex !== descriptor.chunkIndex ||
@@ -295,10 +356,12 @@ function validateBlock(block, descriptor, catalog) {
       playback.frameCount !== descriptor.frameCount ||
       playback.durationMilliseconds !== descriptor.frameCount * catalog.frameMilliseconds ||
       playback.loop !== false ||
-      playback.frames?.length !== descriptor.frameCount ||
-      playback.mounted?.shapeTransformIndices?.length !== playback.particleCount ||
-      playback.frames.some((row) => row?.length !== playback.particleCount * 2) ||
-      lighting?.schema !== LIGHTING_BLOCK_SCHEMA ||
+      playback.particleCount !== catalog.particleCount ||
+      playback.leafCount !== catalog.leafCount ||
+      playback.transforms?.length !== descriptor.frameCount * catalog.particleCount ||
+      playback.transforms.some((transform) =>
+        typeof transform !== "string" || !transform.startsWith("matrix3d(")) ||
+      lighting?.schema !== CSSCYCLONE_LIGHTING_BLOCK_SCHEMA ||
       lighting.streamId !== catalog.streamId ||
       lighting.streamBlockIndex !== descriptor.index ||
       lighting.chunkIndex !== descriptor.chunkIndex ||
@@ -306,8 +369,11 @@ function validateBlock(block, descriptor, catalog) {
       lighting.startFrameIndex !== descriptor.startFrameIndex ||
       lighting.frameCount !== descriptor.frameCount ||
       lighting.particleCount !== playback.particleCount ||
-      lighting.frameParticleColorStateIndices?.length !== descriptor.frameCount ||
-      lighting.frameParticleColorStateIndices.some((row) => row?.length !== playback.particleCount)) {
+      !(lighting.frameParticleColorStateIndices instanceof Uint16Array) ||
+      lighting.frameParticleColorStateIndices.length !== descriptor.frameCount * playback.particleCount ||
+      block.preparedMatrixExpansionCount !== playback.transforms.length ||
+      !Number.isSafeInteger(block.preparedCssStringByteLength) ||
+      block.preparedCssStringByteLength < playback.transforms.length) {
     throw new Error(`Prepared Cyclone block ${descriptor.index} drifted`);
   }
 }

--- a/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
@@ -136,31 +136,10 @@ export function buildCyclonePreparedPlayback({
   source = buildCycloneSourceSequence(),
   modelId = CSSCYCLONE_MODEL_ID,
 } = {}) {
-  const transforms = [];
-  const transformIndices = new Map();
-  const internTransform = (matrix) => {
-    const transform = `matrix3d(${formatMatrix3dValues(matrix, 6)})`;
-    const existing = transformIndices.get(transform);
-    if (existing !== undefined) return existing;
-    const index = transforms.length;
-    transforms.push(transform);
-    transformIndices.set(transform, index);
-    return index;
-  };
-  const first = source.frames[0];
-  const mountedShapeTransformIndices = first.particles.map((particle) => internTransform(particle.matrix));
-  const rowForFrame = (frame) => {
-    const shapeOperations = [];
-    for (let index = 0; index < frame.particles.length; index += 1) {
-      const particle = frame.particles[index];
-      const transformIndex = internTransform(particle.matrix);
-      shapeOperations.push(index, transformIndex);
-    }
-    return Object.freeze(shapeOperations);
-  };
-  const frames = source.frames.map(rowForFrame);
+  const transforms = source.frames.flatMap((frame) => frame.particles.map((particle) =>
+    `matrix3d(${formatMatrix3dValues(particle.matrix, 6)})`));
   const playback = deepFreeze({
-    schema: "csscyclone-prepared-dom-playback@3",
+    schema: "csscyclone-prepared-dom-playback@4",
     bankId: source.bank.id,
     streamId: source.bank.streamId,
     chunkIndex: source.bank.chunkIndex,
@@ -169,23 +148,19 @@ export function buildCyclonePreparedPlayback({
     modelId,
     frameMilliseconds: source.bank.frameMilliseconds,
     durationMilliseconds: source.durationMilliseconds,
-    frameCount: frames.length,
+    frameCount: source.frames.length,
     loop: false,
     particleCount: source.bank.particleCount,
     leafCount: source.bank.particleCount * CSSCYCLONE_FACE_INDICES.length,
     transforms: Object.freeze(transforms),
-    mounted: Object.freeze({
-      shapeTransformIndices: Object.freeze(mountedShapeTransformIndices),
-    }),
-    frames: Object.freeze(frames),
   });
   return deepFreeze({
     source,
     playback,
     metrics: Object.freeze({
-      preparedFrameCount: frames.length,
-      uniquePreparedTransformCount: transforms.length,
-      shapeTransformSelections: frames.reduce((sum, row) => sum + row.length / 2, 0),
+      preparedFrameCount: source.frames.length,
+      uniquePreparedTransformCount: new Set(transforms).size,
+      shapeTransformSelections: transforms.length,
     }),
   });
 }

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -1,4 +1,5 @@
-const PI = Math.PI;
+import { advanceCycloneParticleTransform } from "../../shared/csscyclone/particleTransform.mjs";
+
 const CONTROL_POINT_COUNT = 6;
 
 export const CSSCYCLONE_SOURCE = Object.freeze({
@@ -82,8 +83,6 @@ export const CSSCYCLONE_PRESENTATION = Object.freeze({
   startupMinimumDominantHueShare: 0.25,
 });
 
-const FACTORIALS = Object.freeze([1, 1, 2, 6, 24, 120, 720]);
-
 export function buildCycloneSourceSequence({ bank = CSSCYCLONE_BANK } = {}) {
   return buildCycloneSourceChunks({ bank }).next().value;
 }
@@ -101,9 +100,10 @@ export function* buildCycloneSourceChunks({ bank = CSSCYCLONE_BANK } = {}) {
     const frames = [];
     const startFrameIndex = chunkIndex * bank.frameCount;
     for (let frame = 0; frame < bank.frameCount; frame += 1) {
-      stepSource(cyclone, particles, rng, deltaSeconds);
+      const transformState = stepSource(cyclone, particles, rng, deltaSeconds);
       frames.push(Object.freeze({
         timeMs: (startFrameIndex + frame) * bank.frameMilliseconds,
+        transformState,
         particles: Object.freeze(particles.map((particle) => Object.freeze({
           matrix: particle.matrix,
           color: particle.color,
@@ -152,6 +152,10 @@ export function selectCycloneSourceParticlePrefix(source, bank = CSSCYCLONE_BANK
     }),
     frames: Object.freeze(source.frames.map((frame) => Object.freeze({
       ...frame,
+      transformState: Object.freeze({
+        ...frame.transformState,
+        particles: Object.freeze(frame.transformState.particles.slice(0, bank.particleCount)),
+      }),
       particles: Object.freeze(frame.particles.slice(0, bank.particleCount)),
     }))),
   });
@@ -248,7 +252,12 @@ function resetParticle(particle, rng) {
 
 function stepSource(cyclone, particles, rng, deltaSeconds) {
   updateCyclone(cyclone, rng, deltaSeconds);
-  for (const particle of particles) updateParticle(particle, rng, deltaSeconds);
+  const particleStates = particles.map((particle) => updateParticle(particle, rng, deltaSeconds));
+  return Object.freeze({
+    points: Object.freeze(cyclone.xyz.map((point) => Object.freeze([...point]))),
+    widths: Object.freeze([...cyclone.width]),
+    particles: Object.freeze(particleStates),
+  });
 }
 
 function updateCyclone(cyclone, rng, deltaSeconds) {
@@ -332,51 +341,28 @@ function retargetWidth(cyclone, index, rng, minimum, randomRange, minimumDuratio
 }
 
 function updateParticle(particle, rng, deltaSeconds) {
-  if (particle.step > 1) resetParticle(particle, rng);
-  const cyclone = particle.cyclone;
-  const position = bezier(cyclone.xyz, particle.step);
-  const previous = bezier(cyclone.xyz, particle.step - 0.01);
-  const direction = normalize(sub3(position, previous));
-  const up = [0, 1, 0];
-  const crossVector = cross3(direction, up);
-  const tiltAngle = -Math.acos(clamp(dot3(direction, up), -1, 1)) * 180 / PI;
-  let widthIndex = Math.floor(particle.step * (CSSCYCLONE_SOURCE.complexity + 2));
-  if (widthIndex >= CSSCYCLONE_SOURCE.complexity + 2) widthIndex = CSSCYCLONE_SOURCE.complexity + 1;
-  const between = (particle.step - widthIndex / (CSSCYCLONE_SOURCE.complexity + 2)) * (CSSCYCLONE_SOURCE.complexity + 2);
-  const cycloneWidth = cyclone.width[widthIndex] * (1 - between) + cyclone.width[widthIndex + 1] * between;
-  const stepDelta = 0.2 * deltaSeconds * CSSCYCLONE_SOURCE.speed /
-    (particle.width * particle.width * cycloneWidth);
-  particle.step += stepDelta;
-  const spinDelta = 1500 * deltaSeconds * CSSCYCLONE_SOURCE.speed /
-    (particle.width * cycloneWidth);
-  particle.spinAngle += spinDelta;
-  let stretch = particle.width * cycloneWidth * spinDelta * 0.02;
-  stretch = Math.min(stretch, cycloneWidth * 2 / CSSCYCLONE_SOURCE.particleSize);
-  stretch = Math.max(stretch, 3);
-  const matrix = multiply4(
-    translation(position),
-    multiply4(
-      rotationAxis(tiltAngle, crossVector),
-      multiply4(
-        rotationY(particle.spinAngle),
-        multiply4(translation([particle.width * cycloneWidth, 0, 0]), scale4([1, 1, stretch])),
-      ),
-    ),
-  );
-  particle.matrix = flattenCss(matrix);
-}
-
-function bezier(points, step) {
-  const output = [0, 0, 0];
-  const degree = CONTROL_POINT_COUNT - 1;
-  for (let index = 0; index < CONTROL_POINT_COUNT; index += 1) {
-    const blend = FACTORIALS[degree] / (FACTORIALS[index] * FACTORIALS[degree - index]) *
-      Math.pow(step, index) * Math.pow(1 - step, degree - index);
-    output[0] += points[index][0] * blend;
-    output[1] += points[index][1] * blend;
-    output[2] += points[index][2] * blend;
-  }
-  return output;
+  const reset = particle.step > 1;
+  if (reset) resetParticle(particle, rng);
+  const preparedState = Object.freeze({
+    width: particle.width,
+    step: particle.step,
+    spinAngle: particle.spinAngle,
+    reset,
+  });
+  const advanced = advanceCycloneParticleTransform({
+    state: preparedState,
+    points: particle.cyclone.xyz,
+    widths: particle.cyclone.width,
+    deltaSeconds,
+    speed: CSSCYCLONE_SOURCE.speed,
+    complexity: CSSCYCLONE_SOURCE.complexity,
+    particleSize: CSSCYCLONE_SOURCE.particleSize,
+  });
+  particle.width = advanced.state.width;
+  particle.step = advanced.state.step;
+  particle.spinAngle = advanced.state.spinAngle;
+  particle.matrix = advanced.matrix;
+  return preparedState;
 }
 
 function hsl2rgb(hue, saturation, luminosity) {
@@ -487,29 +473,6 @@ function scale4([x, y, z]) {
   return matrix;
 }
 
-function rotationY(degrees) {
-  const radians = degrees * PI / 180;
-  const cosine = Math.cos(radians);
-  const sine = Math.sin(radians);
-  return [[cosine, 0, sine, 0], [0, 1, 0, 0], [-sine, 0, cosine, 0], [0, 0, 0, 1]];
-}
-
-function rotationAxis(degrees, axis) {
-  const length = Math.hypot(...axis);
-  if (length < 1e-12 || Math.abs(degrees) < 1e-12) return identity4();
-  const [x, y, z] = axis.map((value) => value / length);
-  const radians = degrees * PI / 180;
-  const cosine = Math.cos(radians);
-  const sine = Math.sin(radians);
-  const one = 1 - cosine;
-  return [
-    [x * x * one + cosine, x * y * one - z * sine, x * z * one + y * sine, 0],
-    [y * x * one + z * sine, y * y * one + cosine, y * z * one - x * sine, 0],
-    [z * x * one - y * sine, z * y * one + x * sine, z * z * one + cosine, 0],
-    [0, 0, 0, 1],
-  ];
-}
-
 function flattenCss(matrix) {
   return Object.freeze(matrix[0].map((_, column) => matrix.map((row) => rounded(row[column]))).flat());
 }
@@ -529,27 +492,6 @@ function mix(left, right, amount) {
 
 function mix3(left, right, amount) {
   return left.map((value, index) => mix(value, right[index], amount));
-}
-
-function sub3(left, right) {
-  return left.map((value, index) => value - right[index]);
-}
-
-function dot3(left, right) {
-  return left.reduce((sum, value, index) => sum + value * right[index], 0);
-}
-
-function cross3(left, right) {
-  return [
-    left[1] * right[2] - right[1] * left[2],
-    left[2] * right[0] - right[2] * left[0],
-    left[0] * right[1] - right[0] * left[1],
-  ];
-}
-
-function normalize(vector) {
-  const length = Math.hypot(...vector);
-  return length === 0 ? [...vector] : vector.map((value) => value / length);
 }
 
 function clamp(value, minimum, maximum) {

--- a/src/adapters/cyclone/src/shared/csscyclone/particleTransform.mjs
+++ b/src/adapters/cyclone/src/shared/csscyclone/particleTransform.mjs
@@ -1,0 +1,168 @@
+const PI = Math.PI;
+
+export function advanceCycloneParticleTransform({
+  state,
+  points,
+  widths,
+  deltaSeconds,
+  speed,
+  complexity,
+  particleSize,
+}) {
+  if (!validState(state) || !validPoints(points) || !validWidths(widths) ||
+      !Number.isFinite(deltaSeconds) || deltaSeconds <= 0 ||
+      !Number.isFinite(speed) || speed <= 0 ||
+      !Number.isSafeInteger(complexity) || complexity < 1 || complexity + 2 >= widths.length ||
+      !Number.isFinite(particleSize) || particleSize <= 0) {
+    throw new TypeError("Complete prepared Cyclone particle transform inputs are required");
+  }
+  const { width } = state;
+  const position = bezier(points, state.step);
+  const previous = bezier(points, state.step - 0.01);
+  const direction = normalize(sub3(position, previous));
+  const up = [0, 1, 0];
+  const crossVector = cross3(direction, up);
+  const tiltAngle = -Math.acos(clamp(dot3(direction, up), -1, 1)) * 180 / PI;
+  let widthIndex = Math.floor(state.step * (complexity + 2));
+  if (widthIndex >= complexity + 2) widthIndex = complexity + 1;
+  const between = (state.step - widthIndex / (complexity + 2)) * (complexity + 2);
+  const cycloneWidth = widths[widthIndex] * (1 - between) + widths[widthIndex + 1] * between;
+  const stepDelta = 0.2 * deltaSeconds * speed / (width * width * cycloneWidth);
+  const spinDelta = 1500 * deltaSeconds * speed / (width * cycloneWidth);
+  const nextState = Object.freeze({
+    width,
+    step: state.step + stepDelta,
+    spinAngle: state.spinAngle + spinDelta,
+  });
+  let stretch = width * cycloneWidth * spinDelta * 0.02;
+  stretch = Math.min(stretch, cycloneWidth * 2 / particleSize);
+  stretch = Math.max(stretch, 3);
+  const matrix = multiply4(
+    translation(position),
+    multiply4(
+      rotationAxis(tiltAngle, crossVector),
+      multiply4(
+        rotationY(nextState.spinAngle),
+        multiply4(translation([width * cycloneWidth, 0, 0]), scale4([1, 1, stretch])),
+      ),
+    ),
+  );
+  return Object.freeze({
+    matrix: Object.freeze(flattenCss(matrix)),
+    state: nextState,
+  });
+}
+
+function validState(state) {
+  return state && [state.width, state.step, state.spinAngle].every(Number.isFinite) && state.width > 0;
+}
+
+function validPoints(points) {
+  return Array.isArray(points) && points.length >= 2 &&
+    points.every((point) => Array.isArray(point) && point.length === 3 && point.every(Number.isFinite));
+}
+
+function validWidths(widths) {
+  return Array.isArray(widths) && widths.length >= 3 && widths.every(Number.isFinite);
+}
+
+function bezier(points, step) {
+  const output = [0, 0, 0];
+  const degree = points.length - 1;
+  for (let index = 0; index < points.length; index += 1) {
+    const blend = factorial(degree) / (factorial(index) * factorial(degree - index)) *
+      Math.pow(step, index) * Math.pow(1 - step, degree - index);
+    output[0] += points[index][0] * blend;
+    output[1] += points[index][1] * blend;
+    output[2] += points[index][2] * blend;
+  }
+  return output;
+}
+
+function factorial(value) {
+  let result = 1;
+  for (let factor = 2; factor <= value; factor += 1) result *= factor;
+  return result;
+}
+
+function identity4() {
+  return [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]];
+}
+
+function multiply4(left, right) {
+  return left.map((row) => right[0].map((unused, column) =>
+    row.reduce((sum, value, index) => sum + value * right[index][column], 0)));
+}
+
+function translation([x, y, z]) {
+  const matrix = identity4();
+  matrix[0][3] = x;
+  matrix[1][3] = y;
+  matrix[2][3] = z;
+  return matrix;
+}
+
+function scale4([x, y, z]) {
+  const matrix = identity4();
+  matrix[0][0] = x;
+  matrix[1][1] = y;
+  matrix[2][2] = z;
+  return matrix;
+}
+
+function rotationY(degrees) {
+  const radians = degrees * PI / 180;
+  const cosine = Math.cos(radians);
+  const sine = Math.sin(radians);
+  return [[cosine, 0, sine, 0], [0, 1, 0, 0], [-sine, 0, cosine, 0], [0, 0, 0, 1]];
+}
+
+function rotationAxis(degrees, axis) {
+  const length = Math.hypot(...axis);
+  if (length < 1e-12 || Math.abs(degrees) < 1e-12) return identity4();
+  const [x, y, z] = axis.map((value) => value / length);
+  const radians = degrees * PI / 180;
+  const cosine = Math.cos(radians);
+  const sine = Math.sin(radians);
+  const one = 1 - cosine;
+  return [
+    [x * x * one + cosine, x * y * one - z * sine, x * z * one + y * sine, 0],
+    [y * x * one + z * sine, y * y * one + cosine, y * z * one - x * sine, 0],
+    [z * x * one - y * sine, z * y * one + x * sine, z * z * one + cosine, 0],
+    [0, 0, 0, 1],
+  ];
+}
+
+function flattenCss(matrix) {
+  return matrix[0].map((unused, column) => matrix.map((row) => rounded(row[column]))).flat();
+}
+
+function normalize(vector) {
+  const length = Math.hypot(...vector);
+  return length > 1e-12 ? vector.map((value) => value / length) : [0, 0, 0];
+}
+
+function sub3(left, right) {
+  return left.map((value, index) => value - right[index]);
+}
+
+function dot3(left, right) {
+  return left.reduce((sum, value, index) => sum + value * right[index], 0);
+}
+
+function cross3(left, right) {
+  return [
+    left[1] * right[2] - left[2] * right[1],
+    left[2] * right[0] - left[0] * right[2],
+    left[0] * right[1] - left[1] * right[0],
+  ];
+}
+
+function clamp(value, minimum, maximum) {
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+function rounded(value) {
+  const result = Number(value.toFixed(6));
+  return Object.is(result, -0) ? 0 : result;
+}

--- a/src/adapters/cyclone/src/shared/csscyclone/preparedBlockTransport.mjs
+++ b/src/adapters/cyclone/src/shared/csscyclone/preparedBlockTransport.mjs
@@ -1,0 +1,305 @@
+import { formatMatrix3dValues } from "@layoutit/polycss";
+import { advanceCycloneParticleTransform } from "./particleTransform.mjs";
+
+export const CSSCYCLONE_BLOCK_ENCODING = "gzip-cyclone-source-state-float64-uint16@1";
+export const CSSCYCLONE_PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@4";
+export const CSSCYCLONE_LIGHTING_BLOCK_SCHEMA = "csscyclone-prepared-lighting-block@2";
+
+const MAGIC = "CCST";
+const VERSION = 1;
+const CONTROL_POINT_COUNT = 6;
+const PARTICLE_STATE_FIELD_COUNT = 3;
+const CYCLONE_FRAME_VALUE_COUNT = CONTROL_POINT_COUNT * 3 + CONTROL_POINT_COUNT;
+const HEADER_BYTES = 24;
+const RESET_EVENT_BYTES = 20;
+
+export function encodeCyclonePreparedBlock({ frames, lightingRows, particleCount }) {
+  if (!Array.isArray(frames) || frames.length < 1 || frames.length > 0xffff ||
+      !Number.isSafeInteger(particleCount) || particleCount < 1 || particleCount > 0xffff ||
+      !Array.isArray(lightingRows) || lightingRows.length !== frames.length ||
+      lightingRows.some((row) => !Array.isArray(row) || row.length !== particleCount ||
+        row.some((value) => !Number.isSafeInteger(value) || value < 0 || value > 0xffff)) ||
+      frames.some((frame) => !validTransformFrame(frame?.transformState, particleCount))) {
+    throw new TypeError("Complete prepared Cyclone source-state block inputs are required");
+  }
+  const resetEvents = [];
+  for (let frameIndex = 1; frameIndex < frames.length; frameIndex += 1) {
+    for (let particleIndex = 0; particleIndex < particleCount; particleIndex += 1) {
+      const state = frames[frameIndex].transformState.particles[particleIndex];
+      if (state.reset) resetEvents.push({ frameIndex, particleIndex, width: state.width, spinAngle: state.spinAngle });
+    }
+  }
+  const cycloneBytes = frames.length * CYCLONE_FRAME_VALUE_COUNT * Float64Array.BYTES_PER_ELEMENT;
+  const initialStateBytes = particleCount * PARTICLE_STATE_FIELD_COUNT * Float64Array.BYTES_PER_ELEMENT;
+  const resetBytes = resetEvents.length * RESET_EVENT_BYTES;
+  const lightingValueCount = frames.length * particleCount;
+  const lightingBytes = lightingValueCount * Uint16Array.BYTES_PER_ELEMENT;
+  const bytes = new Uint8Array(HEADER_BYTES + cycloneBytes + initialStateBytes + resetBytes + lightingBytes);
+  const view = new DataView(bytes.buffer);
+  for (let index = 0; index < MAGIC.length; index += 1) bytes[index] = MAGIC.charCodeAt(index);
+  bytes[4] = VERSION;
+  bytes[5] = CONTROL_POINT_COUNT;
+  bytes[6] = PARTICLE_STATE_FIELD_COUNT;
+  bytes[7] = 0;
+  view.setUint16(8, particleCount, true);
+  view.setUint16(10, frames.length, true);
+  view.setUint32(12, resetEvents.length, true);
+  view.setUint32(16, lightingValueCount, true);
+  view.setUint32(20, 0, true);
+  let offset = HEADER_BYTES;
+  for (const frame of frames) {
+    for (const point of frame.transformState.points) {
+      for (const value of point) {
+        view.setFloat64(offset, value, true);
+        offset += Float64Array.BYTES_PER_ELEMENT;
+      }
+    }
+    for (const value of frame.transformState.widths) {
+      view.setFloat64(offset, value, true);
+      offset += Float64Array.BYTES_PER_ELEMENT;
+    }
+  }
+  for (const state of frames[0].transformState.particles) {
+    for (const value of [state.width, state.step, state.spinAngle]) {
+      view.setFloat64(offset, value, true);
+      offset += Float64Array.BYTES_PER_ELEMENT;
+    }
+  }
+  for (const event of resetEvents) {
+    view.setUint16(offset, event.frameIndex, true);
+    view.setUint16(offset + 2, event.particleIndex, true);
+    view.setFloat64(offset + 4, event.width, true);
+    view.setFloat64(offset + 12, event.spinAngle, true);
+    offset += RESET_EVENT_BYTES;
+  }
+  for (const row of lightingRows) {
+    for (const value of row) {
+      view.setUint16(offset, value, true);
+      offset += Uint16Array.BYTES_PER_ELEMENT;
+    }
+  }
+  if (offset !== bytes.byteLength) throw new Error("Prepared Cyclone source-state block byte count drifted");
+  return bytes;
+}
+
+export function decodeCyclonePreparedBlock(bytes, descriptor, catalog) {
+  const operations = decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog);
+  let result = operations.next();
+  while (!result.done) result = operations.next();
+  return result.value;
+}
+
+export async function decodeCyclonePreparedBlockIncrementally(
+  bytes,
+  descriptor,
+  catalog,
+  {
+    setDelay = globalThis.setTimeout.bind(globalThis),
+    readNow = () => globalThis.performance.now(),
+    sliceBudgetMilliseconds = 4,
+    isCurrent = () => true,
+    onSlice = () => undefined,
+  } = {},
+) {
+  if (typeof setDelay !== "function" || typeof readNow !== "function" ||
+      typeof isCurrent !== "function" || typeof onSlice !== "function" ||
+      !Number.isFinite(sliceBudgetMilliseconds) ||
+      sliceBudgetMilliseconds <= 0 || sliceBudgetMilliseconds > 4) {
+    throw new TypeError("Cyclone incremental source-state decoder scheduling is invalid");
+  }
+  const operations = decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog);
+  let firstSlice = true;
+  while (true) {
+    if (!firstSlice) {
+      await new Promise((resolveDelay) => setDelay(resolveDelay, catalog.frameMilliseconds));
+      if (!isCurrent()) return null;
+    }
+    firstSlice = false;
+    if (!isCurrent()) return null;
+    const startedAt = readNow();
+    let operationCount = 0;
+    while (operationCount < 8_192) {
+      const result = operations.next();
+      if (result.done) {
+        onSlice(operationCount, readNow() - startedAt);
+        return result.value;
+      }
+      operationCount += result.value;
+      if (operationCount >= 64 && readNow() - startedAt >= sliceBudgetMilliseconds) break;
+    }
+    onSlice(operationCount, readNow() - startedAt);
+  }
+}
+
+function* decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog) {
+  if (!(bytes instanceof Uint8Array) || bytes.byteLength < HEADER_BYTES ||
+      String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]) !== MAGIC ||
+      bytes[4] !== VERSION || bytes[5] !== CONTROL_POINT_COUNT ||
+      bytes[6] !== PARTICLE_STATE_FIELD_COUNT || bytes[7] !== 0 ||
+      descriptor?.encoding !== CSSCYCLONE_BLOCK_ENCODING ||
+      catalog?.playbackSchema !== CSSCYCLONE_PLAYBACK_SCHEMA ||
+      catalog?.lightingBlockSchema !== CSSCYCLONE_LIGHTING_BLOCK_SCHEMA) {
+    throw new Error(`Prepared Cyclone block ${descriptor?.index ?? "unknown"} binary header drifted`);
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const particleCount = view.getUint16(8, true);
+  const frameCount = view.getUint16(10, true);
+  const resetEventCount = view.getUint32(12, true);
+  const lightingValueCount = view.getUint32(16, true);
+  if (view.getUint32(20, true) !== 0 || particleCount !== catalog.particleCount ||
+      frameCount !== descriptor.frameCount || lightingValueCount !== particleCount * frameCount ||
+      !validSourceProfile(catalog.sourceTransformProfile)) {
+    throw new Error(`Prepared Cyclone block ${descriptor.index} source-state counts drifted`);
+  }
+  const cycloneBytes = frameCount * CYCLONE_FRAME_VALUE_COUNT * Float64Array.BYTES_PER_ELEMENT;
+  const initialStateBytes = particleCount * PARTICLE_STATE_FIELD_COUNT * Float64Array.BYTES_PER_ELEMENT;
+  const resetBytes = resetEventCount * RESET_EVENT_BYTES;
+  const lightingBytes = lightingValueCount * Uint16Array.BYTES_PER_ELEMENT;
+  if (HEADER_BYTES + cycloneBytes + initialStateBytes + resetBytes + lightingBytes !== bytes.byteLength) {
+    throw new Error(`Prepared Cyclone block ${descriptor.index} binary byte length drifted`);
+  }
+  const cycloneOffset = HEADER_BYTES;
+  const initialStateOffset = cycloneOffset + cycloneBytes;
+  const resetOffset = initialStateOffset + initialStateBytes;
+  const lightingOffset = resetOffset + resetBytes;
+  const states = Array.from({ length: particleCount }, (_, particleIndex) => {
+    const offset = initialStateOffset + particleIndex * PARTICLE_STATE_FIELD_COUNT * Float64Array.BYTES_PER_ELEMENT;
+    return {
+      width: view.getFloat64(offset, true),
+      step: view.getFloat64(offset + 8, true),
+      spinAngle: view.getFloat64(offset + 16, true),
+    };
+  });
+  if (states.some((state) => !validParticleState(state))) {
+    throw new Error(`Prepared Cyclone block ${descriptor.index} initial particle state drifted`);
+  }
+  const resetEvents = [];
+  let previousFrameIndex = 0;
+  let previousParticleIndex = -1;
+  for (let eventIndex = 0; eventIndex < resetEventCount; eventIndex += 1) {
+    const offset = resetOffset + eventIndex * RESET_EVENT_BYTES;
+    const event = {
+      frameIndex: view.getUint16(offset, true),
+      particleIndex: view.getUint16(offset + 2, true),
+      width: view.getFloat64(offset + 4, true),
+      spinAngle: view.getFloat64(offset + 12, true),
+    };
+    if (event.frameIndex < 1 || event.frameIndex >= frameCount ||
+        event.particleIndex >= particleCount || !Number.isFinite(event.width) || event.width <= 0 ||
+        !Number.isFinite(event.spinAngle) || event.frameIndex < previousFrameIndex ||
+        (event.frameIndex === previousFrameIndex && event.particleIndex <= previousParticleIndex)) {
+      throw new Error(`Prepared Cyclone block ${descriptor.index} reset event drifted`);
+    }
+    previousFrameIndex = event.frameIndex;
+    previousParticleIndex = event.particleIndex;
+    resetEvents.push(event);
+  }
+  const transforms = new Array(frameCount * particleCount);
+  let resetCursor = 0;
+  let operationsSinceYield = 0;
+  for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
+    const frameOffset = cycloneOffset + frameIndex * CYCLONE_FRAME_VALUE_COUNT * Float64Array.BYTES_PER_ELEMENT;
+    const points = Array.from({ length: CONTROL_POINT_COUNT }, (_, pointIndex) =>
+      Array.from({ length: 3 }, (unused, axis) =>
+        view.getFloat64(frameOffset + (pointIndex * 3 + axis) * Float64Array.BYTES_PER_ELEMENT, true)));
+    const widthOffset = frameOffset + CONTROL_POINT_COUNT * 3 * Float64Array.BYTES_PER_ELEMENT;
+    const widths = Array.from({ length: CONTROL_POINT_COUNT }, (unused, widthIndex) =>
+      view.getFloat64(widthOffset + widthIndex * Float64Array.BYTES_PER_ELEMENT, true));
+    for (let particleIndex = 0; particleIndex < particleCount; particleIndex += 1) {
+      const reset = resetEvents[resetCursor];
+      if (reset?.frameIndex === frameIndex && reset.particleIndex === particleIndex) {
+        states[particleIndex] = { width: reset.width, step: 0, spinAngle: reset.spinAngle };
+        resetCursor += 1;
+      }
+      const advanced = advanceCycloneParticleTransform({
+        state: states[particleIndex],
+        points,
+        widths,
+        deltaSeconds: catalog.frameMilliseconds / 1_000,
+        speed: catalog.sourceTransformProfile.speed,
+        complexity: catalog.sourceTransformProfile.complexity,
+        particleSize: catalog.sourceTransformProfile.particleSize,
+      });
+      transforms[frameIndex * particleCount + particleIndex] =
+        `matrix3d(${formatMatrix3dValues(advanced.matrix, 6)})`;
+      states[particleIndex] = advanced.state;
+      operationsSinceYield += 1;
+      if (operationsSinceYield === 64) {
+        yield operationsSinceYield;
+        operationsSinceYield = 0;
+      }
+    }
+  }
+  if (operationsSinceYield > 0) yield operationsSinceYield;
+  if (resetCursor !== resetEvents.length) {
+    throw new Error(`Prepared Cyclone block ${descriptor.index} reset events were not consumed`);
+  }
+  const lightingValues = new Uint16Array(lightingValueCount);
+  for (let index = 0; index < lightingValues.length; index += 1) {
+    lightingValues[index] = view.getUint16(lightingOffset + index * Uint16Array.BYTES_PER_ELEMENT, true);
+  }
+  const preparedCssStringByteLength = transforms.reduce(
+    (total, transform) => total + transform.length * Uint16Array.BYTES_PER_ELEMENT,
+    0,
+  );
+  return Object.freeze({
+    schema: "csscyclone-prepared-stream-block@2",
+    streamId: catalog.streamId,
+    streamBlockIndex: descriptor.index,
+    chunkIndex: descriptor.chunkIndex,
+    blockIndex: descriptor.blockIndex,
+    startFrameIndex: descriptor.startFrameIndex,
+    frameCount,
+    playback: Object.freeze({
+      schema: CSSCYCLONE_PLAYBACK_SCHEMA,
+      modelId: catalog.modelId,
+      streamId: catalog.streamId,
+      streamBlockIndex: descriptor.index,
+      chunkIndex: descriptor.chunkIndex,
+      blockIndex: descriptor.blockIndex,
+      chunkCount: catalog.chunkCount,
+      blockCount: catalog.blockCount,
+      blocksPerChunk: catalog.blocksPerChunk,
+      startFrameIndex: descriptor.startFrameIndex,
+      frameCount,
+      particleCount,
+      leafCount: catalog.leafCount,
+      frameMilliseconds: catalog.frameMilliseconds,
+      durationMilliseconds: frameCount * catalog.frameMilliseconds,
+      loop: false,
+      transforms: Object.freeze(transforms),
+    }),
+    lighting: Object.freeze({
+      schema: CSSCYCLONE_LIGHTING_BLOCK_SCHEMA,
+      streamId: catalog.streamId,
+      streamBlockIndex: descriptor.index,
+      chunkIndex: descriptor.chunkIndex,
+      blockIndex: descriptor.blockIndex,
+      startFrameIndex: descriptor.startFrameIndex,
+      frameCount,
+      particleCount,
+      frameParticleColorStateIndices: lightingValues,
+    }),
+    preparedMatrixExpansionCount: transforms.length,
+    preparedCssStringByteLength,
+  });
+}
+
+function validTransformFrame(state, particleCount) {
+  return state && Array.isArray(state.points) && state.points.length === CONTROL_POINT_COUNT &&
+    state.points.every((point) => Array.isArray(point) && point.length === 3 && point.every(Number.isFinite)) &&
+    Array.isArray(state.widths) && state.widths.length === CONTROL_POINT_COUNT && state.widths.every(Number.isFinite) &&
+    Array.isArray(state.particles) && state.particles.length === particleCount &&
+    state.particles.every((particle) => validParticleState(particle) && typeof particle.reset === "boolean");
+}
+
+function validParticleState(state) {
+  return state && Number.isFinite(state.width) && state.width > 0 &&
+    Number.isFinite(state.step) && Number.isFinite(state.spinAngle);
+}
+
+function validSourceProfile(profile) {
+  return profile?.controlPointCount === CONTROL_POINT_COUNT && Number.isFinite(profile.speed) && profile.speed > 0 &&
+    Number.isSafeInteger(profile.complexity) && profile.complexity >= 1 &&
+    Number.isFinite(profile.particleSize) && profile.particleSize > 0;
+}

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -34,7 +34,7 @@ function fixture({
   const shapeElements = Array.from({ length: 2 }, () => new FakeHTMLElement());
   const leafElements = Array.from({ length: 2 }, () => new FakeHTMLElement());
   const playback = {
-    schema: "csscyclone-prepared-dom-playback@3",
+    schema: "csscyclone-prepared-dom-playback@4",
     modelId: "cyclone",
     streamId: "stream",
     streamBlockIndex: 0,
@@ -49,14 +49,8 @@ function fixture({
     leafCount: 2,
     frameMilliseconds: 20,
     durationMilliseconds: 80,
+    loop: false,
     transforms: ["a", "b", "c", "d", "e", "f", "g", "h"],
-    mounted: { shapeTransformIndices: [0, 1] },
-    frames: [
-      [0, 0, 1, 1],
-      [0, 2, 1, 3],
-      [0, 4, 1, 5],
-      [0, 6, 1, 7],
-    ],
   };
   const lighting = {
     schema: "csscyclone-prepared-smooth-lighting-atlas@7",
@@ -86,7 +80,7 @@ function fixture({
       startFrameIndex: streamBlockIndex * 4,
     };
     return {
-      schema: "csscyclone-prepared-stream-block@1",
+      schema: "csscyclone-prepared-stream-block@2",
       streamId: "stream",
       streamBlockIndex,
       chunkIndex: 0,
@@ -95,7 +89,7 @@ function fixture({
       frameCount: 4,
       playback: blockPlayback,
       lighting: {
-        schema: "csscyclone-prepared-lighting-block@1",
+        schema: "csscyclone-prepared-lighting-block@2",
         streamId: "stream",
         streamBlockIndex,
         chunkIndex: 0,
@@ -103,7 +97,7 @@ function fixture({
         startFrameIndex: streamBlockIndex * 4,
         frameCount: 4,
         particleCount: 2,
-        frameParticleColorStateIndices: [[0, 0], [0, 0], [0, 0], [0, 0]],
+        frameParticleColorStateIndices: new Uint16Array(8),
       },
     };
   });
@@ -209,14 +203,14 @@ test("hands each prepared publication from its deadline timer to requestAnimatio
   assert.equal(stats.schedulerDelayCallbackCount, 1);
 });
 
-test("starts only after the complete prepared stream is decoded", async () => {
+test("starts with the complete configured decoded horizon", async () => {
   const state = fixture({
-    blockCount: 5,
-    runtimeLookaheadBlockCount: 4,
-    initialLookaheadBlockCount: 4,
+    blockCount: 13,
+    runtimeLookaheadBlockCount: 11,
+    initialLookaheadBlockCount: 11,
   });
-  assert.deepEqual(state.player.stats().pendingBlockIndices, [1, 2, 3, 4]);
-  assert.equal(state.player.stats().pendingBlockReadyCount, 4);
+  assert.deepEqual(state.player.stats().pendingBlockIndices, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+  assert.equal(state.player.stats().pendingBlockReadyCount, 11);
   assert.deepEqual(state.loadBlockCalls, []);
 
   state.player.resume();
@@ -227,10 +221,10 @@ test("starts only after the complete prepared stream is decoded", async () => {
 
   const stats = state.player.stats();
   assert.equal(stats.activeBlockIndex, 1);
-  assert.deepEqual(stats.pendingBlockIndices, [2, 3, 4, 0]);
-  assert.equal(stats.pendingBlockReadyCount, 4);
+  assert.deepEqual(stats.pendingBlockIndices, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  assert.equal(stats.pendingBlockReadyCount, 11);
   assert.equal(stats.runtimePreparedBlockWaitCount, 0);
-  assert.deepEqual(state.loadBlockCalls, [0]);
+  assert.deepEqual(state.loadBlockCalls, [12]);
 });
 
 test("collapses missed prepared frames once at the next paint-aligned callback", async () => {

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -20,6 +20,14 @@ import {
   prepareCyclonePaletteColor,
 } from "../src/prepare/csscyclone/preparedLighting.mjs";
 import { resolveCyclonePerspective } from "../src/csscyclone/preparedPlayback.mjs";
+import {
+  CSSCYCLONE_BLOCK_ENCODING,
+  CSSCYCLONE_LIGHTING_BLOCK_SCHEMA,
+  CSSCYCLONE_PLAYBACK_SCHEMA,
+  decodeCyclonePreparedBlock,
+  decodeCyclonePreparedBlockIncrementally,
+  encodeCyclonePreparedBlock,
+} from "../src/shared/csscyclone/preparedBlockTransport.mjs";
 
 test("pins the current Really Slick Cyclone source profile", () => {
   assert.equal(CSSCYCLONE_SOURCE.revision, "5f0a788bf0cc47f66a233ed528919295cd1e7500");
@@ -120,14 +128,96 @@ test("builds a stable retained particle graph and prepared state bank", () => {
   assert.equal(preparedModel.model.render.shapes.length, 3);
   assert.equal(preparedModel.model.render.leaves.length, 18);
   assert.equal(preparedModel.model.topology.polygons.length, 18);
-  assert.equal(preparedPlayback.playback.frames.length, 4);
   assert.equal(preparedPlayback.playback.transforms.length, 12);
-  assert.equal(preparedPlayback.playback.schema, "csscyclone-prepared-dom-playback@3");
-  assert.equal(preparedPlayback.playback.frames[0].length, 6);
+  assert.equal(preparedPlayback.playback.schema, "csscyclone-prepared-dom-playback@4");
   assert.equal(preparedPlayback.metrics.shapeTransformSelections, 12);
   assert.equal(preparedModel.metrics.runtimeGeometryConstructionCount, 0);
   assert.equal(preparedModel.metrics.runtimeAtlasRasterizationCount, 0);
   assert.equal(preparedModel.metrics.runtimeDomGrowth, false);
+});
+
+test("round-trips exact prepared matrices through compact source-state blocks", async () => {
+  const bank = {
+    ...CSSCYCLONE_BANK,
+    id: "transport-test",
+    particleCount: 10,
+    warmupFrames: 20,
+    frameCount: 20,
+    chunkCount: 1,
+  };
+  const source = buildCycloneSourceSequence({ bank });
+  const expected = buildCyclonePreparedPlayback({ source }).playback;
+  const lightingRows = source.frames.map((unused, frameIndex) =>
+    Array.from({ length: bank.particleCount }, (ignored, particleIndex) =>
+      (frameIndex + particleIndex) % 7));
+  const bytes = encodeCyclonePreparedBlock({
+    frames: source.frames,
+    lightingRows,
+    particleCount: bank.particleCount,
+  });
+  const descriptor = Object.freeze({
+    index: 0,
+    chunkIndex: 0,
+    blockIndex: 0,
+    startFrameIndex: 0,
+    frameCount: bank.frameCount,
+    encoding: CSSCYCLONE_BLOCK_ENCODING,
+  });
+  const catalog = Object.freeze({
+    streamId: bank.id,
+    modelId: CSSCYCLONE_MODEL_IDS.desktop,
+    particleCount: bank.particleCount,
+    leafCount: bank.particleCount * 6,
+    frameMilliseconds: bank.frameMilliseconds,
+    chunkCount: 1,
+    blockCount: 1,
+    blocksPerChunk: 1,
+    playbackSchema: CSSCYCLONE_PLAYBACK_SCHEMA,
+    lightingBlockSchema: CSSCYCLONE_LIGHTING_BLOCK_SCHEMA,
+    sourceTransformProfile: Object.freeze({
+      controlPointCount: 6,
+      speed: CSSCYCLONE_SOURCE.speed,
+      complexity: CSSCYCLONE_SOURCE.complexity,
+      particleSize: CSSCYCLONE_SOURCE.particleSize,
+    }),
+  });
+  const decoded = decodeCyclonePreparedBlock(bytes, descriptor, catalog);
+  assert.deepEqual(decoded.playback.transforms, expected.transforms);
+  assert.deepEqual(
+    [...decoded.lighting.frameParticleColorStateIndices],
+    lightingRows.flat(),
+  );
+  assert.equal(decoded.preparedMatrixExpansionCount, expected.transforms.length);
+  assert.ok(decoded.preparedCssStringByteLength > bytes.byteLength);
+  let clock = 0;
+  let delayCount = 0;
+  const slices = [];
+  const incrementallyDecoded = await decodeCyclonePreparedBlockIncrementally(
+    bytes,
+    descriptor,
+    catalog,
+    {
+      setDelay(callback) {
+        delayCount += 1;
+        callback();
+      },
+      readNow() {
+        clock += 1;
+        return clock;
+      },
+      sliceBudgetMilliseconds: 2,
+      onSlice(operationCount, durationMilliseconds) {
+        slices.push({ operationCount, durationMilliseconds });
+      },
+    },
+  );
+  assert.deepEqual(incrementallyDecoded.playback.transforms, expected.transforms);
+  assert.ok(delayCount >= 1);
+  assert.ok(slices.every(({ operationCount }) => operationCount <= 8_192));
+  assert.throws(
+    () => decodeCyclonePreparedBlock(bytes.slice(0, -1), descriptor, catalog),
+    /binary byte length drifted/u,
+  );
 });
 
 test("prepares smooth reference lighting without a runtime lighting timeline", async () => {

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -20,6 +20,17 @@ const startupSelections = Object.freeze([
 const catalog = Object.freeze({
   schema: "csscyclone-prepared-stream-catalog@1",
   streamId: "desktop-stream",
+  modelId: "cyclone",
+  particleCount: 400,
+  leafCount: 2_400,
+  playbackSchema: "csscyclone-prepared-dom-playback@4",
+  lightingBlockSchema: "csscyclone-prepared-lighting-block@2",
+  sourceTransformProfile: Object.freeze({
+    controlPointCount: 6,
+    speed: 10,
+    complexity: 3,
+    particleSize: 7,
+  }),
   chunkCount: 24,
   chunkFrameCount: 450,
   blockCount: 216,
@@ -55,7 +66,7 @@ const catalog = Object.freeze({
       });
     })),
   }),
-  runtimeLookaheadBlockCount: 3,
+  runtimeLookaheadBlockCount: 11,
   entries: Object.freeze(Array.from({ length: 216 }, (_, index) => Object.freeze({
     index,
     chunkIndex: Math.floor(index / 9),
@@ -63,7 +74,7 @@ const catalog = Object.freeze({
     startFrameIndex: index * 50,
     frameCount: 50,
     sourceContinuousFromPrevious: index > 0,
-    encoding: "gzip-newline-json",
+    encoding: "gzip-cyclone-source-state-float64-uint16@1",
     assetUrl: `/block-${index}.bin`,
     byteLength: 1,
     sha256: hash,

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -9,9 +9,14 @@ import {
   CSSCYCLONE_FACE_INDICES,
   CSSCYCLONE_MODEL_IDS,
   buildCyclonePreparedModel,
-  buildCyclonePreparedPlayback,
 } from "../src/prepare/csscyclone/modelBuilder.mjs";
 import { createCyclonePreparedLightingStream } from "../src/prepare/csscyclone/preparedLighting.mjs";
+import {
+  CSSCYCLONE_BLOCK_ENCODING,
+  CSSCYCLONE_LIGHTING_BLOCK_SCHEMA,
+  CSSCYCLONE_PLAYBACK_SCHEMA,
+  encodeCyclonePreparedBlock,
+} from "../src/shared/csscyclone/preparedBlockTransport.mjs";
 import {
   CSSCYCLONE_BANKS,
   CSSCYCLONE_PRESENTATION,
@@ -26,6 +31,7 @@ const outputRoot = join(repositoryRoot, "build/generated/public/csscyclone");
 const stagingRoot = join(repositoryRoot, `build/generated/.csscyclone-${process.pid}`);
 const sourceLock = JSON.parse(await readFile(join(adapterRoot, "notes/references/source-lock.json"), "utf8"));
 const blockFrameCount = 50;
+const runtimeLookaheadBlockCount = 11;
 const startupPaletteFamilies = CSSCYCLONE_PRESENTATION.startupPaletteFamilies;
 const startupSilhouetteSampleFrameOffsets = CSSCYCLONE_PRESENTATION.startupSilhouetteSampleFrameOffsets;
 const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
@@ -78,8 +84,9 @@ await writeJson(join(stagingRoot, "prepared.json"), {
     runtimeGeometryConstruction: false,
     runtimeAtlasRasterization: false,
     runtimeDomGrowth: false,
-    runtimePreparedStateMaterialization: false,
-    runtimeMatrixFormatting: false,
+    runtimePreparedStateMaterialization: true,
+    runtimeBlockLoadMatrixFormatting: true,
+    runtimeFrameMatrixFormatting: false,
     runtimeIdLookup: false
   },
   profileSelection: {
@@ -118,7 +125,6 @@ async function prepareProfile(profile) {
   const { bank, startupSelections } = profile;
   const blocksPerChunk = bank.frameCount / blockFrameCount;
   const blockCount = bank.chunkCount * blocksPerChunk;
-  const runtimeLookaheadBlockCount = blockCount - 1;
   if (!Number.isSafeInteger(blocksPerChunk)) {
     throw new Error(`Cyclone ${profile.id} prepared chunk must divide into exact transport blocks`);
   }
@@ -141,7 +147,6 @@ async function prepareProfile(profile) {
       const result = buildCyclonePreparedModel({ source, modelId: profile.modelId });
       preparedModel = Object.freeze({ model: result.model, metrics: result.metrics });
     }
-    const preparedPlayback = buildCyclonePreparedPlayback({ source, modelId: profile.modelId });
     const lighting = lightingStream.add(source);
     for (const selection of startupSelections.filter((entry) =>
       entry.chunkIndex === source.bank.chunkIndex)) {
@@ -151,40 +156,14 @@ async function prepareProfile(profile) {
       const streamBlockIndex = source.bank.chunkIndex * blocksPerChunk + blockIndex;
       const localStartFrameIndex = blockIndex * blockFrameCount;
       const startFrameIndex = source.bank.startFrameIndex + localStartFrameIndex;
-      const blockPlayback = slicePreparedPlayback({
-        playback: preparedPlayback.playback,
-        blockIndex,
-        streamBlockIndex,
-        startFrameIndex,
-        localStartFrameIndex,
-        blockCount,
-        blocksPerChunk,
-      });
-      const blockLighting = Object.freeze({
-        schema: "csscyclone-prepared-lighting-block@1",
-        streamId: source.bank.streamId,
-        chunkIndex: source.bank.chunkIndex,
-        blockIndex,
-        streamBlockIndex,
-        startFrameIndex,
-        frameCount: blockFrameCount,
-        particleCount: source.bank.particleCount,
-        frameParticleColorStateIndices: lighting.frameParticleColorStateIndices.slice(
+      const decoded = Buffer.from(encodeCyclonePreparedBlock({
+        frames: source.frames.slice(localStartFrameIndex, localStartFrameIndex + blockFrameCount),
+        lightingRows: lighting.frameParticleColorStateIndices.slice(
           localStartFrameIndex,
           localStartFrameIndex + blockFrameCount,
         ),
-      });
-      const decoded = Buffer.from(`${JSON.stringify({
-        schema: "csscyclone-prepared-stream-block@1",
-        streamId: source.bank.streamId,
-        chunkIndex: source.bank.chunkIndex,
-        blockIndex,
-        streamBlockIndex,
-        startFrameIndex,
-        frameCount: blockFrameCount,
-        playback: blockPlayback,
-        lighting: blockLighting,
-      })}\n`);
+        particleCount: source.bank.particleCount,
+      }));
       const encoded = gzipSync(decoded, { level: 9 });
       const encodedSha256 = sha256(encoded);
       const decodedSha256 = sha256(decoded);
@@ -198,7 +177,7 @@ async function prepareProfile(profile) {
         frameCount: blockFrameCount,
         sourceContinuousFromPrevious: streamBlockIndex > 0,
         assetUrl,
-        encoding: "gzip-newline-json",
+        encoding: CSSCYCLONE_BLOCK_ENCODING,
         byteLength: encoded.byteLength,
         sha256: encodedSha256,
         decodedByteLength: decoded.byteLength,
@@ -207,9 +186,9 @@ async function prepareProfile(profile) {
       preparedBlockEncodedBytes += encoded.byteLength;
       preparedBlockDecodedBytes += decoded.byteLength;
     }
-    preparedFrameCount += preparedPlayback.metrics.preparedFrameCount;
-    uniquePreparedTransformCount += preparedPlayback.metrics.uniquePreparedTransformCount;
-    shapeTransformSelections += preparedPlayback.metrics.shapeTransformSelections;
+    preparedFrameCount += source.frames.length;
+    uniquePreparedTransformCount += source.frames.length * source.bank.particleCount;
+    shapeTransformSelections += source.frames.length * source.bank.particleCount;
   }
   const residentBlockWindowCount = runtimeLookaheadBlockCount + 1;
   const maximumResidentBlockWindowDecodedBytes = Math.max(...blockEntries.map((unused, startIndex) =>
@@ -225,6 +204,17 @@ async function prepareProfile(profile) {
   const catalogBytes = Buffer.from(`${JSON.stringify({
     schema: "csscyclone-prepared-stream-catalog@1",
     streamId: bank.id,
+    modelId: profile.modelId,
+    particleCount: bank.particleCount,
+    leafCount: bank.particleCount * CSSCYCLONE_FACE_INDICES.length,
+    playbackSchema: CSSCYCLONE_PLAYBACK_SCHEMA,
+    lightingBlockSchema: CSSCYCLONE_LIGHTING_BLOCK_SCHEMA,
+    sourceTransformProfile: Object.freeze({
+      controlPointCount: 6,
+      speed: CSSCYCLONE_SOURCE.speed,
+      complexity: CSSCYCLONE_SOURCE.complexity,
+      particleSize: CSSCYCLONE_SOURCE.particleSize,
+    }),
     seed: bank.seed,
     chunkCount: bank.chunkCount,
     chunkFrameCount: bank.frameCount,
@@ -295,7 +285,7 @@ async function prepareProfile(profile) {
         maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
         startupColorProfile,
         startupSelection: "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat",
-        handoff: "source-continuous-full-stream-decoded-before-playback",
+        handoff: "source-continuous-twelve-block-decoded-window",
       }),
       productParticleCount: bank.particleCount,
       productLeafCount: bank.particleCount * CSSCYCLONE_FACE_INDICES.length,
@@ -322,7 +312,10 @@ async function prepareProfile(profile) {
       residentBlockWindowCount,
       maximumResidentBlockWindowDecodedBytes,
       runtimeLookaheadBlockCount,
-      runtimePreparedStateMaterialization: false,
+      transportEncoding: CSSCYCLONE_BLOCK_ENCODING,
+      runtimePreparedStateMaterialization: true,
+      runtimePreparedStateMaterializationPhase: "block-load-before-publication",
+      runtimeIncrementalLookaheadMaterialization: true,
     }),
     lighting: preparedLighting.contract,
   });
@@ -342,52 +335,6 @@ async function prepareProfile(profile) {
       maximumResidentBlockWindowDecodedBytes,
       ...preparedLighting.metrics,
     }),
-  });
-}
-
-function slicePreparedPlayback({
-  playback,
-  blockIndex,
-  streamBlockIndex,
-  startFrameIndex,
-  localStartFrameIndex,
-  blockCount,
-  blocksPerChunk,
-}) {
-  const sourceRows = playback.frames.slice(
-    localStartFrameIndex,
-    localStartFrameIndex + blockFrameCount,
-  );
-  const transforms = [];
-  const remappedTransformIndices = new Map();
-  const frames = sourceRows.map((row) => Object.freeze(row.map((value, index) => {
-    if (index % 2 === 0) return value;
-    let remapped = remappedTransformIndices.get(value);
-    if (remapped === undefined) {
-      remapped = transforms.length;
-      transforms.push(playback.transforms[value]);
-      remappedTransformIndices.set(value, remapped);
-    }
-    return remapped;
-  })));
-  const shapeTransformIndices = Array(playback.particleCount);
-  for (let operation = 0; operation < frames[0].length; operation += 2) {
-    shapeTransformIndices[frames[0][operation]] = frames[0][operation + 1];
-  }
-  return Object.freeze({
-    ...playback,
-    blockIndex,
-    streamBlockIndex,
-    blockCount,
-    blocksPerChunk,
-    startFrameIndex,
-    durationMilliseconds: blockFrameCount * playback.frameMilliseconds,
-    frameCount: blockFrameCount,
-    transforms: Object.freeze(transforms),
-    mounted: Object.freeze({
-      shapeTransformIndices: Object.freeze(shapeTransformIndices),
-    }),
-    frames: Object.freeze(frames),
   });
 }
 


### PR DESCRIPTION
## What changed
- replace repeated per-frame CSS `matrix3d(...)` JSON strings with exact source-state binary blocks
- store shared control points/widths, initial particle state, sparse reset events, and flat Uint16 lighting indices
- rebuild exact prepared CSS matrices once at block load, with Gravitywell-style bounded incremental decoding during playback
- retain the active block plus 11 successors on desktop and mobile

## Payload
- mobile full motion stream: 103.7 MB gzip -> 2.76 MB gzip
- desktop full motion stream: 246.2 MB gzip -> 3.98 MB gzip
- mobile initial 12-block motion window: <=154,379 bytes
- desktop initial 12-block motion window: <=223,164 bytes

## Verification
- exact compact transport round-trip equals the prior prepared matrix strings
- `pnpm test:cyclone` (29/29)
- `pnpm build:cyclone`
- local Chromium mobile profile: 25 block switches, 0 prepared-block waits, 0 frame gaps >=100ms
- local Chromium desktop profile: 15 block switches, 0 prepared-block waits, 0 frame gaps >=100ms

USB Android was not visible to adb during this verification, so the browser traces above are local Chromium evidence.