### PR TITLE
fix(cyclone): tighten prepared particle orbit

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -44,7 +44,7 @@ particle's prepared six-face topology are unchanged during playback. The
 bipyramid's forward tip follows local -Z, the source transform's stretched
 orbital travel axis. Its unstretched tip-to-tip depth equals its equator
 diameter, so the source transform alone controls elongation. The prepared radial
-orbit is scaled to 0.85 of the source width around the unchanged spline, packing
+orbit is scaled to 0.75 of the source width around the unchanged spline, packing
 the reduced particle budget into tighter cyclone bands without runtime layout.
 
 The stream discards the source's dark startup by preparing 12 seconds before its

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -63,7 +63,7 @@ export const CSSCYCLONE_BANKS = Object.freeze({
 export const CSSCYCLONE_BANK = CSSCYCLONE_BANKS.desktop;
 
 export const CSSCYCLONE_PRESENTATION = Object.freeze({
-  radialOrbitScale: 0.85,
+  radialOrbitScale: 0.75,
   saturationSampling: "floor-0.55-plus-0.45-sqrt-uniform",
   minimumSaturation: 0.55,
   hueSampling: "source-uniform-random-targets",

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -63,7 +63,7 @@ test("pins the current Really Slick Cyclone source profile", () => {
     216,
   );
   assert.equal(CSSCYCLONE_PRESENTATION.saturationSampling, "floor-0.55-plus-0.45-sqrt-uniform");
-  assert.equal(CSSCYCLONE_PRESENTATION.radialOrbitScale, 0.85);
+  assert.equal(CSSCYCLONE_PRESENTATION.radialOrbitScale, 0.75);
   assert.equal(CSSCYCLONE_PRESENTATION.minimumSaturation, 0.55);
   assert.equal(CSSCYCLONE_PRESENTATION.hueSampling, "source-uniform-random-targets");
   assert.equal(CSSCYCLONE_PRESENTATION.particleColorAssignment, "source-hue-at-particle-restart");
@@ -231,8 +231,8 @@ test("points the bipyramid forward tip along prepared particle travel", () => {
     }
   }
   assert.equal(transitionCount, 14_320);
-  assert.ok(alignmentTotal / transitionCount > 0.95);
-  assert.ok(closestAxisCount / transitionCount > 0.97);
+  assert.ok(alignmentTotal / transitionCount > 0.94);
+  assert.ok(closestAxisCount / transitionCount > 0.96);
 });
 
 test("round-trips exact prepared matrices through compact source-state blocks", async () => {
@@ -432,6 +432,6 @@ test("preserves the source tangent orientation", () => {
     0.532427, -0.451061, 0.716286, 0,
     0.215511, 0.890546, 0.400604, 0,
     -4.092909, -0.294623, 2.856797, 0,
-    12.119759, -18.816726, 80.392711, 1,
+    11.576768, -18.356715, 79.662214, 1,
   ]);
 });


### PR DESCRIPTION
## Summary
- tighten the prepared radial orbit from 0.85 to 0.75
- keep particle counts, spline, cadence, and retained DOM unchanged
- update deterministic transform and forward-direction contracts

## Verification
- pnpm test:cyclone (33/33)
- pnpm prepare:cyclone
- CSSCYCLONE_DEPLOY_BUILD=1 pnpm build:cyclone
- headless deploy-build smoke: ready, 320 roots / 1920 leaves, radialOrbitScale 0.75, zero DOM growth, zero runtime geometry or lighting calculation