### PR TITLE
fix(cyclone): orient compact particle faces

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -39,8 +39,11 @@ claim. Mobile/coarse-pointer devices and viewports below 600px select the
 166-particle prepared profile before mount and use a 90-degree presentation
 field of view instead of the source-default 80 degrees. Prepared motion and each
 particle's prepared five-face topology are unchanged during playback. The
-pyramid apex follows the source tangent axis; replacing the source's symmetric
-six-triangle particle is an intentional presentation and performance deviation.
+pyramid apex follows local -Z, the source transform's stretched orbital travel
+axis. Its unstretched nose-to-cap depth equals its cap width, so the source
+transform alone controls elongation, and the complete primitive uses a uniform
+0.6 presentation scale. Replacing the source's symmetric six-triangle particle
+is an intentional presentation and performance deviation.
 
 The stream discards the source's dark startup by preparing 12 seconds before its
 first published frame. Its 12,960 states cover 216 seconds before repeating.

--- a/src/adapters/cyclone/src/csscyclone/styles.css
+++ b/src/adapters/cyclone/src/csscyclone/styles.css
@@ -170,10 +170,6 @@ body > .polycss-camera :is(u, b) {
   width: 32px;
   height: 32px;
   border-width: 0;
-  border-top-left-radius: 50% 100%;
-  border-top-right-radius: 50% 100%;
-  corner-top-left-shape: bevel;
-  corner-top-right-shape: bevel;
   backface-visibility: hidden;
   color: transparent;
   background-color: transparent;
@@ -182,6 +178,13 @@ body > .polycss-camera :is(u, b) {
   background-size: var(--cyclone-lighting-size);
   image-rendering: auto;
   transform-origin: 0 0;
+}
+
+body > .polycss-camera u {
+  border-top-left-radius: 50% 100%;
+  border-top-right-radius: 50% 100%;
+  corner-top-left-shape: bevel;
+  corner-top-right-shape: bevel;
 }
 
 body.error::after {

--- a/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
@@ -15,21 +15,34 @@ export const CSSCYCLONE_MODEL_IDS = Object.freeze({
 });
 export const CSSCYCLONE_MODEL_ID = CSSCYCLONE_MODEL_IDS.desktop;
 const PARTICLE_RADIUS = CSSCYCLONE_SOURCE.particleSize / 4;
-const CAP_HALF_EXTENT = PARTICLE_RADIUS / Math.sqrt(2);
+const PARTICLE_PRESENTATION_SCALE = 0.6;
+const PARTICLE_HALF_EXTENT = PARTICLE_RADIUS * PARTICLE_PRESENTATION_SCALE / Math.sqrt(2);
 export const CSSCYCLONE_PARTICLE_VERTICES = Object.freeze([
-  Object.freeze([0, PARTICLE_RADIUS, 0]),
-  Object.freeze([-CAP_HALF_EXTENT, -PARTICLE_RADIUS, -CAP_HALF_EXTENT]),
-  Object.freeze([CAP_HALF_EXTENT, -PARTICLE_RADIUS, -CAP_HALF_EXTENT]),
-  Object.freeze([CAP_HALF_EXTENT, -PARTICLE_RADIUS, CAP_HALF_EXTENT]),
-  Object.freeze([-CAP_HALF_EXTENT, -PARTICLE_RADIUS, CAP_HALF_EXTENT]),
+  Object.freeze([0, 0, -PARTICLE_HALF_EXTENT]),
+  Object.freeze([-PARTICLE_HALF_EXTENT, -PARTICLE_HALF_EXTENT, PARTICLE_HALF_EXTENT]),
+  Object.freeze([PARTICLE_HALF_EXTENT, -PARTICLE_HALF_EXTENT, PARTICLE_HALF_EXTENT]),
+  Object.freeze([PARTICLE_HALF_EXTENT, PARTICLE_HALF_EXTENT, PARTICLE_HALF_EXTENT]),
+  Object.freeze([-PARTICLE_HALF_EXTENT, PARTICLE_HALF_EXTENT, PARTICLE_HALF_EXTENT]),
 ]);
 export const CSSCYCLONE_FACE_INDICES = Object.freeze([
-  Object.freeze([0, 2, 1]),
-  Object.freeze([0, 3, 2]),
-  Object.freeze([0, 4, 3]),
-  Object.freeze([0, 1, 4]),
+  Object.freeze([0, 1, 2]),
+  Object.freeze([0, 2, 3]),
+  Object.freeze([0, 3, 4]),
+  Object.freeze([0, 4, 1]),
   Object.freeze([1, 2, 3, 4]),
 ]);
+const CSSCYCLONE_FACE_PLANS = Object.freeze(CSSCYCLONE_FACE_INDICES.map((localIndices, faceIndex) => {
+  const vertices = localIndices.map((index) => CSSCYCLONE_PARTICLE_VERTICES[index]);
+  return localIndices.length === 4
+    ? Object.freeze({
+        matrix: quadMatrix(vertices, `particle-face-${faceIndex}`),
+        tileVertexOrder: Object.freeze([0, 1, 2, 3]),
+      })
+    : trianglePlan(vertices, `particle-face-${faceIndex}`);
+}));
+export const CSSCYCLONE_FACE_TILE_VERTEX_ORDERS = Object.freeze(
+  CSSCYCLONE_FACE_PLANS.map(({ tileVertexOrder }) => tileVertexOrder),
+);
 
 export function buildCyclonePreparedModel({
   source = buildCycloneSourceSequence(),
@@ -50,7 +63,6 @@ export function buildCyclonePreparedModel({
     shapes.push(Object.freeze({ id: shapeId, matrix: initial.particles[particleIndex].matrix }));
     for (let faceIndex = 0; faceIndex < CSSCYCLONE_FACE_INDICES.length; faceIndex += 1) {
       const localIndices = CSSCYCLONE_FACE_INDICES[faceIndex];
-      const face = localIndices.map((index) => CSSCYCLONE_PARTICLE_VERTICES[index]);
       const polygonId = `${shapeId}-face-${faceIndex}`;
       polygons.push(Object.freeze({
         id: polygonId,
@@ -66,7 +78,7 @@ export function buildCyclonePreparedModel({
         strategy: quad ? "solid-quad" : "solid-triangle",
         width: SOLID_TRIANGLE_CANONICAL_SIZE,
         height: SOLID_TRIANGLE_CANONICAL_SIZE,
-        matrix: quad ? quadMatrix(face, polygonId) : triangleMatrix(face, polygonId),
+        matrix: CSSCYCLONE_FACE_PLANS[faceIndex].matrix,
         atlas: null,
         fallback: null,
       }));
@@ -163,7 +175,7 @@ export function buildCyclonePreparedPlayback({
   });
 }
 
-function triangleMatrix(vertices, id) {
+function trianglePlan(vertices, id) {
   const plan = computeSolidTrianglePlanFromCssPoints(
     { vertices: vertices.map((vertex) => [...vertex]) },
     0,
@@ -176,7 +188,15 @@ function triangleMatrix(vertices, id) {
   if (!values || values.length !== 16 || values.some((value) => !Number.isFinite(value))) {
     throw new Error(`Cyclone triangle is not renderable: ${id}`);
   }
-  return Object.freeze(values.map((value) => rounded(value)));
+  const { a, b, c } = plan.basis ?? {};
+  if (![a, b, c].every((value) => Number.isSafeInteger(value) && value >= 0 && value < 3) ||
+      new Set([a, b, c]).size !== 3) {
+    throw new Error(`Cyclone triangle basis is invalid: ${id}`);
+  }
+  return Object.freeze({
+    matrix: Object.freeze(values.map((value) => rounded(value))),
+    tileVertexOrder: Object.freeze([c, a, b]),
+  });
 }
 
 function quadMatrix(vertices, id) {

--- a/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import sharp from "sharp";
 import {
   CSSCYCLONE_FACE_INDICES,
+  CSSCYCLONE_FACE_TILE_VERTEX_ORDERS,
   CSSCYCLONE_PARTICLE_VERTICES,
 } from "./modelBuilder.mjs";
 import { CSSCYCLONE_PRESENTATION } from "./sourceModel.mjs";
@@ -166,13 +167,15 @@ async function buildPreparedLightingAsset({
         normal,
       }));
       for (let faceIndex = 0; faceIndex < CSSCYCLONE_FACE_INDICES.length; faceIndex += 1) {
+        const faceVertexIndices = CSSCYCLONE_FACE_INDICES[faceIndex];
         writeAffineFaceTile({
           rgba,
           width: unpackedWidth,
           columns: unpackedColumns,
           tileIndex: stateIndex * CSSCYCLONE_FACE_INDICES.length + faceIndex,
           vertexColors,
-          vertexIndices: CSSCYCLONE_FACE_INDICES[faceIndex],
+          vertexIndices: CSSCYCLONE_FACE_TILE_VERTEX_ORDERS[faceIndex]
+            .map((index) => faceVertexIndices[index]),
         });
       }
     }

--- a/src/adapters/cyclone/test/csscyclone-shell.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-shell.test.mjs
@@ -33,6 +33,8 @@ test("uses the cssGraphics shell without product UI or alternate renderers", asy
   );
   assert.match(styles, /background-image:\s*var\(--cyclone-lighting-atlas\)/u);
   assert.match(styles, /body > \.polycss-camera :is\(u, b\)/u);
+  assert.match(styles, /body > \.polycss-camera u\s*\{[^}]*corner-top-left-shape:\s*bevel;/su);
+  assert.doesNotMatch(styles, /body > \.polycss-camera :is\(u, b\)\s*\{[^}]*corner-top-left-shape:/su);
   assert.doesNotMatch(styles, /color-mix|--cyclone-tone/u);
   assert.match(client, /cameraElement\.style\.removeProperty\("perspective"\)/u);
   assert.match(client, /sceneElement\.style\.removeProperty\("transform"\)/u);

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -12,6 +12,7 @@ import {
 } from "../src/prepare/csscyclone/sourceModel.mjs";
 import {
   CSSCYCLONE_FACE_INDICES,
+  CSSCYCLONE_FACE_TILE_VERTEX_ORDERS,
   CSSCYCLONE_MODEL_IDS,
   CSSCYCLONE_PARTICLE_VERTICES,
   buildCyclonePreparedModel,
@@ -31,6 +32,16 @@ import {
   decodeCyclonePreparedBlockIncrementally,
   encodeCyclonePreparedBlock,
 } from "../src/shared/csscyclone/preparedBlockTransport.mjs";
+
+function dot(left, right) {
+  return left.reduce((sum, value, index) => sum + value * right[index], 0);
+}
+
+function normalized(vector) {
+  const length = Math.hypot(...vector);
+  assert.ok(length > 1e-12);
+  return vector.map((value) => value / length);
+}
 
 test("pins the current Really Slick Cyclone source profile", () => {
   assert.equal(CSSCYCLONE_SOURCE.revision, "5f0a788bf0cc47f66a233ed528919295cd1e7500");
@@ -145,15 +156,88 @@ test("builds a stable retained particle graph and prepared state bank", () => {
     preparedModel.model.render.leaves.slice(0, 5).map(({ strategy }) => strategy),
     ["solid-triangle", "solid-triangle", "solid-triangle", "solid-triangle", "solid-quad"],
   );
-  assert.equal(CSSCYCLONE_PARTICLE_VERTICES[0][1] > 0, true);
-  assert.equal(CSSCYCLONE_PARTICLE_VERTICES.slice(1).every((vertex) => vertex[1] < 0), true);
+  assert.equal(CSSCYCLONE_PARTICLE_VERTICES[0][2] < 0, true);
+  assert.equal(CSSCYCLONE_PARTICLE_VERTICES.slice(1).every((vertex) => vertex[2] > 0), true);
+  assert.equal(
+    CSSCYCLONE_PARTICLE_VERTICES[1][2] - CSSCYCLONE_PARTICLE_VERTICES[0][2],
+    CSSCYCLONE_PARTICLE_VERTICES[2][0] - CSSCYCLONE_PARTICLE_VERTICES[1][0],
+  );
+  assert.ok(Math.abs(
+    CSSCYCLONE_PARTICLE_VERTICES[2][0] - CSSCYCLONE_PARTICLE_VERTICES[1][0] -
+      CSSCYCLONE_SOURCE.particleSize / 2 * 0.6 / Math.sqrt(2),
+  ) < 1e-12);
   assert.deepEqual(CSSCYCLONE_FACE_INDICES.at(-1), [1, 2, 3, 4]);
+  assert.deepEqual(CSSCYCLONE_FACE_TILE_VERTEX_ORDERS, [
+    [2, 0, 1],
+    [2, 0, 1],
+    [2, 0, 1],
+    [2, 0, 1],
+    [0, 1, 2, 3],
+  ]);
+  preparedModel.model.render.leaves.slice(0, 5).forEach((leaf, faceIndex) => {
+    const centroid = CSSCYCLONE_FACE_INDICES[faceIndex]
+      .map((index) => CSSCYCLONE_PARTICLE_VERTICES[index])
+      .reduce((sum, vertex) => sum.map((value, axis) => value + vertex[axis]), [0, 0, 0])
+      .map((value) => value / CSSCYCLONE_FACE_INDICES[faceIndex].length);
+    const normal = leaf.matrix.slice(8, 11);
+    assert.equal(normal.reduce((sum, value, axis) => sum + value * centroid[axis], 0) > 0, true);
+  });
   assert.equal(preparedPlayback.playback.transforms.length, 12);
   assert.equal(preparedPlayback.playback.schema, "csscyclone-prepared-dom-playback@5");
   assert.equal(preparedPlayback.metrics.shapeTransformSelections, 12);
   assert.equal(preparedModel.metrics.runtimeGeometryConstructionCount, 0);
   assert.equal(preparedModel.metrics.runtimeAtlasRasterizationCount, 0);
   assert.equal(preparedModel.metrics.runtimeDomGrowth, false);
+});
+
+test("points the pyramid apex along prepared particle travel", () => {
+  const source = buildCycloneSourceSequence({
+    bank: {
+      ...CSSCYCLONE_BANK,
+      particleCount: 80,
+      warmupFrames: 720,
+      frameCount: 180,
+      chunkCount: 1,
+    },
+  });
+  const localApex = normalized(CSSCYCLONE_PARTICLE_VERTICES[0]);
+  let alignmentTotal = 0;
+  let closestAxisCount = 0;
+  let transitionCount = 0;
+  for (let frameIndex = 0; frameIndex < source.frames.length - 1; frameIndex += 1) {
+    const frame = source.frames[frameIndex];
+    const nextFrame = source.frames[frameIndex + 1];
+    for (let particleIndex = 0; particleIndex < source.bank.particleCount; particleIndex += 1) {
+      const matrix = frame.particles[particleIndex].matrix;
+      const nextMatrix = nextFrame.particles[particleIndex].matrix;
+      const velocity = normalized([
+        nextMatrix[12] - matrix[12],
+        nextMatrix[13] - matrix[13],
+        nextMatrix[14] - matrix[14],
+      ]);
+      const transformedAxes = [
+        [matrix[0], matrix[1], matrix[2]],
+        [matrix[4], matrix[5], matrix[6]],
+        [matrix[8], matrix[9], matrix[10]],
+      ].map(normalized);
+      const apexDirection = normalized([
+        matrix[0] * localApex[0] + matrix[4] * localApex[1] + matrix[8] * localApex[2],
+        matrix[1] * localApex[0] + matrix[5] * localApex[1] + matrix[9] * localApex[2],
+        matrix[2] * localApex[0] + matrix[6] * localApex[1] + matrix[10] * localApex[2],
+      ]);
+      const apexAlignment = dot(velocity, apexDirection);
+      const cardinalAlignments = transformedAxes.flatMap((axis) => [
+        dot(velocity, axis),
+        dot(velocity, axis.map((value) => -value)),
+      ]);
+      alignmentTotal += apexAlignment;
+      if (apexAlignment >= Math.max(...cardinalAlignments)) closestAxisCount += 1;
+      transitionCount += 1;
+    }
+  }
+  assert.equal(transitionCount, 14_320);
+  assert.ok(alignmentTotal / transitionCount > 0.95);
+  assert.ok(closestAxisCount / transitionCount > 0.97);
 });
 
 test("round-trips exact prepared matrices through compact source-state blocks", async () => {


### PR DESCRIPTION
## Summary
- point the five-face PolyCSS particle apex along the prepared local -Z travel axis
- correct triangle winding, cap styling, and lighting-atlas vertex order
- reduce the complete particle primitive to a uniform 0.6 presentation scale

## Verification
- pnpm test:cyclone (32/32)
- pnpm prepare:cyclone
- pnpm build:cyclone
- deterministic desktop browser capture: 320 retained roots, 1600 leaves, U/U/U/U/B, zero model wrappers
- source-motion regression: 14,320 transitions, mean apex/velocity cosine > 0.95, closest axis share > 0.97