### PR TITLE
fix(cloth): preserve immutable asset caching

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -53,9 +53,9 @@
     Cache-Control = "public, max-age=31536000, immutable"
 
 [[headers]]
-  for = "/csscloth/model/cloth/assets/*"
+  for = "/csscloth/*"
   [headers.values]
-    Cache-Control = "public, max-age=31536000, immutable"
+    Cache-Control = "public, max-age=0, must-revalidate"
 
 [[headers]]
   for = "/csscloth/playback-bank-*"
@@ -63,9 +63,9 @@
     Cache-Control = "public, max-age=31536000, immutable"
 
 [[headers]]
-  for = "/csscloth/*"
+  for = "/csscloth/model/cloth/assets/*"
   [headers.values]
-    Cache-Control = "public, max-age=0, must-revalidate"
+    Cache-Control = "public, max-age=31536000, immutable"
 
 [[headers]]
   for = "/cssmenger/assets/*"

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -172,6 +172,16 @@ test("deployment serves the landing at the root", async () => {
   );
   assert.match(packageManifest, /pnpm prepare:cloth:artifact/u);
   assert.match(packageManifest, /CSSCLOTH_DEPLOY_BUILD=1 pnpm build:cloth/u);
+  assert.ok(
+    netlify.indexOf('for = "/csscloth/*"') <
+      netlify.indexOf('for = "/csscloth/playback-bank-*"'),
+    "Cloth hash-named bank headers must override the broad metadata rule",
+  );
+  assert.ok(
+    netlify.indexOf('for = "/csscloth/*"') <
+      netlify.indexOf('for = "/csscloth/model/cloth/assets/*"'),
+    "Cloth hash-named texture headers must override the broad metadata rule",
+  );
   assert.match(
     packageManifest,
     /"prepare:electropaint:deploy": "pnpm prepare:electropaint:artifact"/u,


### PR DESCRIPTION
## Summary

- order Cloth cache rules so hash-named banks and textures override broad metadata revalidation
- pin the precedence contract in the site deployment test

## Verification

- `pnpm test:site`
- observed production failure before fix: prepared metadata, bank, and texture all returned `max-age=0, must-revalidate`