### PR TITLE
fix(cyclone): preserve adjacent playback cadence

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -1,9 +1,10 @@
 # cssCyclone
 
 This adapter translates Really Slick Cyclone into one retained PolyCSS Morph
-graph. Desktop mounts the source-default 400 particle roots and mobile mounts a
-prepared prefix of 166 complete source particles. Every particle retains all six
-original solid-triangle leaves: 2,400 desktop leaves or 996 mobile leaves. The
+graph. The source-default 400-particle simulation is prepared into prefixes of
+360 complete particles on desktop and 166 on mobile. Every retained particle
+keeps all six original solid-triangle leaves: 2,160 desktop leaves or 996 mobile
+leaves. The
 selected profile plays 24 source-continuous logical chunks of 540 prepared
 16.667 ms
 transform states. The stream is transported as 216 one-second prepared blocks

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -87,8 +87,8 @@ export function createCyclonePreparedPlayer({
   let destroyed = false;
   let frameRequest = null;
   let delayRequest = null;
-  let clockOrigin = readNow() - initialFrameIndex * playback.frameMilliseconds;
-  let pausedAt = initialFrameIndex * playback.frameMilliseconds;
+  let nextFrameAt = null;
+  let pausedDelayMilliseconds = playback.frameMilliseconds;
   let frameIndex = initialFrameIndex;
   const schedulerLeadMilliseconds = Math.min(8, playback.frameMilliseconds / 2);
   let schedulerFrameRequestCount = 0;
@@ -97,6 +97,7 @@ export function createCyclonePreparedPlayer({
   let schedulerDelayRequestCount = 0;
   let schedulerDelayCallbackCount = 0;
   let schedulerDelayCancelCount = 0;
+  let schedulerLateResetCount = 0;
   let collapsedFrameCount = 0;
   let applyCount = 0;
   let shapeTransformWrites = 0;
@@ -228,9 +229,7 @@ export function createCyclonePreparedPlayer({
 
   function schedule() {
     if (paused || destroyed || frameRequest !== null || delayRequest !== null) return;
-    const elapsed = Math.max(0, readNow() - clockOrigin);
-    const nextFrameTime = Math.min(playback.durationMilliseconds, (frameIndex + 1) * playback.frameMilliseconds);
-    const waitMilliseconds = Math.max(0, nextFrameTime - elapsed - schedulerLeadMilliseconds);
+    const waitMilliseconds = Math.max(0, nextFrameAt - readNow() - schedulerLeadMilliseconds);
     if (waitMilliseconds <= 1) {
       requestPaintAlignedWake();
       return;
@@ -243,20 +242,21 @@ export function createCyclonePreparedPlayer({
     schedulerDelayRequestCount += 1;
   }
 
-  async function wake() {
+  async function wake(timestamp) {
     frameRequest = null;
     if (paused || destroyed) return;
     schedulerFrameCallbackCount += 1;
     try {
-      const elapsed = Math.max(0, readNow() - clockOrigin);
-      const paintAlignedElapsed = elapsed + schedulerLeadMilliseconds;
-      if (paintAlignedElapsed >= playback.durationMilliseconds) {
-        const boundaryTime = clockOrigin + playback.durationMilliseconds;
-        const waited = await activatePendingBlock();
-        clockOrigin = waited ? readNow() : boundaryTime;
-        pausedAt = 0;
+      if (frameIndex + 1 >= playback.frameCount) {
+        await activatePendingBlock();
       } else {
-        advanceTo(Math.floor(paintAlignedElapsed / playback.frameMilliseconds));
+        advanceTo(frameIndex + 1);
+      }
+      nextFrameAt += playback.frameMilliseconds;
+      const publicationTime = Math.max(Number(timestamp) || 0, readNow());
+      if (nextFrameAt <= publicationTime) {
+        nextFrameAt = publicationTime + playback.frameMilliseconds;
+        schedulerLateResetCount += 1;
       }
     } catch (error) {
       paused = true;
@@ -268,9 +268,9 @@ export function createCyclonePreparedPlayer({
 
   function pause() {
     if (paused || destroyed) return snapshot();
-    pausedAt = Math.min(
-      playback.durationMilliseconds,
-      Math.max(0, readNow() - clockOrigin),
+    pausedDelayMilliseconds = Math.min(
+      playback.frameMilliseconds,
+      Math.max(0, nextFrameAt - readNow()),
     );
     paused = true;
     if (frameRequest !== null) {
@@ -288,7 +288,8 @@ export function createCyclonePreparedPlayer({
 
   function resume() {
     if (!paused || destroyed) return snapshot();
-    clockOrigin = readNow() - pausedAt;
+    nextFrameAt = readNow() + pausedDelayMilliseconds;
+    pausedDelayMilliseconds = playback.frameMilliseconds;
     paused = false;
     schedule();
     return snapshot();
@@ -306,7 +307,7 @@ export function createCyclonePreparedPlayer({
       frameIndex = nextFrameIndex;
       applyCount += 1;
     }
-    pausedAt = nextFrameIndex * playback.frameMilliseconds;
+    pausedDelayMilliseconds = playback.frameMilliseconds;
     if (!wasPaused) resume();
     return snapshot();
   }
@@ -342,6 +343,7 @@ export function createCyclonePreparedPlayer({
       schedulerDelayRequestCount,
       schedulerDelayCallbackCount,
       schedulerDelayCancelCount,
+      schedulerLateResetCount,
       runtimeSchedulerTransport: "deadline-setTimeout-requestAnimationFrame-prepared-publication",
       collapsedFrameCount,
       applyCount,

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -34,8 +34,8 @@ export const CSSCYCLONE_SOURCE = Object.freeze({
   stretch: true,
 });
 
-const CSSCYCLONE_DESKTOP_BANK = Object.freeze({
-  id: "desktop-stream",
+export const CSSCYCLONE_SOURCE_BANK = Object.freeze({
+  id: "source-stream",
   name: "Cyclone",
   seed: 1,
   particleCount: 400,
@@ -47,9 +47,13 @@ const CSSCYCLONE_DESKTOP_BANK = Object.freeze({
 });
 
 export const CSSCYCLONE_BANKS = Object.freeze({
-  desktop: CSSCYCLONE_DESKTOP_BANK,
+  desktop: Object.freeze({
+    ...CSSCYCLONE_SOURCE_BANK,
+    id: "desktop-stream",
+    particleCount: 360,
+  }),
   mobile: Object.freeze({
-    ...CSSCYCLONE_DESKTOP_BANK,
+    ...CSSCYCLONE_SOURCE_BANK,
     id: "mobile-stream",
     name: "Cyclone Mobile",
     particleCount: 166,
@@ -70,7 +74,7 @@ export const CSSCYCLONE_PRESENTATION = Object.freeze({
   startupSelections: Object.freeze([
     startupSelection("blue-a", "blue", 17, 249),
     startupSelection("blue-b", "blue", 23, 492),
-    startupSelection("yellow-a", "yellow", 6, 450),
+    startupSelection("yellow-a", "yellow", 6, 447),
     startupSelection("yellow-b", "yellow", 21, 162),
     startupSelection("red-a", "red", 19, 171),
     startupSelection("red-b", "red", 13, 104),
@@ -154,7 +158,7 @@ export function selectCycloneSourceParticlePrefix(source, bank = CSSCYCLONE_BANK
       bank.warmupFrames !== source.bank.warmupFrames ||
       bank.frameCount !== source.bank.frameCount ||
       bank.chunkCount !== source.bank.chunkCount) {
-    throw new Error("Cyclone mobile particle-prefix source binding drifted");
+    throw new Error("Cyclone particle-prefix source binding drifted");
   }
   return deepFreeze({
     ...source,

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -188,6 +188,11 @@ function fixture({
       frames.delete(id);
       await callback(now);
     },
+    async advanceAt(value) {
+      now = value;
+      if (delays.size > 0) this.fireDelay();
+      await this.fireFrame();
+    },
   };
 }
 
@@ -222,9 +227,10 @@ test("starts from one materialized successor while filling the verified horizon"
   assert.equal(state.player.stats().pendingBlockReadyCount, 2);
 
   state.player.resume();
-  state.fireDelay();
-  state.setNow(81);
-  await state.fireFrame();
+  await state.advanceAt(20);
+  await state.advanceAt(40);
+  await state.advanceAt(60);
+  await state.advanceAt(80);
   await Promise.resolve();
 
   const stats = state.player.stats();
@@ -235,18 +241,32 @@ test("starts from one materialized successor while filling the verified horizon"
   assert.deepEqual(state.loadBlockCalls, [2, 3]);
 });
 
-test("collapses missed prepared frames once at the next paint-aligned callback", async () => {
+test("publishes one adjacent prepared frame and resets a missed deadline", async () => {
   const state = fixture();
   state.player.resume();
   state.fireDelay();
   state.setNow(57);
   await state.fireFrame();
-  assert.deepEqual(state.shapeElements.map((element) => element.style.transform), ["g", "h"]);
+  assert.deepEqual(state.shapeElements.map((element) => element.style.transform), ["c", "d"]);
   const stats = state.player.stats();
-  assert.equal(stats.frameIndex, 3);
-  assert.equal(stats.collapsedFrameCount, 2);
+  assert.equal(stats.frameIndex, 1);
+  assert.equal(stats.collapsedFrameCount, 0);
+  assert.equal(stats.schedulerLateResetCount, 1);
   assert.equal(stats.applyCount, 2);
   assert.equal(stats.shapeTransformWrites, 4);
+});
+
+test("does not skip a prepared frame when only the scheduler lead crosses its deadline", async () => {
+  const state = fixture();
+  state.player.resume();
+  state.fireDelay();
+  state.setNow(26);
+  await state.fireFrame();
+  assert.deepEqual(state.shapeElements.map((element) => element.style.transform), ["c", "d"]);
+  const stats = state.player.stats();
+  assert.equal(stats.frameIndex, 1);
+  assert.equal(stats.collapsedFrameCount, 0);
+  assert.equal(stats.applyCount, 2);
 });
 
 test("pause cancels pending delay and frame requests", () => {

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -5,6 +5,7 @@ import {
   CSSCYCLONE_BANKS,
   CSSCYCLONE_PRESENTATION,
   CSSCYCLONE_SOURCE,
+  CSSCYCLONE_SOURCE_BANK,
   buildCycloneSourceChunks,
   buildCycloneSourceSequence,
   selectCycloneSourceParticlePrefix,
@@ -88,11 +89,12 @@ test("pins the current Really Slick Cyclone source profile", () => {
   assert.equal(CSSCYCLONE_PRESENTATION.startupMinimumDominantHueShare, 0.25);
 });
 
-test("prepares the mobile bank with fewer complete source particles", () => {
-  assert.equal(CSSCYCLONE_BANKS.desktop.particleCount, 400);
+test("prepares desktop and mobile banks as complete source-particle prefixes", () => {
+  assert.equal(CSSCYCLONE_SOURCE_BANK.particleCount, 400);
+  assert.equal(CSSCYCLONE_BANKS.desktop.particleCount, 360);
   assert.equal(CSSCYCLONE_BANKS.mobile.particleCount, 166);
   const desktopBank = {
-    ...CSSCYCLONE_BANKS.desktop,
+    ...CSSCYCLONE_SOURCE_BANK,
     warmupFrames: 2,
     frameCount: 2,
     chunkCount: 1,

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -11,7 +11,7 @@ const startupPaletteFamilies = Object.freeze(["blue", "yellow", "red", "magenta"
 const startupSelections = Object.freeze([
   Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 17, startFrameIndex: 249, frameCount: 48 }),
   Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 23, startFrameIndex: 492, frameCount: 48 }),
-  Object.freeze({ id: "yellow-a", paletteFamily: "yellow", chunkIndex: 6, startFrameIndex: 450, frameCount: 48 }),
+  Object.freeze({ id: "yellow-a", paletteFamily: "yellow", chunkIndex: 6, startFrameIndex: 447, frameCount: 48 }),
   Object.freeze({ id: "yellow-b", paletteFamily: "yellow", chunkIndex: 21, startFrameIndex: 162, frameCount: 48 }),
   Object.freeze({ id: "red-a", paletteFamily: "red", chunkIndex: 19, startFrameIndex: 171, frameCount: 48 }),
   Object.freeze({ id: "red-b", paletteFamily: "red", chunkIndex: 13, startFrameIndex: 104, frameCount: 48 }),
@@ -24,8 +24,8 @@ const catalog = Object.freeze({
   schema: "csscyclone-prepared-stream-catalog@3",
   streamId: "desktop-stream",
   modelId: "cyclone",
-  particleCount: 400,
-  leafCount: 2_400,
+  particleCount: 360,
+  leafCount: 2_160,
   playbackSchema: "csscyclone-prepared-dom-playback@5",
   lightingBlockSchema: "csscyclone-prepared-lighting-block@2",
   sourceTransformProfile: Object.freeze({

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -22,6 +22,7 @@ import {
   CSSCYCLONE_PREPARED_CADENCE,
   CSSCYCLONE_PRESENTATION,
   CSSCYCLONE_SOURCE,
+  CSSCYCLONE_SOURCE_BANK,
   buildCycloneSourceChunks,
   selectCycloneSourceParticlePrefix,
 } from "../src/prepare/csscyclone/sourceModel.mjs";
@@ -47,7 +48,7 @@ const profileConfigs = Object.freeze([
     catalogUrl: "/csscyclone/catalog.json",
     blockRoot: "/csscyclone/blocks",
     lightingAssetRoot: "/csscyclone/assets",
-    particleSelection: "source-default-all-particles",
+    particleSelection: "prepared-source-particle-prefix",
     startupSelections: CSSCYCLONE_PRESENTATION.startupSelections,
   }),
   Object.freeze({
@@ -143,10 +144,8 @@ async function prepareProfile(profile) {
   let shapeTransformSelections = 0;
   let preparedBlockEncodedBytes = 0;
   let preparedBlockDecodedBytes = 0;
-  for (const desktopSource of buildCycloneSourceChunks({ bank: CSSCYCLONE_BANKS.desktop })) {
-    const source = profile.id === "mobile"
-      ? selectCycloneSourceParticlePrefix(desktopSource, bank)
-      : desktopSource;
+  for (const desktopSource of buildCycloneSourceChunks({ bank: CSSCYCLONE_SOURCE_BANK })) {
+    const source = selectCycloneSourceParticlePrefix(desktopSource, bank);
     if (preparedModel === null) {
       const result = buildCyclonePreparedModel({ source, modelId: profile.modelId });
       preparedModel = Object.freeze({ model: result.model, metrics: result.metrics });
@@ -265,7 +264,7 @@ async function prepareProfile(profile) {
     presentation: Object.freeze({
       sourceDefaults: Object.freeze({
         cyclones: 1,
-        particles: CSSCYCLONE_BANKS.desktop.particleCount,
+        particles: CSSCYCLONE_SOURCE_BANK.particleCount,
         size: CSSCYCLONE_SOURCE.particleSize,
         complexity: CSSCYCLONE_SOURCE.complexity,
         speed: CSSCYCLONE_SOURCE.speed,


### PR DESCRIPTION
## Summary
- publish exactly one adjacent prepared Cyclone state per paint-aligned callback and reset late deadlines instead of collapsing source frames
- retain a 360-particle desktop prefix from the unchanged 400-particle source simulation; mobile remains 166
- requalify the affected yellow startup window without weakening the existing palette-family gate

## Verification
- pnpm test:cyclone (31/31)
- pnpm prepare:cyclone
- pnpm build:cyclone
- desktop Chrome steady 20 s: 1200 publications, 16.66 ms mean, p95 20.9 ms, max 25.7 ms, 0 collapsed, 0 waits, 0 long tasks
- mobile Chrome fresh 20 s: 1199 publications, 16.68 ms mean, p95 18.1 ms, max 33.4 ms, 0 collapsed, 0 waits, 0 long tasks
- stable retained DOM and 0 model wrappers on both profiles