### PR TITLE
fix(cyclone): bound prepared block publication

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -4,7 +4,8 @@ This adapter translates Really Slick Cyclone into one retained PolyCSS Morph
 graph. Desktop mounts the source-default 400 particle roots and mobile mounts a
 prepared prefix of 166 complete source particles. Every particle retains all six
 original solid-triangle leaves: 2,400 desktop leaves or 996 mobile leaves. The
-selected profile plays 24 source-continuous logical chunks of 450 prepared 20 ms
+selected profile plays 24 source-continuous logical chunks of 540 prepared
+16.667 ms
 transform states. The stream is transported as 216 one-second prepared blocks
 so decompression stays outside long animation frames. Source fixed-function
 smooth-vertex lighting is prepared at the first published frame into a verified
@@ -27,7 +28,7 @@ performs no color calculation. The same source RNG draws preserve RNG cadence,
 geometry, restart timing, and coherent color bands, but prepared hue values are
 intentionally quantized and low lightness is intentionally lifted; these are not
 exact source colors.
-Startup is prebaked to ten audited 40-frame source windows. The selector gives
+Startup is prebaked to ten audited 48-frame source windows. The selector gives
 each of the five prepared palette variants—blue, yellow, red, magenta, and
 green—exactly once per session-shuffled cycle before any family repeats, then
 chooses between two expressive browser-reviewed source windows in that family.
@@ -38,8 +39,8 @@ claim. Mobile/coarse-pointer devices and viewports below 600px select the
 field of view instead of the source-default 80 degrees. Prepared motion and each
 particle's complete six-face topology are unchanged.
 
-The stream discards the source's dark startup by preparing 24 seconds before its
-first published frame. Its 10,800 states cover 216 seconds before repeating.
+The stream discards the source's dark startup by preparing 12 seconds before its
+first published frame. Its 12,960 states cover 216 seconds before repeating.
 Startup uses `crypto.getRandomValues` to shuffle the five-family session bag and
 to select an audited source window and frame, excluding the previous exact
 window. Playback
@@ -48,10 +49,12 @@ gzip transport stores shared source control points and widths, one initial
 state per particle, sparse reset events, and flat `Uint16` lighting indices;
 it does not store repeated CSS transform strings. It downloads, verifies, and
 decompresses the active block plus 11 successors behind the loading indicator
-on both desktop and mobile, but initially expands CSS strings only for the
-active block and its immediate successor. A dedicated preparation worker
-materializes the rest sequentially while the main thread publishes the same
-stable retained DOM and maintains the 12-second source-state window. The
+on both desktop and mobile, but expands CSS strings only for the active block
+and two successors. Those first three blocks are complete before the loading
+indicator clears. A dedicated preparation worker expands later successors
+sequentially; the main thread adopts each prepared response in bounded 128 KiB
+slices while publishing the same stable retained DOM and maintaining the
+12-second compact source-state window. The
 single terminal stream wrap is the only
 non-source-continuous boundary.
 

--- a/src/adapters/cyclone/src/csscyclone/client.mjs
+++ b/src/adapters/cyclone/src/csscyclone/client.mjs
@@ -105,11 +105,11 @@ export async function mountCycloneClient(host) {
       },
       onBlockWindow(streamBlockIndices) {
         blockLoader.retain(streamBlockIndices);
+        for (const streamBlockIndex of streamBlockIndices) blockLoader.prefetch(streamBlockIndex);
       },
     });
     player.resize();
     addEventListener("resize", player.resize, { passive: true });
-    state.ready = true;
     state.metadata = metadata;
     state.profile = profile;
     state.catalog = catalog;
