### PR TITLE
fix(cyclone): publish prepared playback at 60hz

### DIFF
--- a/src/adapters/cyclone/src/csscyclone/preparedBlockWorker.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedBlockWorker.mjs
@@ -5,7 +5,7 @@ let catalog = null;
 self.addEventListener("message", ({ data }) => {
   try {
     if (data?.type === "initialize") {
-      if (catalog !== null || data.catalog?.schema !== "csscyclone-prepared-stream-catalog@1") {
+      if (catalog !== null || data.catalog?.schema !== "csscyclone-prepared-stream-catalog@2") {
         throw new Error("Prepared Cyclone worker catalog drifted");
       }
       catalog = data.catalog;

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -5,7 +5,7 @@ import {
   CSSCYCLONE_PLAYBACK_SCHEMA,
 } from "../shared/csscyclone/preparedBlockTransport.mjs";
 
-const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@1";
+const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@2";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@2";
 const LIGHTING_SCHEMA = "csscyclone-prepared-smooth-lighting-atlas@7";
 const SOURCE_FIELD_OF_VIEW_DEGREES = 80;
@@ -90,7 +90,7 @@ export function createCyclonePreparedPlayer({
   let clockOrigin = readNow() - initialFrameIndex * playback.frameMilliseconds;
   let pausedAt = initialFrameIndex * playback.frameMilliseconds;
   let frameIndex = initialFrameIndex;
-  const schedulerLeadMilliseconds = Math.min(4, playback.frameMilliseconds / 4);
+  const schedulerLeadMilliseconds = Math.min(8, playback.frameMilliseconds / 2);
   let schedulerFrameRequestCount = 0;
   let schedulerFrameCallbackCount = 0;
   let schedulerFrameCancelCount = 0;
@@ -409,6 +409,8 @@ function validateBinding(
   if (modelTransform !== STYLESHEET_MODEL_TRANSFORM ||
       catalog?.schema !== CATALOG_SCHEMA ||
       catalog.blockCount !== catalog.entries?.length ||
+      catalog.framesPerSecond !== 60 ||
+      catalog.frameMilliseconds !== 1_000 / catalog.framesPerSecond ||
       !Number.isSafeInteger(catalog.runtimeLookaheadBlockCount) ||
       catalog.runtimeLookaheadBlockCount < 1 ||
       catalog.runtimeLookaheadBlockCount > catalog.blockCount ||
@@ -463,6 +465,9 @@ function validateBlockBinding(block, catalog, model, lighting) {
       playback.blockCount !== catalog.blockCount ||
       playback.blocksPerChunk !== catalog.blocksPerChunk ||
       playback.startFrameIndex !== block.startFrameIndex ||
+      playback.framesPerSecond !== catalog.framesPerSecond ||
+      playback.frameMilliseconds !== catalog.frameMilliseconds ||
+      playback.durationMilliseconds !== block.frameCount / catalog.framesPerSecond * 1_000 ||
       playback.frameCount !== block.frameCount ||
       playback.particleCount !== model.render.shapes.length ||
       playback.leafCount !== model.render.leaves.length ||

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -6,7 +6,7 @@ import {
   decodeCyclonePreparedBlockIncrementally,
 } from "../shared/csscyclone/preparedBlockTransport.mjs";
 
-const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@1";
+const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@2";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@2";
 const RUNTIME_LOOKAHEAD_BLOCK_COUNT = 11;
 const STARTUP_MATERIALIZED_LOOKAHEAD_BLOCK_COUNT = 1;
@@ -449,9 +449,12 @@ function validateCatalog(catalog) {
       catalog.blockCount !== catalog.chunkCount * catalog.blocksPerChunk ||
       !Number.isSafeInteger(catalog.blockFrameCount) || catalog.blockFrameCount < 1 ||
       catalog.chunkFrameCount !== catalog.blocksPerChunk * catalog.blockFrameCount ||
-      !Number.isSafeInteger(catalog.frameMilliseconds) || catalog.frameMilliseconds < 1 ||
+      catalog.framesPerSecond !== 60 ||
+      !Number.isFinite(catalog.frameMilliseconds) ||
+      catalog.frameMilliseconds !== 1_000 / catalog.framesPerSecond ||
       catalog.streamFrameCount !== catalog.chunkCount * catalog.chunkFrameCount ||
-      catalog.streamDurationMilliseconds !== catalog.streamFrameCount * catalog.frameMilliseconds ||
+      catalog.streamDurationMilliseconds !== catalog.streamFrameCount /
+        catalog.framesPerSecond * 1_000 ||
       !Array.isArray(catalog.startupPaletteFamilies) ||
       catalog.startupPaletteFamilies.length !== STARTUP_PALETTE_FAMILIES.length ||
       catalog.startupPaletteFamilies.some((family, index) =>
@@ -564,9 +567,10 @@ function validateBlock(block, descriptor, catalog) {
       playback.blockCount !== catalog.blockCount ||
       playback.blocksPerChunk !== catalog.blocksPerChunk ||
       playback.startFrameIndex !== descriptor.startFrameIndex ||
+      playback.framesPerSecond !== catalog.framesPerSecond ||
       playback.frameMilliseconds !== catalog.frameMilliseconds ||
       playback.frameCount !== descriptor.frameCount ||
-      playback.durationMilliseconds !== descriptor.frameCount * catalog.frameMilliseconds ||
+      playback.durationMilliseconds !== descriptor.frameCount / catalog.framesPerSecond * 1_000 ||
       playback.loop !== false ||
       playback.particleCount !== catalog.particleCount ||
       playback.leafCount !== catalog.leafCount ||

--- a/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
@@ -139,13 +139,14 @@ export function buildCyclonePreparedPlayback({
   const transforms = source.frames.flatMap((frame) => frame.particles.map((particle) =>
     `matrix3d(${formatMatrix3dValues(particle.matrix, 6)})`));
   const playback = deepFreeze({
-    schema: "csscyclone-prepared-dom-playback@4",
+    schema: "csscyclone-prepared-dom-playback@5",
     bankId: source.bank.id,
     streamId: source.bank.streamId,
     chunkIndex: source.bank.chunkIndex,
     chunkCount: source.bank.chunkCount,
     startFrameIndex: source.bank.startFrameIndex,
     modelId,
+    framesPerSecond: source.bank.framesPerSecond,
     frameMilliseconds: source.bank.frameMilliseconds,
     durationMilliseconds: source.durationMilliseconds,
     frameCount: source.frames.length,

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -1,6 +1,19 @@
 import { advanceCycloneParticleTransform } from "../../shared/csscyclone/particleTransform.mjs";
 
 const CONTROL_POINT_COUNT = 6;
+const PREPARED_FRAMES_PER_SECOND = 60;
+const preparedFrames = (seconds) => Math.round(seconds * PREPARED_FRAMES_PER_SECOND);
+const STARTUP_WINDOW_FRAME_COUNT = preparedFrames(0.8);
+
+export const CSSCYCLONE_PREPARED_CADENCE = Object.freeze({
+  framesPerSecond: PREPARED_FRAMES_PER_SECOND,
+  frameMilliseconds: 1_000 / PREPARED_FRAMES_PER_SECOND,
+  warmupSeconds: 12,
+  chunkSeconds: 9,
+  blockSeconds: 1,
+  streamSeconds: 216,
+  startupWindowSeconds: 0.8,
+});
 
 export const CSSCYCLONE_SOURCE = Object.freeze({
   repository: "https://github.com/reallyslickscreensavers/reallyslickscreensavers",
@@ -26,9 +39,10 @@ const CSSCYCLONE_DESKTOP_BANK = Object.freeze({
   name: "Cyclone",
   seed: 1,
   particleCount: 400,
-  frameMilliseconds: 20,
-  warmupFrames: 600,
-  frameCount: 450,
+  framesPerSecond: CSSCYCLONE_PREPARED_CADENCE.framesPerSecond,
+  frameMilliseconds: CSSCYCLONE_PREPARED_CADENCE.frameMilliseconds,
+  warmupFrames: preparedFrames(CSSCYCLONE_PREPARED_CADENCE.warmupSeconds),
+  frameCount: preparedFrames(CSSCYCLONE_PREPARED_CADENCE.chunkSeconds),
   chunkCount: 24,
 });
 
@@ -54,31 +68,31 @@ export const CSSCYCLONE_PRESENTATION = Object.freeze({
   maximumColorFamilyCount: 3,
   startupPaletteFamilies: Object.freeze(["blue", "yellow", "red", "magenta", "green"]),
   startupSelections: Object.freeze([
-    Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 20, frameCount: 40 }),
-    Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 190, frameCount: 40 }),
-    Object.freeze({ id: "yellow-a", paletteFamily: "yellow", chunkIndex: 1, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "yellow-b", paletteFamily: "yellow", chunkIndex: 7, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "red-a", paletteFamily: "red", chunkIndex: 5, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "red-b", paletteFamily: "red", chunkIndex: 9, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "magenta-a", paletteFamily: "magenta", chunkIndex: 4, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "magenta-b", paletteFamily: "magenta", chunkIndex: 11, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "green-a", paletteFamily: "green", chunkIndex: 17, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "green-b", paletteFamily: "green", chunkIndex: 19, startFrameIndex: 55, frameCount: 40 }),
+    startupSelection("blue-a", "blue", 17, 249),
+    startupSelection("blue-b", "blue", 23, 492),
+    startupSelection("yellow-a", "yellow", 6, 450),
+    startupSelection("yellow-b", "yellow", 21, 162),
+    startupSelection("red-a", "red", 19, 171),
+    startupSelection("red-b", "red", 13, 104),
+    startupSelection("magenta-a", "magenta", 18, 279),
+    startupSelection("magenta-b", "magenta", 12, 414),
+    startupSelection("green-a", "green", 7, 250),
+    startupSelection("green-b", "green", 15, 201),
   ]),
   mobileStartupSelections: Object.freeze([
-    Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 75, frameCount: 40 }),
-    Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 190, frameCount: 40 }),
-    Object.freeze({ id: "yellow-a", paletteFamily: "yellow", chunkIndex: 1, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "yellow-b", paletteFamily: "yellow", chunkIndex: 7, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "red-a", paletteFamily: "red", chunkIndex: 5, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "red-b", paletteFamily: "red", chunkIndex: 9, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "magenta-a", paletteFamily: "magenta", chunkIndex: 4, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "magenta-b", paletteFamily: "magenta", chunkIndex: 11, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "green-a", paletteFamily: "green", chunkIndex: 17, startFrameIndex: 55, frameCount: 40 }),
-    Object.freeze({ id: "green-b", paletteFamily: "green", chunkIndex: 19, startFrameIndex: 55, frameCount: 40 }),
+    startupSelection("blue-a", "blue", 1, 123),
+    startupSelection("blue-b", "blue", 23, 492),
+    startupSelection("yellow-a", "yellow", 6, 447),
+    startupSelection("yellow-b", "yellow", 21, 168),
+    startupSelection("red-a", "red", 19, 160),
+    startupSelection("red-b", "red", 13, 339),
+    startupSelection("magenta-a", "magenta", 18, 261),
+    startupSelection("magenta-b", "magenta", 12, 414),
+    startupSelection("green-a", "green", 7, 256),
+    startupSelection("green-b", "green", 7, 492),
   ]),
   startupSilhouetteSampling: "browser-reviewed-expressive-source-windows",
-  startupSilhouetteSampleFrameOffsets: Object.freeze([0, 10, 20, 30, 39]),
+  startupSilhouetteSampleFrameOffsets: Object.freeze([0, 0.2, 0.4, 0.6, 0.78].map(preparedFrames)),
   startupMinimumMeanSaturation: 0.68,
   startupMinimumDominantHueShare: 0.25,
 });
@@ -102,7 +116,7 @@ export function* buildCycloneSourceChunks({ bank = CSSCYCLONE_BANK } = {}) {
     for (let frame = 0; frame < bank.frameCount; frame += 1) {
       const transformState = stepSource(cyclone, particles, rng, deltaSeconds);
       frames.push(Object.freeze({
-        timeMs: (startFrameIndex + frame) * bank.frameMilliseconds,
+        timeMs: (startFrameIndex + frame) / bank.framesPerSecond * 1_000,
         transformState,
         particles: Object.freeze(particles.map((particle) => Object.freeze({
           matrix: particle.matrix,
@@ -123,8 +137,8 @@ export function* buildCycloneSourceChunks({ bank = CSSCYCLONE_BANK } = {}) {
       }),
       modelMatrix: flattenCss(multiply4(scale4([1, -1, 1]), translation([0, 0, -CSSCYCLONE_SOURCE.viewDistance]))),
       frames,
-      durationMilliseconds: bank.frameCount * bank.frameMilliseconds,
-      streamDurationMilliseconds: bank.chunkCount * bank.frameCount * bank.frameMilliseconds,
+      durationMilliseconds: bank.frameCount / bank.framesPerSecond * 1_000,
+      streamDurationMilliseconds: bank.chunkCount * bank.frameCount / bank.framesPerSecond * 1_000,
     });
   }
 }
@@ -135,6 +149,7 @@ export function selectCycloneSourceParticlePrefix(source, bank = CSSCYCLONE_BANK
       !Array.isArray(source.frames) || source.frames.length !== source.bank?.frameCount ||
       bank.particleCount > source.bank.particleCount ||
       bank.seed !== source.bank.seed ||
+      bank.framesPerSecond !== source.bank.framesPerSecond ||
       bank.frameMilliseconds !== source.bank.frameMilliseconds ||
       bank.warmupFrames !== source.bank.warmupFrames ||
       bank.frameCount !== source.bank.frameCount ||
@@ -165,7 +180,7 @@ function validateBank(bank) {
   for (const [name, value] of Object.entries({
     seed: bank?.seed,
     particleCount: bank?.particleCount,
-    frameMilliseconds: bank?.frameMilliseconds,
+    framesPerSecond: bank?.framesPerSecond,
     warmupFrames: bank?.warmupFrames,
     frameCount: bank?.frameCount,
     chunkCount: bank?.chunkCount,
@@ -174,6 +189,20 @@ function validateBank(bank) {
       throw new RangeError(`Cyclone ${name} must be a positive safe integer`);
     }
   }
+  if (!Number.isFinite(bank?.frameMilliseconds) ||
+      bank.frameMilliseconds !== 1_000 / bank.framesPerSecond) {
+    throw new RangeError("Cyclone frame milliseconds must match the prepared frame rate");
+  }
+}
+
+function startupSelection(id, paletteFamily, chunkIndex, startFrameIndex) {
+  return Object.freeze({
+    id,
+    paletteFamily,
+    chunkIndex,
+    startFrameIndex,
+    frameCount: STARTUP_WINDOW_FRAME_COUNT,
+  });
 }
 
 function createCyclone(rng) {

--- a/src/adapters/cyclone/src/shared/csscyclone/preparedBlockTransport.mjs
+++ b/src/adapters/cyclone/src/shared/csscyclone/preparedBlockTransport.mjs
@@ -2,7 +2,7 @@ import { formatMatrix3dValues } from "@layoutit/polycss";
 import { advanceCycloneParticleTransform } from "./particleTransform.mjs";
 
 export const CSSCYCLONE_BLOCK_ENCODING = "gzip-cyclone-source-state-float64-uint16@1";
-export const CSSCYCLONE_PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@4";
+export const CSSCYCLONE_PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@5";
 export const CSSCYCLONE_LIGHTING_BLOCK_SCHEMA = "csscyclone-prepared-lighting-block@2";
 
 const MAGIC = "CCST";
@@ -264,8 +264,9 @@ function* decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog) {
       frameCount,
       particleCount,
       leafCount: catalog.leafCount,
+      framesPerSecond: catalog.framesPerSecond,
       frameMilliseconds: catalog.frameMilliseconds,
-      durationMilliseconds: frameCount * catalog.frameMilliseconds,
+      durationMilliseconds: frameCount / catalog.framesPerSecond * 1_000,
       loop: false,
       transforms: Object.freeze(transforms),
     }),

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -34,7 +34,7 @@ function fixture({
   const shapeElements = Array.from({ length: 2 }, () => new FakeHTMLElement());
   const leafElements = Array.from({ length: 2 }, () => new FakeHTMLElement());
   const playback = {
-    schema: "csscyclone-prepared-dom-playback@4",
+    schema: "csscyclone-prepared-dom-playback@5",
     modelId: "cyclone",
     streamId: "stream",
     streamBlockIndex: 0,
@@ -47,8 +47,9 @@ function fixture({
     frameCount: 4,
     particleCount: 2,
     leafCount: 2,
-    frameMilliseconds: 20,
-    durationMilliseconds: 80,
+    framesPerSecond: 60,
+    frameMilliseconds: 1_000 / 60,
+    durationMilliseconds: 4 / 60 * 1_000,
     loop: false,
     transforms: ["a", "b", "c", "d", "e", "f", "g", "h"],
   };
@@ -102,7 +103,7 @@ function fixture({
     };
   });
   const catalog = {
-    schema: "csscyclone-prepared-stream-catalog@1",
+    schema: "csscyclone-prepared-stream-catalog@2",
     streamId: "stream",
     chunkCount: 1,
     chunkFrameCount: blockCount * 4,
@@ -110,9 +111,11 @@ function fixture({
     entries: Array.from({ length: blockCount }, () => ({})),
     blocksPerChunk: blockCount,
     blockFrameCount: 4,
+    framesPerSecond: 60,
+    frameMilliseconds: 1_000 / 60,
     runtimeLookaheadBlockCount,
     streamFrameCount: blockCount * 4,
-    streamDurationMilliseconds: blockCount * 80,
+    streamDurationMilliseconds: blockCount * 4 / 60 * 1_000,
   };
   const mounted = {
     model: {
@@ -191,7 +194,7 @@ test("hands each prepared publication from its deadline timer to requestAnimatio
   state.player.resume();
   assert.equal(state.delays.size, 1);
   assert.equal(state.frames.size, 0);
-  assert.equal(state.fireDelay(), 16);
+  assert.equal(state.fireDelay(), 1_000 / 60 - 8);
   assert.equal(state.frames.size, 1);
   state.setNow(20);
   await state.fireFrame();
@@ -234,7 +237,7 @@ test("collapses missed prepared frames once at the next paint-aligned callback",
   const state = fixture();
   state.player.resume();
   state.fireDelay();
-  state.setNow(61);
+  state.setNow(57);
   await state.fireFrame();
   assert.deepEqual(state.shapeElements.map((element) => element.style.transform), ["g", "h"]);
   const stats = state.player.stats();

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -37,8 +37,17 @@ test("pins the current Really Slick Cyclone source profile", () => {
   assert.equal(CSSCYCLONE_SOURCE.particleSize, 7);
   assert.equal(CSSCYCLONE_SOURCE.complexity, 3);
   assert.equal(CSSCYCLONE_SOURCE.speed, 10);
+  assert.equal(CSSCYCLONE_BANK.framesPerSecond, 60);
+  assert.equal(CSSCYCLONE_BANK.frameMilliseconds, 1_000 / 60);
+  assert.equal(CSSCYCLONE_BANK.warmupFrames, 720);
   assert.equal(CSSCYCLONE_BANK.chunkCount, 24);
-  assert.equal(CSSCYCLONE_BANK.frameCount, 450);
+  assert.equal(CSSCYCLONE_BANK.frameCount, 540);
+  assert.equal(CSSCYCLONE_BANK.warmupFrames / CSSCYCLONE_BANK.framesPerSecond, 12);
+  assert.equal(CSSCYCLONE_BANK.frameCount / CSSCYCLONE_BANK.framesPerSecond, 9);
+  assert.equal(
+    CSSCYCLONE_BANK.chunkCount * CSSCYCLONE_BANK.frameCount / CSSCYCLONE_BANK.framesPerSecond,
+    216,
+  );
   assert.equal(CSSCYCLONE_PRESENTATION.saturationSampling, "floor-0.55-plus-0.45-sqrt-uniform");
   assert.equal(CSSCYCLONE_PRESENTATION.minimumSaturation, 0.55);
   assert.equal(CSSCYCLONE_PRESENTATION.hueSampling, "source-uniform-random-targets");
@@ -57,24 +66,24 @@ test("pins the current Really Slick Cyclone source profile", () => {
   assert.equal(CSSCYCLONE_PRESENTATION.mobileStartupSelections.length, 10);
   assert.deepEqual(
     CSSCYCLONE_PRESENTATION.mobileStartupSelections.find(({ id }) => id === "blue-a"),
-    { id: "blue-a", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 75, frameCount: 40 },
+    { id: "blue-a", paletteFamily: "blue", chunkIndex: 1, startFrameIndex: 123, frameCount: 48 },
   );
   assert.deepEqual(
     CSSCYCLONE_PRESENTATION.startupSelections.map(({ id, paletteFamily, chunkIndex }) =>
       [id, paletteFamily, chunkIndex]),
     [
-      ["blue-a", "blue", 0], ["blue-b", "blue", 0],
-      ["yellow-a", "yellow", 1], ["yellow-b", "yellow", 7],
-      ["red-a", "red", 5], ["red-b", "red", 9],
-      ["magenta-a", "magenta", 4], ["magenta-b", "magenta", 11],
-      ["green-a", "green", 17], ["green-b", "green", 19],
+      ["blue-a", "blue", 17], ["blue-b", "blue", 23],
+      ["yellow-a", "yellow", 6], ["yellow-b", "yellow", 21],
+      ["red-a", "red", 19], ["red-b", "red", 13],
+      ["magenta-a", "magenta", 18], ["magenta-b", "magenta", 12],
+      ["green-a", "green", 7], ["green-b", "green", 15],
     ],
   );
   assert.equal(
     CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
     "browser-reviewed-expressive-source-windows",
   );
-  assert.deepEqual(CSSCYCLONE_PRESENTATION.startupSilhouetteSampleFrameOffsets, [0, 10, 20, 30, 39]);
+  assert.deepEqual(CSSCYCLONE_PRESENTATION.startupSilhouetteSampleFrameOffsets, [0, 12, 24, 36, 47]);
   assert.equal(CSSCYCLONE_PRESENTATION.startupMinimumMeanSaturation, 0.68);
   assert.equal(CSSCYCLONE_PRESENTATION.startupMinimumDominantHueShare, 0.25);
 });
@@ -129,7 +138,7 @@ test("builds a stable retained particle graph and prepared state bank", () => {
   assert.equal(preparedModel.model.render.leaves.length, 18);
   assert.equal(preparedModel.model.topology.polygons.length, 18);
   assert.equal(preparedPlayback.playback.transforms.length, 12);
-  assert.equal(preparedPlayback.playback.schema, "csscyclone-prepared-dom-playback@4");
+  assert.equal(preparedPlayback.playback.schema, "csscyclone-prepared-dom-playback@5");
   assert.equal(preparedPlayback.metrics.shapeTransformSelections, 12);
   assert.equal(preparedModel.metrics.runtimeGeometryConstructionCount, 0);
   assert.equal(preparedModel.metrics.runtimeAtlasRasterizationCount, 0);
@@ -263,7 +272,7 @@ test("prepares smooth reference lighting without a runtime lighting timeline", a
 });
 
 test("publishes only exact source color restarts through sparse leaf addresses", async () => {
-  const bank = { ...CSSCYCLONE_BANK, particleCount: 3, warmupFrames: 20, frameCount: 40 };
+  const bank = { ...CSSCYCLONE_BANK, particleCount: 3, warmupFrames: 24, frameCount: 48 };
   const source = buildCycloneSourceSequence({ bank });
   const prepared = await buildCyclonePreparedLighting({ source });
   let changedParticleCount = 0;
@@ -324,12 +333,12 @@ test("is deterministic for an explicit bank seed", () => {
 });
 
 test("preserves the source tangent orientation", () => {
-  const bank = { ...CSSCYCLONE_BANK, particleCount: 2, warmupFrames: 20, frameCount: 2 };
+  const bank = { ...CSSCYCLONE_BANK, particleCount: 2, warmupFrames: 24, frameCount: 2 };
   const source = buildCycloneSourceSequence({ bank });
   assert.deepEqual(source.frames[0].particles[0].matrix, [
-    0.616677, -0.443615, 0.65032, 0,
-    0.215753, 0.889711, 0.402324, 0,
-    -4.542442, -0.646772, 3.866253, 0,
-    13.837036, -19.302883, 80.890841, 1,
+    0.532427, -0.451061, 0.716286, 0,
+    0.215511, 0.890546, 0.400604, 0,
+    -4.092909, -0.294623, 2.856797, 0,
+    12.934245, -19.506742, 81.488458, 1,
   ]);
 });

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -6,24 +6,24 @@ const hash = "0".repeat(64);
 const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
 const startupPaletteFamilies = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
 const startupSelections = Object.freeze([
-  Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 20, frameCount: 40 }),
-  Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 0, startFrameIndex: 190, frameCount: 40 }),
-  Object.freeze({ id: "yellow-a", paletteFamily: "yellow", chunkIndex: 1, startFrameIndex: 55, frameCount: 40 }),
-  Object.freeze({ id: "yellow-b", paletteFamily: "yellow", chunkIndex: 7, startFrameIndex: 55, frameCount: 40 }),
-  Object.freeze({ id: "red-a", paletteFamily: "red", chunkIndex: 5, startFrameIndex: 55, frameCount: 40 }),
-  Object.freeze({ id: "red-b", paletteFamily: "red", chunkIndex: 9, startFrameIndex: 55, frameCount: 40 }),
-  Object.freeze({ id: "magenta-a", paletteFamily: "magenta", chunkIndex: 4, startFrameIndex: 55, frameCount: 40 }),
-  Object.freeze({ id: "magenta-b", paletteFamily: "magenta", chunkIndex: 11, startFrameIndex: 55, frameCount: 40 }),
-  Object.freeze({ id: "green-a", paletteFamily: "green", chunkIndex: 17, startFrameIndex: 55, frameCount: 40 }),
-  Object.freeze({ id: "green-b", paletteFamily: "green", chunkIndex: 19, startFrameIndex: 55, frameCount: 40 }),
+  Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 17, startFrameIndex: 249, frameCount: 48 }),
+  Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 23, startFrameIndex: 492, frameCount: 48 }),
+  Object.freeze({ id: "yellow-a", paletteFamily: "yellow", chunkIndex: 6, startFrameIndex: 450, frameCount: 48 }),
+  Object.freeze({ id: "yellow-b", paletteFamily: "yellow", chunkIndex: 21, startFrameIndex: 162, frameCount: 48 }),
+  Object.freeze({ id: "red-a", paletteFamily: "red", chunkIndex: 19, startFrameIndex: 171, frameCount: 48 }),
+  Object.freeze({ id: "red-b", paletteFamily: "red", chunkIndex: 13, startFrameIndex: 104, frameCount: 48 }),
+  Object.freeze({ id: "magenta-a", paletteFamily: "magenta", chunkIndex: 18, startFrameIndex: 279, frameCount: 48 }),
+  Object.freeze({ id: "magenta-b", paletteFamily: "magenta", chunkIndex: 12, startFrameIndex: 414, frameCount: 48 }),
+  Object.freeze({ id: "green-a", paletteFamily: "green", chunkIndex: 7, startFrameIndex: 250, frameCount: 48 }),
+  Object.freeze({ id: "green-b", paletteFamily: "green", chunkIndex: 15, startFrameIndex: 201, frameCount: 48 }),
 ]);
 const catalog = Object.freeze({
-  schema: "csscyclone-prepared-stream-catalog@1",
+  schema: "csscyclone-prepared-stream-catalog@2",
   streamId: "desktop-stream",
   modelId: "cyclone",
   particleCount: 400,
   leafCount: 2_400,
-  playbackSchema: "csscyclone-prepared-dom-playback@4",
+  playbackSchema: "csscyclone-prepared-dom-playback@5",
   lightingBlockSchema: "csscyclone-prepared-lighting-block@2",
   sourceTransformProfile: Object.freeze({
     controlPointCount: 6,
@@ -32,17 +32,18 @@ const catalog = Object.freeze({
     particleSize: 7,
   }),
   chunkCount: 24,
-  chunkFrameCount: 450,
+  chunkFrameCount: 540,
   blockCount: 216,
   blocksPerChunk: 9,
-  blockFrameCount: 50,
-  frameMilliseconds: 20,
-  streamFrameCount: 10_800,
+  blockFrameCount: 60,
+  framesPerSecond: 60,
+  frameMilliseconds: 1_000 / 60,
+  streamFrameCount: 12_960,
   streamDurationMilliseconds: 216_000,
   startupPaletteFamilies,
   startupSelections,
   startupSilhouetteSampling: "browser-reviewed-expressive-source-windows",
-  startupSilhouetteSampleFrameOffsets: Object.freeze([0, 10, 20, 30, 39]),
+  startupSilhouetteSampleFrameOffsets: Object.freeze([0, 12, 24, 36, 47]),
   maximumColorFamilyCount: 3,
   selection: "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat",
   startupColorProfile: Object.freeze({
@@ -72,8 +73,8 @@ const catalog = Object.freeze({
     index,
     chunkIndex: Math.floor(index / 9),
     blockIndex: index % 9,
-    startFrameIndex: index * 50,
-    frameCount: 50,
+    startFrameIndex: index * 60,
+    frameCount: 60,
     sourceContinuousFromPrevious: index > 0,
     encoding: "gzip-cyclone-source-state-float64-uint16@1",
     assetUrl: `/block-${index}.bin`,
@@ -90,8 +91,8 @@ test("selects a balanced prepared source-palette window once", () => {
   }), {
     selectionId: "red-b",
     paletteFamily: "red",
-    chunkIndex: 9,
-    frameIndex: 76,
+    chunkIndex: 13,
+    frameIndex: 141,
     mode: "crypto-random-balanced-source-palette",
   });
 });
@@ -103,8 +104,8 @@ test("does not immediately repeat the previous prepared window", () => {
   }), {
     selectionId: "red-a",
     paletteFamily: "red",
-    chunkIndex: 5,
-    frameIndex: 76,
+    chunkIndex: 19,
+    frameIndex: 208,
     mode: "crypto-random-balanced-source-palette-no-repeat",
   });
 });
@@ -116,8 +117,8 @@ test("uses the session-shuffled family while retaining a random curated source w
   }), {
     selectionId: "green-b",
     paletteFamily: "green",
-    chunkIndex: 19,
-    frameIndex: 76,
+    chunkIndex: 15,
+    frameIndex: 238,
     mode: "session-shuffled-palette-crypto-random-source-window",
   });
 });
@@ -140,11 +141,11 @@ test("gives each prepared three-family palette variant equal selection coverage"
 
 test("accepts an explicit chunk and frame for deterministic browser proof", () => {
   assert.deepEqual(selectInitialCyclonePosition(catalog, {
-    search: "?chunk=23&frame=449&palette=green",
+    search: "?chunk=23&frame=539&palette=green",
   }), {
     paletteFamily: "green",
     chunkIndex: 23,
-    frameIndex: 449,
+    frameIndex: 539,
     mode: "explicit",
   });
 });

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -19,6 +19,7 @@ import {
 } from "../src/shared/csscyclone/preparedBlockTransport.mjs";
 import {
   CSSCYCLONE_BANKS,
+  CSSCYCLONE_PREPARED_CADENCE,
   CSSCYCLONE_PRESENTATION,
   CSSCYCLONE_SOURCE,
   buildCycloneSourceChunks,
@@ -30,7 +31,8 @@ const repositoryRoot = resolve(adapterRoot, "..", "..", "..");
 const outputRoot = join(repositoryRoot, "build/generated/public/csscyclone");
 const stagingRoot = join(repositoryRoot, `build/generated/.csscyclone-${process.pid}`);
 const sourceLock = JSON.parse(await readFile(join(adapterRoot, "notes/references/source-lock.json"), "utf8"));
-const blockFrameCount = 50;
+const blockFrameCount = CSSCYCLONE_PREPARED_CADENCE.framesPerSecond *
+  CSSCYCLONE_PREPARED_CADENCE.blockSeconds;
 const runtimeLookaheadBlockCount = 11;
 const startupMaterializedLookaheadBlockCount = 1;
 const startupPaletteFamilies = CSSCYCLONE_PRESENTATION.startupPaletteFamilies;
@@ -203,7 +205,7 @@ async function prepareProfile(profile) {
   );
   const preparedLighting = await lightingStream.finalize();
   const catalogBytes = Buffer.from(`${JSON.stringify({
-    schema: "csscyclone-prepared-stream-catalog@1",
+    schema: "csscyclone-prepared-stream-catalog@2",
     streamId: bank.id,
     modelId: profile.modelId,
     particleCount: bank.particleCount,
@@ -222,9 +224,10 @@ async function prepareProfile(profile) {
     blockCount,
     blocksPerChunk,
     blockFrameCount,
+    framesPerSecond: bank.framesPerSecond,
     frameMilliseconds: bank.frameMilliseconds,
     streamFrameCount: bank.chunkCount * bank.frameCount,
-    streamDurationMilliseconds: bank.chunkCount * bank.frameCount * bank.frameMilliseconds,
+    streamDurationMilliseconds: bank.chunkCount * bank.frameCount / bank.framesPerSecond * 1_000,
     startupPaletteFamilies,
     startupSelections,
     startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
@@ -278,8 +281,10 @@ async function prepareProfile(profile) {
         seed: bank.seed,
         chunkCount: bank.chunkCount,
         chunkFrameCount: bank.frameCount,
+        framesPerSecond: bank.framesPerSecond,
+        frameMilliseconds: bank.frameMilliseconds,
         streamFrameCount: bank.chunkCount * bank.frameCount,
-        streamDurationMilliseconds: bank.chunkCount * bank.frameCount * bank.frameMilliseconds,
+        streamDurationMilliseconds: bank.chunkCount * bank.frameCount / bank.framesPerSecond * 1_000,
         startupPaletteFamilies,
         startupSelections,
         startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
@@ -293,7 +298,7 @@ async function prepareProfile(profile) {
       productLeafCount: bank.particleCount * CSSCYCLONE_FACE_INDICES.length,
       viewDistance: CSSCYCLONE_SOURCE.viewDistance,
       fieldOfViewDegrees: CSSCYCLONE_SOURCE.fieldOfViewDegrees,
-      startupWarmupMilliseconds: bank.warmupFrames * bank.frameMilliseconds,
+      startupWarmupMilliseconds: bank.warmupFrames / bank.framesPerSecond * 1_000,
     }),
     model: Object.freeze({
       id: profile.modelId,
@@ -411,19 +416,29 @@ function buildStartupColorProfile(selectionProfiles, bank, startupSelections) {
         startupSelections.some((selection) => offset >= selection.frameCount))) {
     throw new Error("Cyclone prepared startup selection configuration is invalid");
   }
-  if (selectionProfiles.length !== startupSelections.length ||
-      selectionProfiles.some((profile, index) => {
-        const selection = startupSelections[index];
-        return profile?.id !== selection.id ||
-          profile.paletteFamily !== selection.paletteFamily ||
-          profile.chunkIndex !== selection.chunkIndex ||
-          profile.startFrameIndex !== selection.startFrameIndex ||
-          profile.frameCount !== selection.frameCount ||
-          profile.meanSaturation < CSSCYCLONE_PRESENTATION.startupMinimumMeanSaturation ||
-          profile.dominantHueSector !== selection.paletteFamily ||
-          profile.dominantHueShare < CSSCYCLONE_PRESENTATION.startupMinimumDominantHueShare;
-      })) {
-    throw new Error("Cyclone prepared startup source-palette profile drifted");
+  const invalidSelectionProfiles = startupSelections.flatMap((selection, index) => {
+    const profile = selectionProfiles[index];
+    const failures = [];
+    if (profile?.id !== selection.id) failures.push("id");
+    if (profile?.paletteFamily !== selection.paletteFamily) failures.push("paletteFamily");
+    if (profile?.chunkIndex !== selection.chunkIndex) failures.push("chunkIndex");
+    if (profile?.startFrameIndex !== selection.startFrameIndex) failures.push("startFrameIndex");
+    if (profile?.frameCount !== selection.frameCount) failures.push("frameCount");
+    if (!(profile?.meanSaturation >= CSSCYCLONE_PRESENTATION.startupMinimumMeanSaturation)) {
+      failures.push("meanSaturation");
+    }
+    if (profile?.dominantHueSector !== selection.paletteFamily) failures.push("dominantHueSector");
+    if (!(profile?.dominantHueShare >= CSSCYCLONE_PRESENTATION.startupMinimumDominantHueShare)) {
+      failures.push("dominantHueShare");
+    }
+    return failures.length === 0 ? [] : [{ selection, profile, failures }];
+  });
+  if (selectionProfiles.length !== startupSelections.length || invalidSelectionProfiles.length > 0) {
+    throw new Error(`Cyclone prepared startup source-palette profile drifted: ${JSON.stringify({
+      selectionProfileCount: selectionProfiles.length,
+      startupSelectionCount: startupSelections.length,
+      invalidSelectionProfiles,
+    })}`);
   }
   return Object.freeze({
     schema: "csscyclone-prepared-startup-color-profile@2",


### PR DESCRIPTION
## Summary
- prepare Cyclone at 60 fps while preserving the 12 s warmup, 9 s chunks, 1 s transport blocks, and 216 s stream
- requalify balanced desktop/mobile startup windows against the exact 60 Hz source streams
- version cadence-bearing catalog/playback contracts and tighten paint-aligned scheduling

## Verification
- `pnpm test:cyclone` (29/29)
- `pnpm prepare:cyclone`
- `pnpm build:cyclone`
- Chrome desktop 10 s: 599 publications, 16.66 ms mean, 23.3 ms p95, 0 collapsed, 0 block waits, 0 long tasks, 0 gaps over 50 ms
- Chrome mobile 10 s: 600 publications, 16.67 ms mean, 21.1 ms p95, 0 collapsed, 0 block waits, 0 long tasks, 0 gaps over 50 ms
- retained DOM stayed stable on both profiles
