### PR TITLE
perf(cyclone): point particles along motion

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -2,16 +2,16 @@
 
 This adapter translates Really Slick Cyclone into one retained PolyCSS Morph
 graph. The source-default 400-particle simulation is prepared into prefixes of
-340 complete particles on desktop and 166 on mobile. Every retained particle
-keeps all six original solid-triangle leaves: 2,040 desktop leaves or 996 mobile
-leaves. The
+320 complete particles on desktop and 166 on mobile. Every retained particle is
+a forward-pointing square pyramid with four solid-triangle sides and one
+solid-quad trailing cap: 1,600 desktop leaves or 830 mobile leaves. The
 selected profile plays 24 source-continuous logical chunks of 540 prepared
 16.667 ms
 transform states. The stream is transported as 216 one-second prepared blocks
 so decompression stays outside long animation frames. Source fixed-function
 smooth-vertex lighting is prepared at the first published frame into a verified
 lossless WebP atlas. Initial leaf addresses are bound once. Later address writes
-are limited to the six leaves of a particle when the source restarts it with a
+are limited to the five leaves of a particle when the source restarts it with a
 new color. The mounted graph is camera, scene, particle roots, and leaves; the
 PolyCSS Morph model wrapper is removed after adoption and its fixed transform is
 composed onto the existing scene node.
@@ -26,7 +26,7 @@ Five lossless lighting-atlas variants provide blue-, yellow-, red-, magenta-,
 and green-centered palettes; each variant spans at most three adjacent hue
 families for the entire playback. The browser selects one prepared atlas and
 performs no color calculation. The same source RNG draws preserve RNG cadence,
-geometry, restart timing, and coherent color bands, but prepared hue values are
+trajectory geometry, restart timing, and coherent color bands, but prepared hue values are
 intentionally quantized and low lightness is intentionally lifted; these are not
 exact source colors.
 Startup is prebaked to ten audited 48-frame source windows. The selector gives
@@ -38,7 +38,9 @@ intentional presentation rather than an exact native-color or random-start
 claim. Mobile/coarse-pointer devices and viewports below 600px select the
 166-particle prepared profile before mount and use a 90-degree presentation
 field of view instead of the source-default 80 degrees. Prepared motion and each
-particle's complete six-face topology are unchanged.
+particle's prepared five-face topology are unchanged during playback. The
+pyramid apex follows the source tangent axis; replacing the source's symmetric
+six-triangle particle is an intentional presentation and performance deviation.
 
 The stream discards the source's dark startup by preparing 12 seconds before its
 first published frame. Its 12,960 states cover 216 seconds before repeating.
@@ -83,7 +85,7 @@ while source color restarts remain exact; this is an intentional performance
 adaptation. The complete dense scene is not claimed to be pixel-identical to
 OpenGL because OpenGL resolves intersecting particles with a per-fragment depth
 buffer while the retained CSS scene uses planar compositor ordering. The
