### PR TITLE
Fix Pipes referral query URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "verify:source-only": "node scripts/verify-source-only.mjs --strict",
     "verify:flowerbox:bank": "node src/adapters/flowerbox/tools/verify-product-bank.mjs",
     "verify:flowerbox:runtime": "node src/adapters/flowerbox/tools/audit-runtime-surface.mjs",
+    "test:3dpipes": "node --test src/adapters/3dpipes/test/*.test.mjs",
     "test:flowerbox:lighting-publication": "node --test src/adapters/flowerbox/test/visible-lighting-publication.test.mjs",
     "test:flowerbox:browser": "node src/adapters/flowerbox/tools/smoke-browser.mjs",
     "test:cloth": "node --max-old-space-size=8192 --test src/adapters/cloth/test/*.test.mjs",

--- a/src/adapters/3dpipes/src/csspipes/routeState.mjs
+++ b/src/adapters/3dpipes/src/csspipes/routeState.mjs
@@ -8,8 +8,8 @@ export function resolveCssPipesRoute(input) {
   if (!supportedPaths.has(url.pathname)) {
     throw new CssPipesContractError(`Unsupported cssPipes route ${url.pathname}`);
   }
-  if (url.search || url.hash) {
-    throw new CssPipesContractError("cssPipes does not accept ad hoc scene selectors");
+  if (url.hash) {
+    throw new CssPipesContractError("cssPipes does not accept fragment scene selectors");
   }
   return Object.freeze({
     pathname: url.pathname.startsWith("/pipes") ? "/pipes/" : "/",

--- a/src/adapters/3dpipes/test/csspipes-route-state.test.mjs
+++ b/src/adapters/3dpipes/test/csspipes-route-state.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveCssPipesRoute } from "../src/csspipes/routeState.mjs";
+
+test("csspipes resolves its deployed route to the prepared manifest default", () => {
+  assert.deepEqual(resolveCssPipesRoute("https://css.graphics/pipes/"), {
+    pathname: "/pipes/",
+    manifestUrl: "/csspipes/manifest.json",
+    selection: "manifest-default",
+  });
+});
+
+test("csspipes ignores referral query parameters", () => {
+  assert.deepEqual(
+    resolveCssPipesRoute("https://css.graphics/pipes/?ref=links.supply,"),
+    resolveCssPipesRoute("https://css.graphics/pipes/"),
+  );
+});
+
+test("csspipes query parameters cannot select an ad hoc scene", () => {
+  assert.equal(
+    resolveCssPipesRoute("https://css.graphics/pipes/?scene=unprepared").selection,
+    "manifest-default",
+  );
+});
+
+test("csspipes still rejects unsupported paths and fragment scene selectors", () => {
+  assert.throws(() => resolveCssPipesRoute("https://css.graphics/not-pipes/"), {
+    name: "CssPipesContractError",
+    message: "Unsupported cssPipes route /not-pipes/",
+  });
+  assert.throws(() => resolveCssPipesRoute("https://css.graphics/pipes/#scene"), {
+    name: "CssPipesContractError",
+    message: "cssPipes does not accept fragment scene selectors",
+  });
+});


### PR DESCRIPTION
## Summary
- allow referral and tracking query parameters on the Pipes product route
- keep prepared scene selection pinned to the manifest default
- retain rejection for unsupported paths and fragment selectors
- add focused route regression coverage for the links.supply URL

## Verification
- pnpm test:3dpipes
- pnpm typecheck
- pnpm build:3dpipes
- headless Chrome: /pipes/?ref=links.supply, reached csspipes-ready with 14 prepared roots