### PR TITLE
Accelerate Cyclone startup materialization

### DIFF
--- a/src/adapters/cyclone/src/csscyclone/preparedBlockWorker.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedBlockWorker.mjs
@@ -83,7 +83,7 @@ async function materializeBlock(data) {
       transforms: transformChunk,
       transformChunkByteLength,
     });
-    if (transformChunkIndex + 1 < transformChunkCount) {
+    if (data.incremental && transformChunkIndex + 1 < transformChunkCount) {
       await new Promise((resolve) => setTimeout(resolve, catalog.frameMilliseconds));
     }
   }

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -404,11 +404,16 @@ function createWorkerBlockMaterializer(catalog) {
       scheduleResponseChunk();
       return;
     }
+    acceptResponseChunk(data, request, response, true);
+    scheduleResponseChunk();
+  }
+
+  function acceptResponseChunk(data, request, response, idleSlice) {
     try {
       const isFinalChunk = data.transformChunkIndex + 1 === response.transformChunkCount;
       response.transforms.push(...data.transforms);
       response.processedTransformChunkCount += 1;
-      response.idleSliceCount += 1;
+      response.idleSliceCount += Number(idleSlice);
       response.receivedTransformBytes += data.transformChunkByteLength;
       response.maximumResponseChunkBytes = Math.max(
         response.maximumResponseChunkBytes,
@@ -419,7 +424,6 @@ function createWorkerBlockMaterializer(catalog) {
       pending.delete(data.requestId);
       request.reject(error);
     }
-    scheduleResponseChunk();
   }
 
   function completeWorkerResponse(requestId, request, response) {
@@ -507,8 +511,12 @@ function createWorkerBlockMaterializer(catalog) {
       return;
     }
     response.queuedTransformChunkCount += 1;
-    responseChunkQueue.push({ data, request, response });
-    scheduleResponseChunk();
+    if (request.incremental) {
+      responseChunkQueue.push({ data, request, response });
+      scheduleResponseChunk();
+    } else {
+      acceptResponseChunk(data, request, response, false);
+    }
   });
   worker.addEventListener("error", (event) => {
     rejectAll(new Error(event.message || "Prepared Cyclone worker failed"));
@@ -526,7 +534,7 @@ function createWorkerBlockMaterializer(catalog) {
       nextRequestId += 1;
       const workerBytes = bytes.slice();
       const result = new Promise((resolve, reject) => {
-        pending.set(requestId, { resolve, reject, response: null });
+        pending.set(requestId, { resolve, reject, response: null, incremental });
       });
       worker.postMessage({
         type: "materialize",

--- a/src/adapters/cyclone/test/csscyclone-shell.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-shell.test.mjs
@@ -56,8 +56,12 @@ test("uses the cssGraphics shell without product UI or alternate renderers", asy
   assert.match(stream, /\{ incremental \}/u);
   assert.match(worker, /type: "materialized-chunk"/u);
   assert.match(worker, /TRANSFORM_RESPONSE_CHUNK_TRANSFORMS = 960/u);
+  assert.match(worker, /data\.incremental && transformChunkIndex \+ 1 < transformChunkCount/u);
   assert.match(worker, /setTimeout\(resolve, catalog\.frameMilliseconds\)/u);
   assert.doesNotMatch(worker, /new TextDecoder\(\)|new TextEncoder\(\)/u);
+  assert.match(stream, /if \(request\.incremental\) \{\s*responseChunkQueue\.push/su);
+  assert.match(stream, /acceptResponseChunk\(data, request, response, false\)/u);
+  assert.match(stream, /pending\.set\(requestId, \{ resolve, reject, response: null, incremental \}\)/u);
   assert.match(stream, /workerMaterializationMaximumResponseChunkBytes/u);
   assert.match(stream, /requestIdle\(processResponseChunk, \{ timeout: 500 \}\)/u);
   assert.doesNotMatch(stream, /requestAnimationFrame\(processResponseChunk\)/u);


### PR DESCRIPTION
## Summary
- bypass frame-paced worker chunk delivery before Cyclone becomes ready
- preserve paced worker delivery and idle-sliced adoption for incremental playback blocks
- lock the startup/background split into the Cyclone shell contract

## Verification
- `pnpm test:cyclone`
- `pnpm build:cyclone`
- `pnpm verify:source-only`
- 20-second Chrome playback probe: 20 continuous block handoffs, 400 idle-sliced background chunks, zero waits, zero collapsed frames, zero long tasks