### PR TITLE
perf(cyclone): slice background block decoding

### DIFF
--- a/src/adapters/cyclone/src/csscyclone/preparedBlockWorker.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedBlockWorker.mjs
@@ -1,4 +1,7 @@
-import { decodeCyclonePreparedBlock } from "../shared/csscyclone/preparedBlockTransport.mjs";
+import {
+  decodeCyclonePreparedBlock,
+  decodeCyclonePreparedBlockIncrementally,
+} from "../shared/csscyclone/preparedBlockTransport.mjs";
 
 const TRANSFORM_RESPONSE_CHUNK_TRANSFORMS = 960;
 
@@ -16,6 +19,7 @@ self.addEventListener("message", ({ data }) => {
       return;
     }
     if (data?.type !== "materialize" || catalog === null ||
+        typeof data.incremental !== "boolean" ||
         !Number.isSafeInteger(data.requestId) || !(data.bytes instanceof Uint8Array)) {
       throw new Error("Prepared Cyclone worker request drifted");
     }
@@ -30,7 +34,17 @@ self.addEventListener("message", ({ data }) => {
 
 async function materializeBlock(data) {
   const startedAt = performance.now();
-  const block = decodeCyclonePreparedBlock(data.bytes, data.descriptor, catalog);
+  const block = data.incremental
+    ? await decodeCyclonePreparedBlockIncrementally(
+      data.bytes,
+      data.descriptor,
+      catalog,
+      {
+        sliceBudgetMilliseconds: 2,
+        sliceDelayMilliseconds: 0,
+      },
+    )
+    : decodeCyclonePreparedBlock(data.bytes, data.descriptor, catalog);
   const transforms = block.playback.transforms;
   const transformByteLength = transforms.reduce((total, transform) => total + transform.length, 0) +
     transforms.length - 1;

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -200,7 +200,11 @@ export function createCyclonePreparedBlockLoader(catalog) {
       let workerResponseIdleSliceCount = 0;
       let workerMaximumResponseChunkBytes = 0;
       const block = offMainThread && workerMaterializer !== null
-        ? await workerMaterializer.materialize(decodedRecord.bytes, descriptor).then((result) => {
+        ? await workerMaterializer.materialize(
+          decodedRecord.bytes,
+          descriptor,
+          { incremental },
+        ).then((result) => {
           workerDurationMilliseconds = result.durationMilliseconds;
           workerResponseChunkCount = result.responseChunkCount;
           workerResponseIdleSliceCount = result.responseIdleSliceCount;
@@ -512,8 +516,11 @@ function createWorkerBlockMaterializer(catalog) {
   worker.postMessage({ type: "initialize", catalog });
 
   return Object.freeze({
-    async materialize(bytes, descriptor) {
+    async materialize(bytes, descriptor, { incremental }) {
       if (destroyed) throw new Error("Prepared Cyclone worker is destroyed");
+      if (typeof incremental !== "boolean") {
+        throw new TypeError("Prepared Cyclone worker materialization mode is invalid");
+      }
       await initialized;
       const requestId = nextRequestId;
       nextRequestId += 1;
@@ -524,6 +531,7 @@ function createWorkerBlockMaterializer(catalog) {
       worker.postMessage({
         type: "materialize",
         requestId,
+        incremental,
         bytes: workerBytes,
         descriptor,
       }, [workerBytes.buffer]);

--- a/src/adapters/cyclone/src/shared/csscyclone/preparedBlockTransport.mjs
+++ b/src/adapters/cyclone/src/shared/csscyclone/preparedBlockTransport.mjs
@@ -97,6 +97,7 @@ export async function decodeCyclonePreparedBlockIncrementally(
     setDelay = globalThis.setTimeout.bind(globalThis),
     readNow = () => globalThis.performance.now(),
     sliceBudgetMilliseconds = 4,
+    sliceDelayMilliseconds = catalog?.frameMilliseconds,
     isCurrent = () => true,
     onSlice = () => undefined,
   } = {},
@@ -104,14 +105,16 @@ export async function decodeCyclonePreparedBlockIncrementally(
   if (typeof setDelay !== "function" || typeof readNow !== "function" ||
       typeof isCurrent !== "function" || typeof onSlice !== "function" ||
       !Number.isFinite(sliceBudgetMilliseconds) ||
-      sliceBudgetMilliseconds <= 0 || sliceBudgetMilliseconds > 4) {
+      sliceBudgetMilliseconds <= 0 || sliceBudgetMilliseconds > 4 ||
+      !Number.isFinite(sliceDelayMilliseconds) || sliceDelayMilliseconds < 0 ||
+      sliceDelayMilliseconds > catalog?.frameMilliseconds) {
     throw new TypeError("Cyclone incremental source-state decoder scheduling is invalid");
   }
   const operations = decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog);
   let firstSlice = true;
   while (true) {
     if (!firstSlice) {
-      await new Promise((resolveDelay) => setDelay(resolveDelay, catalog.frameMilliseconds));
+      await new Promise((resolveDelay) => setDelay(resolveDelay, sliceDelayMilliseconds));
       if (!isCurrent()) return null;
     }
     firstSlice = false;

--- a/src/adapters/cyclone/test/csscyclone-shell.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-shell.test.mjs
@@ -50,7 +50,10 @@ test("uses the cssGraphics shell without product UI or alternate renderers", asy
   );
   assert.match(styles, /body\.priming::before/u);
   assert.match(stream, /new Worker\(new URL\("\.\/preparedBlockWorker\.mjs"/u);
-  assert.match(worker, /decodeCyclonePreparedBlock/u);
+  assert.match(worker, /decodeCyclonePreparedBlockIncrementally/u);
+  assert.match(worker, /data\.incremental/u);
+  assert.match(worker, /sliceDelayMilliseconds: 0/u);
+  assert.match(stream, /\{ incremental \}/u);
   assert.match(worker, /type: "materialized-chunk"/u);
   assert.match(worker, /TRANSFORM_RESPONSE_CHUNK_TRANSFORMS = 960/u);
   assert.match(worker, /setTimeout\(resolve, catalog\.frameMilliseconds\)/u);

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -291,14 +291,16 @@ test("round-trips exact prepared matrices through compact source-state blocks", 
   assert.ok(decoded.preparedCssStringByteLength > bytes.byteLength);
   let clock = 0;
   let delayCount = 0;
+  const delayMilliseconds = [];
   const slices = [];
   const incrementallyDecoded = await decodeCyclonePreparedBlockIncrementally(
     bytes,
     descriptor,
     catalog,
     {
-      setDelay(callback) {
+      setDelay(callback, milliseconds) {
         delayCount += 1;
+        delayMilliseconds.push(milliseconds);
         callback();
       },
       readNow() {
@@ -313,6 +315,7 @@ test("round-trips exact prepared matrices through compact source-state blocks", 
   );
   assert.deepEqual(incrementallyDecoded.playback.transforms, expected.transforms);
   assert.ok(delayCount >= 1);
+  assert.ok(delayMilliseconds.every((milliseconds) => milliseconds === catalog.frameMilliseconds));
   assert.ok(slices.every(({ operationCount }) => operationCount <= 8_192));
   assert.throws(
     () => decodeCyclonePreparedBlock(bytes.slice(0, -1), descriptor, catalog),


### PR DESCRIPTION
## Summary
- preserve one-shot startup block decoding
- slice only background playback decoding into bounded worker turns
- keep prepared transforms, retained DOM, particle counts, colors, and publication cadence unchanged

## Trace evidence
- worker longest RunMicrotasks: 177.594 ms baseline mean -> 3.653 ms treatment mean
- presented-frame p95: 17.234 ms -> 16.669 ms
- zero runtime block waits, collapsed frames, DOM growth, or page errors

## Verification
- pnpm test:cyclone (33/33)
- CSSCYCLONE_DEPLOY_BUILD=1 pnpm build:cyclone
- git diff --check