@@ -117,17 +117,31 @@ export async function mountCycloneClient(host) {
     state.blockLoader = blockLoader;
     state.mounted = mounted;
     state.player = player;
-    document.body.classList.replace("loading", "ready");
+    document.body.classList.replace("loading", "priming");
+    const primingFrameIndex = initialBlockFrameIndex + 1 < catalog.blockFrameCount
+      ? initialBlockFrameIndex + 1
+      : initialBlockFrameIndex - 1;
+    player.seekFrame(primingFrameIndex);
+    await waitForCycloneScenePaint();
+    player.seekFrame(initialBlockFrameIndex);
+    await waitForCycloneScenePaint();
+    document.body.classList.replace("priming", "ready");
+    await waitForCycloneScenePaint();
+    state.ready = true;
     player.resume();
     return state;
   } catch (error) {
     lightingAsset?.destroy();
     state.errors.push(String(error?.stack || error));
-    document.body.classList.remove("loading");
+    document.body.classList.remove("loading", "priming");
     document.body.classList.add("error");
     console.error(error);
     throw error;
   }
+}
+
+function waitForCycloneScenePaint() {
+  return new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)));
 }
 
 function cleanPreparedDom(mounted) {

--- a/src/adapters/cyclone/src/csscyclone/preparedBlockWorker.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedBlockWorker.mjs
@@ -5,7 +5,7 @@ let catalog = null;
 self.addEventListener("message", ({ data }) => {
   try {
     if (data?.type === "initialize") {
-      if (catalog !== null || data.catalog?.schema !== "csscyclone-prepared-stream-catalog@2") {
+      if (catalog !== null || data.catalog?.schema !== "csscyclone-prepared-stream-catalog@3") {
         throw new Error("Prepared Cyclone worker catalog drifted");
       }
       catalog = data.catalog;

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -5,7 +5,7 @@ import {
   CSSCYCLONE_PLAYBACK_SCHEMA,
 } from "../shared/csscyclone/preparedBlockTransport.mjs";
 
-const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@2";
+const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@3";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@2";
 const LIGHTING_SCHEMA = "csscyclone-prepared-smooth-lighting-atlas@7";
 const SOURCE_FIELD_OF_VIEW_DEGREES = 80;
@@ -164,12 +164,13 @@ export function createCyclonePreparedPlayer({
   function queueLookaheadBlocks() {
     if (destroyed) return;
     const indices = lookaheadBlockIndices();
-    const retainedIndices = new Set(indices);
+    const materializedIndices = indices.slice(0, catalog.runtimeMaterializedLookaheadBlockCount);
+    const retainedIndices = new Set(materializedIndices);
     onBlockWindow([activeBlockIndex, ...indices]);
     for (const index of pendingBlocks.keys()) {
       if (!retainedIndices.has(index)) pendingBlocks.delete(index);
     }
-    for (const index of indices) {
+    for (const index of materializedIndices) {
       if (pendingBlocks.has(index)) continue;
       const pending = { block: null, promise: null, error: null };
       preparedBlockPrefetchCount += 1;
@@ -414,8 +415,11 @@ function validateBinding(
       !Number.isSafeInteger(catalog.runtimeLookaheadBlockCount) ||
       catalog.runtimeLookaheadBlockCount < 1 ||
       catalog.runtimeLookaheadBlockCount > catalog.blockCount ||
+      !Number.isSafeInteger(catalog.runtimeMaterializedLookaheadBlockCount) ||
+      catalog.runtimeMaterializedLookaheadBlockCount < 1 ||
+      catalog.runtimeMaterializedLookaheadBlockCount > catalog.runtimeLookaheadBlockCount ||
       !Array.isArray(initialLookaheadBlocks) ||
-      initialLookaheadBlocks.length > catalog.runtimeLookaheadBlockCount ||
+      initialLookaheadBlocks.length > catalog.runtimeMaterializedLookaheadBlockCount ||
       new Set(initialLookaheadBlocks.map((block) => block?.streamBlockIndex)).size !==
         initialLookaheadBlocks.length ||
       initialLookaheadBlocks.some((block, index) =>

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -6,10 +6,11 @@ import {
   decodeCyclonePreparedBlockIncrementally,
 } from "../shared/csscyclone/preparedBlockTransport.mjs";
 
-const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@2";
+const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@3";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@2";
 const RUNTIME_LOOKAHEAD_BLOCK_COUNT = 11;
-const STARTUP_MATERIALIZED_LOOKAHEAD_BLOCK_COUNT = 1;
+const RUNTIME_MATERIALIZED_LOOKAHEAD_BLOCK_COUNT = 2;
+const STARTUP_MATERIALIZED_LOOKAHEAD_BLOCK_COUNT = 2;
 const STARTUP_HUE_SECTOR_NAMES = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
 const STARTUP_PALETTE_FAMILIES = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
 const STARTUP_SILHOUETTE_SAMPLING = "browser-reviewed-expressive-source-windows";
@@ -343,7 +344,7 @@ function createWorkerBlockMaterializer(catalog) {
     return null;
   }
   const pending = new Map();
-  const transformDecoder = new TextDecoder();
+  let responseMaterializationTail = Promise.resolve();
   let nextRequestId = 0;
   let destroyed = false;
   let resolveInitialization;
@@ -383,17 +384,28 @@ function createWorkerBlockMaterializer(catalog) {
     }
     const request = pending.get(data.requestId);
     if (!request) return;
-    pending.delete(data.requestId);
-    const transforms = Object.freeze(transformDecoder.decode(data.transformBytes).split("\n"));
-    const block = Object.freeze({
-      ...data.block,
-      playback: Object.freeze({ ...data.block.playback, transforms }),
-      lighting: Object.freeze(data.block.lighting),
+    responseMaterializationTail = responseMaterializationTail.then(async () => {
+      if (pending.get(data.requestId) !== request) return;
+      try {
+        const transforms = await decodeCyclonePreparedTransformsIncrementally(
+          data.transformBytes,
+          data.block?.playback?.frameCount * data.block?.playback?.particleCount,
+        );
+        const block = Object.freeze({
+          ...data.block,
+          playback: Object.freeze({ ...data.block.playback, transforms }),
+          lighting: Object.freeze(data.block.lighting),
+        });
+        pending.delete(data.requestId);
+        request.resolve(Object.freeze({
+          block,
+          durationMilliseconds: data.durationMilliseconds,
+        }));
+      } catch (error) {
+        pending.delete(data.requestId);
+        request.reject(error);
+      }
     });
-    request.resolve(Object.freeze({
-      block,
-      durationMilliseconds: data.durationMilliseconds,
-    }));
   });
   worker.addEventListener("error", (event) => {
     rejectAll(new Error(event.message || "Prepared Cyclone worker failed"));
@@ -425,6 +437,44 @@ function createWorkerBlockMaterializer(catalog) {
       worker.terminate();
     },
   });
+}
+
+export async function decodeCyclonePreparedTransformsIncrementally(
+  bytes,
+  expectedTransformCount,
+  {
+    chunkByteLength = 128 * 1_024,
+    setDelay = globalThis.setTimeout.bind(globalThis),
+  } = {},
+) {
+  if (!(bytes instanceof Uint8Array) || bytes.byteLength < 1 ||
+      !Number.isSafeInteger(expectedTransformCount) || expectedTransformCount < 1 ||
+      !Number.isSafeInteger(chunkByteLength) || chunkByteLength < 1 ||
+      chunkByteLength > 128 * 1_024 || typeof setDelay !== "function") {
+    throw new TypeError("Prepared Cyclone transform response slicing is invalid");
+  }
+  const decoder = new TextDecoder();
+  const transforms = [];
+  let carry = "";
+  for (let offset = 0; offset < bytes.byteLength; offset += chunkByteLength) {
+    if (offset > 0) await new Promise((resolve) => setDelay(resolve, 0));
+    const end = Math.min(bytes.byteLength, offset + chunkByteLength);
+    const isFinalChunk = end === bytes.byteLength;
+    const text = carry + decoder.decode(bytes.subarray(offset, end), { stream: !isFinalChunk });
+    const lines = text.split("\n");
+    if (isFinalChunk) {
+      transforms.push(...lines);
+      carry = "";
+    } else {
+      carry = lines.pop();
+      transforms.push(...lines);
+    }
+  }
+  if (carry !== "" || transforms.length !== expectedTransformCount ||
+      transforms.some((transform) => !transform.startsWith("matrix3d("))) {
+    throw new Error("Prepared Cyclone worker transform response drifted");
+  }
+  return Object.freeze(transforms);
 }
 
 function validateCatalog(catalog) {
@@ -481,9 +531,13 @@ function validateCatalog(catalog) {
         catalog.startupSelections.some((selection) => frameOffset >= selection.frameCount)) ||
       catalog.selection !== STARTUP_SELECTION ||
       catalog.runtimeLookaheadBlockCount !== RUNTIME_LOOKAHEAD_BLOCK_COUNT ||
+      catalog.runtimeMaterializedLookaheadBlockCount !==
+        RUNTIME_MATERIALIZED_LOOKAHEAD_BLOCK_COUNT ||
       catalog.startupMaterializedLookaheadBlockCount !==
         STARTUP_MATERIALIZED_LOOKAHEAD_BLOCK_COUNT ||
-      catalog.startupMaterializedLookaheadBlockCount >= catalog.runtimeLookaheadBlockCount ||
+      catalog.startupMaterializedLookaheadBlockCount >
+        catalog.runtimeMaterializedLookaheadBlockCount ||
+      catalog.runtimeMaterializedLookaheadBlockCount > catalog.runtimeLookaheadBlockCount ||
       catalog.entries.some((entry, index) => entry?.index !== index ||
         entry.chunkIndex !== Math.floor(index / catalog.blocksPerChunk) ||
         entry.blockIndex !== index % catalog.blocksPerChunk ||

--- a/src/adapters/cyclone/src/csscyclone/styles.css
+++ b/src/adapters/cyclone/src/csscyclone/styles.css
@@ -20,7 +20,8 @@ body {
   background: linear-gradient(180deg, #0b1119 0%, #000 100%);
 }
 
-body.loading::before {
+body.loading::before,
+body.priming::before {
   content: "";
   position: fixed;
   inset: 0;
@@ -28,7 +29,12 @@ body.loading::before {
   background: #000;
 }
 
-body.loading::after {
+body.priming::before {
+  background: rgb(0 0 0 / 99.8%);
+}
+
+body.loading::after,
+body.priming::after {
   content: "";
   position: fixed;
   inset: 50% auto auto 50%;
@@ -49,7 +55,8 @@ body.loading::after {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  body.loading::after {
+  body.loading::after,
+  body.priming::after {
     animation: none;
   }
 }

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -25,6 +25,7 @@ test.after(() => {
 function fixture({
   blockCount = 1,
   runtimeLookaheadBlockCount = 1,
+  runtimeMaterializedLookaheadBlockCount = Math.min(2, runtimeLookaheadBlockCount),
   initialLookaheadBlockCount = 0,
 } = {}) {
   let now = 0;
@@ -103,7 +104,7 @@ function fixture({
     };
   });
   const catalog = {
-    schema: "csscyclone-prepared-stream-catalog@2",
+    schema: "csscyclone-prepared-stream-catalog@3",
     streamId: "stream",
     chunkCount: 1,
     chunkFrameCount: blockCount * 4,
@@ -114,6 +115,7 @@ function fixture({
     framesPerSecond: 60,
     frameMilliseconds: 1_000 / 60,
     runtimeLookaheadBlockCount,
+    runtimeMaterializedLookaheadBlockCount,
     streamFrameCount: blockCount * 4,
     streamDurationMilliseconds: blockCount * 4 / 60 * 1_000,
   };
@@ -214,10 +216,10 @@ test("starts from one materialized successor while filling the verified horizon"
   });
   assert.deepEqual(state.player.stats().pendingBlockIndices, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
   assert.equal(state.player.stats().pendingBlockReadyCount, 1);
-  assert.deepEqual(state.loadBlockCalls, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+  assert.deepEqual(state.loadBlockCalls, [2]);
   await Promise.resolve();
   await Promise.resolve();
-  assert.equal(state.player.stats().pendingBlockReadyCount, 11);
+  assert.equal(state.player.stats().pendingBlockReadyCount, 2);
 
   state.player.resume();
   state.fireDelay();
@@ -228,9 +230,9 @@ test("starts from one materialized successor while filling the verified horizon"
   const stats = state.player.stats();
   assert.equal(stats.activeBlockIndex, 1);
   assert.deepEqual(stats.pendingBlockIndices, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-  assert.equal(stats.pendingBlockReadyCount, 11);
+  assert.equal(stats.pendingBlockReadyCount, 2);
   assert.equal(stats.runtimePreparedBlockWaitCount, 0);
-  assert.deepEqual(state.loadBlockCalls, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  assert.deepEqual(state.loadBlockCalls, [2, 3]);
 });
 
 test("collapses missed prepared frames once at the next paint-aligned callback", async () => {

--- a/src/adapters/cyclone/test/csscyclone-shell.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-shell.test.mjs
@@ -39,6 +39,8 @@ test("uses the cssGraphics shell without product UI or alternate renderers", asy
   assert.doesNotMatch(playback, /sceneElement\.style\.transform|cameraElement\.style\.perspective/u);
   assert.match(playback, /deadline-setTimeout-requestAnimationFrame-prepared-publication/u);
   assert.match(client, /blockLoader\.prime\(residentBlockIndices\)/u);
+  assert.match(client, /await waitForCycloneScenePaint\(\)/u);
+  assert.match(styles, /body\.priming::before/u);
   assert.match(stream, /new Worker\(new URL\("\.\/preparedBlockWorker\.mjs"/u);
   assert.match(worker, /decodeCyclonePreparedBlock/u);
   assert.doesNotMatch(`${client}\n${playback}\n${stream}\n${worker}`, /WebGL|CanvasRenderingContext/u);

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { selectInitialCyclonePosition } from "../src/csscyclone/preparedStream.mjs";
+import {
+  decodeCyclonePreparedTransformsIncrementally,
+  selectInitialCyclonePosition,
+} from "../src/csscyclone/preparedStream.mjs";
 
 const hash = "0".repeat(64);
 const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
@@ -18,7 +21,7 @@ const startupSelections = Object.freeze([
   Object.freeze({ id: "green-b", paletteFamily: "green", chunkIndex: 15, startFrameIndex: 201, frameCount: 48 }),
 ]);
 const catalog = Object.freeze({
-  schema: "csscyclone-prepared-stream-catalog@2",
+  schema: "csscyclone-prepared-stream-catalog@3",
   streamId: "desktop-stream",
   modelId: "cyclone",
   particleCount: 400,
@@ -68,7 +71,8 @@ const catalog = Object.freeze({
     })),
   }),
   runtimeLookaheadBlockCount: 11,
-  startupMaterializedLookaheadBlockCount: 1,
+  runtimeMaterializedLookaheadBlockCount: 2,
+  startupMaterializedLookaheadBlockCount: 2,
   entries: Object.freeze(Array.from({ length: 216 }, (_, index) => Object.freeze({
     index,
     chunkIndex: Math.floor(index / 9),
@@ -83,6 +87,24 @@ const catalog = Object.freeze({
     decodedByteLength: 1,
     decodedSha256: hash,
   }))),
+});
+
+test("slices worker transform responses before publishing a materialized block", async () => {
+  const source = ["matrix3d(1)", "matrix3d(2)", "matrix3d(3)"].join("\n");
+  let yieldCount = 0;
+  const transforms = await decodeCyclonePreparedTransformsIncrementally(
+    new TextEncoder().encode(source),
+    3,
+    {
+      chunkByteLength: 8,
+      setDelay(callback) {
+        yieldCount += 1;
+        callback();
+      },
+    },
+  );
+  assert.deepEqual(transforms, ["matrix3d(1)", "matrix3d(2)", "matrix3d(3)"]);
+  assert.ok(yieldCount > 0);
 });
 
 test("selects a balanced prepared source-palette window once", () => {

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -34,7 +34,8 @@ const sourceLock = JSON.parse(await readFile(join(adapterRoot, "notes/references
 const blockFrameCount = CSSCYCLONE_PREPARED_CADENCE.framesPerSecond *
   CSSCYCLONE_PREPARED_CADENCE.blockSeconds;
 const runtimeLookaheadBlockCount = 11;
-const startupMaterializedLookaheadBlockCount = 1;
+const runtimeMaterializedLookaheadBlockCount = 2;
+const startupMaterializedLookaheadBlockCount = 2;
 const startupPaletteFamilies = CSSCYCLONE_PRESENTATION.startupPaletteFamilies;
 const startupSilhouetteSampleFrameOffsets = CSSCYCLONE_PRESENTATION.startupSilhouetteSampleFrameOffsets;
 const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
@@ -205,7 +206,7 @@ async function prepareProfile(profile) {
   );
   const preparedLighting = await lightingStream.finalize();
   const catalogBytes = Buffer.from(`${JSON.stringify({
-    schema: "csscyclone-prepared-stream-catalog@2",
+    schema: "csscyclone-prepared-stream-catalog@3",
     streamId: bank.id,
     modelId: profile.modelId,
     particleCount: bank.particleCount,
@@ -237,6 +238,7 @@ async function prepareProfile(profile) {
     selection: "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat",
     playbackOrder: "source-continuous-ascending-chunks-with-one-terminal-stream-wrap",
     runtimeLookaheadBlockCount,
+    runtimeMaterializedLookaheadBlockCount,
     startupMaterializedLookaheadBlockCount,
     entries: blockEntries,
   })}\n`);
@@ -319,6 +321,7 @@ async function prepareProfile(profile) {
       residentBlockWindowCount,
       maximumResidentBlockWindowDecodedBytes,
       runtimeLookaheadBlockCount,
+      runtimeMaterializedLookaheadBlockCount,
       startupMaterializedLookaheadBlockCount,
       transportEncoding: CSSCYCLONE_BLOCK_ENCODING,
       runtimePreparedStateMaterialization: true,
@@ -327,6 +330,7 @@ async function prepareProfile(profile) {
       runtimeOffMainThreadLookaheadMaterialization: true,
       startupVerifiedBlockCount: residentBlockWindowCount,
       startupMaterializedBlockCount: startupMaterializedLookaheadBlockCount + 1,
+      maximumRuntimeMaterializedBlockCount: runtimeMaterializedLookaheadBlockCount + 1,
     }),
     lighting: preparedLighting.contract,
   });


### PR DESCRIPTION
## Summary
- keep the verified 12-block compact source-state horizon while materializing only the active block and two successors
- complete the initial three materialized blocks and first retained-layer paint behind the loading phase
- adopt worker-prepared CSS strings in bounded 128 KiB main-thread slices instead of one ~6 MB decode/split task
- document the corrected 60 Hz stream and residency contract

## Verification
- `pnpm test:cyclone` (30/30)
- `pnpm prepare:cyclone`
- `pnpm build:cyclone`
- desktop steady-state Chrome, 20 s / 20 worker completions: 1,197 publications, 16.71 ms mean, 36.2 ms max, 0 long tasks, 0 block waits, 3 collapsed frames, stable DOM
- mobile Chrome, fresh navigation + 20 s / 20 worker completions: 1,199 publications, 16.66 ms mean, 26.8 ms max, 0 long tasks, 0 block waits, 1 collapsed frame, stable DOM
- desktop expanded-string residency reduced from ~76 MB to 12.7-19.3 MB while retaining all 12 verified compact blocks