-supported Chrome path renders all six CSS triangle leaves per particle with no
+supported Chrome path renders all five prepared CSS leaves per particle with no
 alternate renderer or geometry fallback.
 
 The adapter is GPL-2.0-or-later; see [NOTICE.md](NOTICE.md).

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -579,7 +579,9 @@ function validateCatalog(catalog) {
       typeof catalog.streamId !== "string" ||
       typeof catalog.modelId !== "string" || catalog.modelId.length < 1 ||
       !Number.isSafeInteger(catalog.particleCount) || catalog.particleCount < 1 ||
-      !Number.isSafeInteger(catalog.leafCount) || catalog.leafCount !== catalog.particleCount * 6 ||
+      !Number.isSafeInteger(catalog.facesPerParticle) || catalog.facesPerParticle < 1 ||
+      !Number.isSafeInteger(catalog.leafCount) ||
+      catalog.leafCount !== catalog.particleCount * catalog.facesPerParticle ||
       catalog.playbackSchema !== CSSCYCLONE_PLAYBACK_SCHEMA ||
       catalog.lightingBlockSchema !== CSSCYCLONE_LIGHTING_BLOCK_SCHEMA ||
       catalog.sourceTransformProfile?.controlPointCount !== 6 ||

--- a/src/adapters/cyclone/src/csscyclone/styles.css
+++ b/src/adapters/cyclone/src/csscyclone/styles.css
@@ -165,7 +165,7 @@ body > .polycss-camera > .polycss-scene {
     matrix3d(1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, -400, 1);
 }
 
-body > .polycss-camera u {
+body > .polycss-camera :is(u, b) {
   position: absolute;
   width: 32px;
   height: 32px;

--- a/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
@@ -15,22 +15,20 @@ export const CSSCYCLONE_MODEL_IDS = Object.freeze({
 });
 export const CSSCYCLONE_MODEL_ID = CSSCYCLONE_MODEL_IDS.desktop;
 const PARTICLE_RADIUS = CSSCYCLONE_SOURCE.particleSize / 4;
-const EQUATOR = Object.freeze(Array.from({ length: 3 }, (_, index) => {
-  const angle = index * Math.PI * 2 / 3;
-  return Object.freeze([Math.cos(angle) * PARTICLE_RADIUS, Math.sin(angle) * PARTICLE_RADIUS, 0]);
-}));
+const CAP_HALF_EXTENT = PARTICLE_RADIUS / Math.sqrt(2);
 export const CSSCYCLONE_PARTICLE_VERTICES = Object.freeze([
-  Object.freeze([0, 0, PARTICLE_RADIUS]),
-  ...EQUATOR,
-  Object.freeze([0, 0, -PARTICLE_RADIUS]),
+  Object.freeze([0, PARTICLE_RADIUS, 0]),
+  Object.freeze([-CAP_HALF_EXTENT, -PARTICLE_RADIUS, -CAP_HALF_EXTENT]),
+  Object.freeze([CAP_HALF_EXTENT, -PARTICLE_RADIUS, -CAP_HALF_EXTENT]),
+  Object.freeze([CAP_HALF_EXTENT, -PARTICLE_RADIUS, CAP_HALF_EXTENT]),
+  Object.freeze([-CAP_HALF_EXTENT, -PARTICLE_RADIUS, CAP_HALF_EXTENT]),
 ]);
 export const CSSCYCLONE_FACE_INDICES = Object.freeze([
-  Object.freeze([0, 1, 2]),
-  Object.freeze([0, 2, 3]),
-  Object.freeze([0, 3, 1]),
-  Object.freeze([4, 2, 1]),
-  Object.freeze([4, 3, 2]),
-  Object.freeze([4, 1, 3]),
+  Object.freeze([0, 2, 1]),
+  Object.freeze([0, 3, 2]),
+  Object.freeze([0, 4, 3]),
+  Object.freeze([0, 1, 4]),
+  Object.freeze([1, 2, 3, 4]),
 ]);
 
 export function buildCyclonePreparedModel({
@@ -47,29 +45,28 @@ export function buildCyclonePreparedModel({
     const vertexOffset = vertices.length;
     const normalOffset = normals.length;
     vertices.push(...CSSCYCLONE_PARTICLE_VERTICES.map((vertex) => Object.freeze([...vertex])));
-    normals.push(...CSSCYCLONE_PARTICLE_VERTICES.map((vertex) => Object.freeze(
-      vertex.map((value) => rounded(value / PARTICLE_RADIUS)),
-    )));
+    normals.push(...CSSCYCLONE_PARTICLE_VERTICES.map((vertex) => Object.freeze(normalized(vertex))));
     const shapeId = particleId(particleIndex);
     shapes.push(Object.freeze({ id: shapeId, matrix: initial.particles[particleIndex].matrix }));
     for (let faceIndex = 0; faceIndex < CSSCYCLONE_FACE_INDICES.length; faceIndex += 1) {
       const localIndices = CSSCYCLONE_FACE_INDICES[faceIndex];
-      const triangle = localIndices.map((index) => CSSCYCLONE_PARTICLE_VERTICES[index]);
+      const face = localIndices.map((index) => CSSCYCLONE_PARTICLE_VERTICES[index]);
       const polygonId = `${shapeId}-face-${faceIndex}`;
       polygons.push(Object.freeze({
         id: polygonId,
         vertexIndices: Object.freeze(localIndices.map((index) => vertexOffset + index)),
         normalIndices: Object.freeze(localIndices.map((index) => normalOffset + index)),
       }));
+      const quad = localIndices.length === 4;
       leaves.push(Object.freeze({
         id: `leaf-${polygonId}`,
         polygonId,
         shapeId,
         materialId: "particle",
-        strategy: "solid-triangle",
+        strategy: quad ? "solid-quad" : "solid-triangle",
         width: SOLID_TRIANGLE_CANONICAL_SIZE,
         height: SOLID_TRIANGLE_CANONICAL_SIZE,
-        matrix: triangleMatrix(triangle, polygonId),
+        matrix: quad ? quadMatrix(face, polygonId) : triangleMatrix(face, polygonId),
         atlas: null,
         fallback: null,
       }));
@@ -180,6 +177,47 @@ function triangleMatrix(vertices, id) {
     throw new Error(`Cyclone triangle is not renderable: ${id}`);
   }
   return Object.freeze(values.map((value) => rounded(value)));
+}
+
+function quadMatrix(vertices, id) {
+  if (vertices.length !== 4) throw new Error(`Cyclone quad is incomplete: ${id}`);
+  const [origin, along, opposite, across] = vertices;
+  const xVector = subtract(along, origin);
+  const yVector = subtract(across, origin);
+  const normal = normalized(cross(xVector, yVector));
+  const nonPlanarity = Math.abs(dot(normal, subtract(opposite, origin)));
+  if (!Number.isFinite(nonPlanarity) || nonPlanarity > 1e-8) {
+    throw new Error(`Cyclone quad is not planar: ${id}`);
+  }
+  const size = SOLID_TRIANGLE_CANONICAL_SIZE;
+  return Object.freeze([
+    xVector[0] / size, xVector[1] / size, xVector[2] / size, 0,
+    yVector[0] / size, yVector[1] / size, yVector[2] / size, 0,
+    normal[0], normal[1], normal[2], 0,
+    origin[0], origin[1], origin[2], 1,
+  ].map((value) => rounded(value)));
+}
+
+function subtract(left, right) {
+  return left.map((value, index) => value - right[index]);
+}
+
+function cross(left, right) {
+  return [
+    left[1] * right[2] - left[2] * right[1],
+    left[2] * right[0] - left[0] * right[2],
+    left[0] * right[1] - left[1] * right[0],
+  ];
+}
+
+function dot(left, right) {
+  return left.reduce((sum, value, index) => sum + value * right[index], 0);
+}
+
+function normalized(vector) {
+  const length = Math.hypot(...vector);
+  if (length < 1e-12) throw new Error("Cyclone particle normal is degenerate");
+  return vector.map((value) => rounded(value / length));
 }
 
 function particleId(index) {

--- a/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
@@ -166,7 +166,7 @@ async function buildPreparedLightingAsset({
         normal,
       }));
       for (let faceIndex = 0; faceIndex < CSSCYCLONE_FACE_INDICES.length; faceIndex += 1) {
-        writeAffineTriangleTile({
+        writeAffineFaceTile({
           rgba,
           width: unpackedWidth,
           columns: unpackedColumns,
@@ -472,7 +472,7 @@ function hsvToRgb(hue, saturation, value) {
   ][index];
 }
 
-function writeAffineTriangleTile({
+function writeAffineFaceTile({
   rgba,
   width,
   columns,
@@ -486,14 +486,16 @@ function writeAffineTriangleTile({
     const v = (localY + 0.5) / CONTENT_SIZE;
     for (let localX = -GUTTER; localX < CONTENT_SIZE + GUTTER; localX += 1) {
       const u = (localX + 0.5) / CONTENT_SIZE;
-      const apex = 1 - v;
-      const right = u - 0.5 * apex;
-      const left = 1 - apex - right;
-      const color = [0, 1, 2].map((channel) => clampByte(
-        vertexColors[vertexIndices[0]][channel] * apex +
-        vertexColors[vertexIndices[1]][channel] * left +
-        vertexColors[vertexIndices[2]][channel] * right,
-      ));
+      const weights = vertexIndices.length === 3
+        ? triangleWeights(u, v)
+        : vertexIndices.length === 4
+        ? quadWeights(u, v)
+        : null;
+      if (weights === null) throw new Error("Cyclone lighting face must be a triangle or quad");
+      const color = [0, 1, 2].map((channel) => clampByte(weights.reduce(
+        (sum, weight, index) => sum + vertexColors[vertexIndices[index]][channel] * weight,
+        0,
+      )));
       const x = originX + localX + GUTTER;
       const y = originY + localY + GUTTER;
       const offset = (y * width + x) * 4;
@@ -503,6 +505,16 @@ function writeAffineTriangleTile({
       rgba[offset + 3] = 255;
     }
   }
+}
+
+function triangleWeights(u, v) {
+  const apex = 1 - v;
+  const right = u - 0.5 * apex;
+  return [apex, 1 - apex - right, right];
+}
+
+function quadWeights(u, v) {
+  return [(1 - u) * (1 - v), u * (1 - v), u * v, (1 - u) * v];
 }
 
 function shadeVertex({ baseColor, normal }) {

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -50,7 +50,7 @@ export const CSSCYCLONE_BANKS = Object.freeze({
   desktop: Object.freeze({
     ...CSSCYCLONE_SOURCE_BANK,
     id: "desktop-stream",
-    particleCount: 340,
+    particleCount: 320,
   }),
   mobile: Object.freeze({
     ...CSSCYCLONE_SOURCE_BANK,
@@ -81,7 +81,7 @@ export const CSSCYCLONE_PRESENTATION = Object.freeze({
     startupSelection("magenta-a", "magenta", 18, 279),
     startupSelection("magenta-b", "magenta", 12, 414),
     startupSelection("green-a", "green", 7, 250),
-    startupSelection("green-b", "green", 15, 201),
+    startupSelection("green-b", "green", 15, 196),
   ]),
   mobileStartupSelections: Object.freeze([
     startupSelection("blue-a", "blue", 1, 123),

--- a/src/adapters/cyclone/test/csscyclone-shell.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-shell.test.mjs
@@ -32,6 +32,7 @@ test("uses the cssGraphics shell without product UI or alternate renderers", asy
     /body > \.polycss-camera > \.polycss-scene\s*\{[^}]*transform:\s*translateZ\(var\(--cyclone-perspective\)\)\s*matrix3d\(1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, -400, 1\);/su,
   );
   assert.match(styles, /background-image:\s*var\(--cyclone-lighting-atlas\)/u);
+  assert.match(styles, /body > \.polycss-camera :is\(u, b\)/u);
   assert.doesNotMatch(styles, /color-mix|--cyclone-tone/u);
   assert.match(client, /cameraElement\.style\.removeProperty\("perspective"\)/u);
   assert.match(client, /sceneElement\.style\.removeProperty\("transform"\)/u);

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -11,7 +11,9 @@ import {
   selectCycloneSourceParticlePrefix,
 } from "../src/prepare/csscyclone/sourceModel.mjs";
 import {
+  CSSCYCLONE_FACE_INDICES,
   CSSCYCLONE_MODEL_IDS,
+  CSSCYCLONE_PARTICLE_VERTICES,
   buildCyclonePreparedModel,
   buildCyclonePreparedPlayback,
 } from "../src/prepare/csscyclone/modelBuilder.mjs";
@@ -91,7 +93,7 @@ test("pins the current Really Slick Cyclone source profile", () => {
 
 test("prepares desktop and mobile banks as complete source-particle prefixes", () => {
   assert.equal(CSSCYCLONE_SOURCE_BANK.particleCount, 400);
-  assert.equal(CSSCYCLONE_BANKS.desktop.particleCount, 340);
+  assert.equal(CSSCYCLONE_BANKS.desktop.particleCount, 320);
   assert.equal(CSSCYCLONE_BANKS.mobile.particleCount, 166);
   const desktopBank = {
     ...CSSCYCLONE_SOURCE_BANK,
@@ -117,10 +119,10 @@ test("prepares desktop and mobile banks as complete source-particle prefixes", (
   });
   assert.equal(preparedModel.model.identity.id, "cyclone-mobile");
   assert.equal(preparedModel.model.render.shapes.length, 166);
-  assert.equal(preparedModel.model.render.leaves.length, 996);
-  assert.equal(preparedModel.metrics.polygonsPerParticle, 6);
+  assert.equal(preparedModel.model.render.leaves.length, 830);
+  assert.equal(preparedModel.metrics.polygonsPerParticle, 5);
   assert.equal(preparedPlayback.playback.particleCount, 166);
-  assert.equal(preparedPlayback.playback.leafCount, 996);
+  assert.equal(preparedPlayback.playback.leafCount, 830);
   assert.deepEqual(source.frames[0].particles, desktopSource.frames[0].particles.slice(0, 166));
 });
 
@@ -137,8 +139,15 @@ test("builds a stable retained particle graph and prepared state bank", () => {
   const preparedModel = buildCyclonePreparedModel({ source });
   const preparedPlayback = buildCyclonePreparedPlayback({ source });
   assert.equal(preparedModel.model.render.shapes.length, 3);
-  assert.equal(preparedModel.model.render.leaves.length, 18);
-  assert.equal(preparedModel.model.topology.polygons.length, 18);
+  assert.equal(preparedModel.model.render.leaves.length, 15);
+  assert.equal(preparedModel.model.topology.polygons.length, 15);
+  assert.deepEqual(
+    preparedModel.model.render.leaves.slice(0, 5).map(({ strategy }) => strategy),
+    ["solid-triangle", "solid-triangle", "solid-triangle", "solid-triangle", "solid-quad"],
+  );
+  assert.equal(CSSCYCLONE_PARTICLE_VERTICES[0][1] > 0, true);
+  assert.equal(CSSCYCLONE_PARTICLE_VERTICES.slice(1).every((vertex) => vertex[1] < 0), true);
+  assert.deepEqual(CSSCYCLONE_FACE_INDICES.at(-1), [1, 2, 3, 4]);
   assert.equal(preparedPlayback.playback.transforms.length, 12);
   assert.equal(preparedPlayback.playback.schema, "csscyclone-prepared-dom-playback@5");
   assert.equal(preparedPlayback.metrics.shapeTransformSelections, 12);
@@ -178,7 +187,7 @@ test("round-trips exact prepared matrices through compact source-state blocks", 
     streamId: bank.id,
     modelId: CSSCYCLONE_MODEL_IDS.desktop,
     particleCount: bank.particleCount,
-    leafCount: bank.particleCount * 6,
+    leafCount: bank.particleCount * CSSCYCLONE_FACE_INDICES.length,
     frameMilliseconds: bank.frameMilliseconds,
     chunkCount: 1,
     blockCount: 1,
@@ -238,10 +247,10 @@ test("prepares smooth reference lighting without a runtime lighting timeline", a
   assert.equal(prepared.contract.schema, "csscyclone-prepared-smooth-lighting-atlas@7");
   assert.equal(prepared.contract.contentSize, 2);
   assert.equal(prepared.contract.gutterPixels, 1);
-  assert.equal(prepared.contract.leafCount, 18);
+  assert.equal(prepared.contract.leafCount, 15);
   assert.equal(prepared.contract.colorStateCount, 3);
   assert.equal(prepared.contract.colorRestartCount, 0);
-  assert.equal(prepared.contract.tileCount, 18);
+  assert.equal(prepared.contract.tileCount, 15);
   assert.ok(prepared.contract.uniqueTileCount <= prepared.contract.tileCount);
   assert.equal(
     prepared.contract.deduplicatedTileCount,
@@ -249,7 +258,7 @@ test("prepares smooth reference lighting without a runtime lighting timeline", a
   );
   assert.equal(prepared.contract.tileDeduplication, "exact-cross-palette-rgba8-slot-content");
   assert.equal(prepared.contract.packing, "near-square-row-major-unique-slots");
-  assert.equal(prepared.contract.tileBackgroundPositions.length, 18);
+  assert.equal(prepared.contract.tileBackgroundPositions.length, 15);
   assert.equal(prepared.contract.paletteFamilyCount, 5);
   assert.equal(prepared.contract.paletteHueSlotCount, 3);
   assert.equal(prepared.contract.maximumColorFamilyCount, 3);
@@ -290,8 +299,8 @@ test("publishes only exact source color restarts through sparse leaf addresses",
   assert.equal(prepared.contract.colorRestartCount, 1);
   assert.equal(changedParticleCount, 1);
   assert.equal(prepared.contract.colorStateCount, 4);
-  assert.equal(prepared.contract.tileCount, 24);
-  assert.equal(prepared.contract.runtime.maximumSparseLeafWritesPerParticleRestart, 6);
+  assert.equal(prepared.contract.tileCount, 20);
+  assert.equal(prepared.contract.runtime.maximumSparseLeafWritesPerParticleRestart, 5);
 });
 
 test("splits one uninterrupted prepared source stream into exact consecutive chunks", () => {

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -25,6 +25,7 @@ const catalog = Object.freeze({
   streamId: "desktop-stream",
   modelId: "cyclone",
   particleCount: 340,
+  facesPerParticle: 6,
   leafCount: 2_040,
   playbackSchema: "csscyclone-prepared-dom-playback@5",
   lightingBlockSchema: "csscyclone-prepared-lighting-block@2",

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -85,7 +85,7 @@ await writeJson(join(stagingRoot, "prepared.json"), {
   renderer: {
     package: "@layoutit/polycss-morph",
     profile: "static-prepared",
-    representation: "retained-particle-roots-with-six-solid-triangle-leaves",
+    representation: "retained-forward-pyramid-roots-with-four-solid-triangle-sides-and-one-solid-quad-cap",
     runtimeGeometryConstruction: false,
     runtimeAtlasRasterization: false,
     runtimeDomGrowth: false,
@@ -209,6 +209,7 @@ async function prepareProfile(profile) {
     streamId: bank.id,
     modelId: profile.modelId,
     particleCount: bank.particleCount,
+    facesPerParticle: CSSCYCLONE_FACE_INDICES.length,
     leafCount: bank.particleCount * CSSCYCLONE_FACE_INDICES.length,
     playbackSchema: CSSCYCLONE_PLAYBACK_SCHEMA,
     lightingBlockSchema: CSSCYCLONE_LIGHTING_BLOCK_SCHEMA,


### PR DESCRIPTION
## Summary

- replace each symmetric six-triangle Cyclone particle with a forward-pointing square pyramid: four triangle sides and one quad trailing cap
- align the apex to the existing local +Y source-tangent axis and retain the original trajectory/spin playback
- reduce the desktop prepared prefix from 340 to 320 particles while keeping mobile at 166
- prepare smooth lighting for both triangle and quad leaves and validate the explicit face count in the stream catalog

This intentionally deviates from the Really Slick particle mesh while preserving its simulation path, tangent orientation, restart cadence, retained-DOM architecture, and prepare-time lighting.

## FrameSleuth

Fresh 8 s local traces at 960x540, both trimmed by 3 s:

- pipeline drop records: 268 -> 197 (-26.5%)
- worst DrawFrame: 25.450 ms -> 21.507 ms (-15.5%)
- DrawFrame p95: 20.309 ms -> 19.149 ms (-5.7%)
- DrawFrame gaps above 1.5x baseline: 6 -> 0
- max Paint: 0.502 ms -> 0.412 ms
- max Raster: 0.215 ms -> 0.111 ms

## Verification

- `pnpm prepare:cyclone`
- `pnpm test:cyclone` (31/31)
- `pnpm build:cyclone`
- desktop browser smoke: 320 roots, 1,280 triangles + 320 caps, zero collapsed frames/block waits/DOM growth
- mobile browser smoke: 166 roots, 664 triangles + 166 caps, zero collapsed frames/block waits/DOM growth
