### PR TITLE
perf(cloth): stream future bank preparation

### DIFF
--- a/src/adapters/cloth/src/csscloth/client.mjs
+++ b/src/adapters/cloth/src/csscloth/client.mjs
@@ -7,7 +7,7 @@ import { createPolyPerspectiveCamera } from "@layoutit/polycss";
 import { createPolyMorphPreparedShadowTarget } from "../shared/csscloth/morphShadowPatch.mjs";
 import { createPolyMorphPreparedCornerTextureTarget } from "../shared/csscloth/morphTexturePatch.mjs";
 import { selectClothStartingBank } from "../shared/csscloth/bankSelection.mjs";
-import { loadClothPreparedPlayback } from "../shared/csscloth/preparedPlaybackTransport.mjs";
+import { createClothPreparedPlaybackStream } from "./preparedPlaybackStream.mjs";
 
 export function mountClothClient(host) {
   const state = { ready: false, errors: [], mounted: null, player: null, metadata: null };
@@ -28,10 +28,11 @@ export function mountClothClient(host) {
       .then((response) => response.json());
     const bankDescriptors = validatePlaybackCatalog(metadata);
     const startingBankIndex = selectClothStartingBank(bankDescriptors.length);
+    const playbackStream = createClothPreparedPlaybackStream();
     const loadStartedAt = performance.now();
     const [loaded, playback] = await Promise.all([
       loadPolyMorphPackage(metadata.renderer.modelRoot, { modelId: metadata.renderer.modelId }),
-      loadClothPreparedPlayback(bankDescriptors[startingBankIndex]),
+      playbackStream.loadInitial(bankDescriptors[startingBankIndex]),
     ]);
     const loadMilliseconds = performance.now() - loadStartedAt;
     if (loaded.model.identity.id !== metadata.renderer.modelId ||
@@ -61,7 +62,8 @@ export function mountClothClient(host) {
       bankDescriptors,
       startingBankIndex,
       loadMilliseconds,
-      loadPlayback: loadClothPreparedPlayback,
+      loadPlayback: playbackStream.loadFuture,
+      playbackStream,
       recordError,
     });
     player.seekFrame(0);
@@ -164,6 +166,7 @@ function createPlayer(mounted, model, initialPlayback, clothTexture, transport) 
     const descriptor = bankDescriptors[bankIndex];
     const startedAt = performance.now();
     prefetchingBankIndex = bankIndex;
+    performance.mark("csscloth-bank-prefetch-start");
     prefetchPromise = transport.loadPlayback(descriptor)
       .then((nextPlayback) => {
         validatePlaybackBank(nextPlayback, descriptor, playback);
@@ -174,6 +177,7 @@ function createPlayer(mounted, model, initialPlayback, clothTexture, transport) 
         preparedPlaybackCompressedBytes += descriptor.compressedByteLength;
         preparedPlaybackDecodedBytes += nextPlayback.decodedByteLength;
         preparedPlaybackLoadMilliseconds += performance.now() - startedAt;
+        performance.mark("csscloth-bank-prefetch-complete");
       })
       .catch((error) => {
         if (!destroyed && prefetchingBankIndex === bankIndex) {
@@ -202,6 +206,7 @@ function createPlayer(mounted, model, initialPlayback, clothTexture, transport) 
     lastFrameIndex = -1;
     publish(0);
     bankHandoffCount += 1;
+    performance.mark("csscloth-bank-handoff");
     prefetchNextBank();
     return true;
   }
@@ -316,6 +321,7 @@ function createPlayer(mounted, model, initialPlayback, clothTexture, transport) 
         (sum, descriptor) => sum + descriptor.compressedByteLength,
         0,
       ),
+      ...transport.playbackStream.stats(),
     });
   }
 
@@ -339,6 +345,7 @@ function createPlayer(mounted, model, initialPlayback, clothTexture, transport) 
       shadowTarget.destroy();
       target.destroy();
       mounted.destroy();
+      transport.playbackStream.destroy();
     },
   });
 }

--- a/src/adapters/cloth/src/csscloth/preparedPlaybackStream.mjs
+++ b/src/adapters/cloth/src/csscloth/preparedPlaybackStream.mjs
@@ -1,0 +1,282 @@
+import {
+  completeClothPreparedPlaybackMaterialization,
+  loadClothPreparedPlayback,
+} from "../shared/csscloth/preparedPlaybackTransport.mjs";
+
+const RESPONSE_CHUNK_TRANSFORM_COUNT = 480;
+
+export function createClothPreparedPlaybackStream() {
+  const workerMaterializer = createWorkerMaterializer();
+  let loadCount = 0;
+  let workerLoadCount = 0;
+  let workerPreparationMaximumMilliseconds = 0;
+  let workerMaterializationMaximumMilliseconds = 0;
+  let responseChunkCount = 0;
+  let responseIdleSliceCount = 0;
+  let responseMaximumChunkBytes = 0;
+  let responseMaximumIdleSliceMilliseconds = 0;
+
+  async function loadInitial(descriptor) {
+    const playback = await loadClothPreparedPlayback(descriptor);
+    loadCount += 1;
+    return playback;
+  }
+
+  async function loadFuture(descriptor) {
+    if (workerMaterializer === null) {
+      const playback = await loadClothPreparedPlayback(descriptor);
+      loadCount += 1;
+      return playback;
+    }
+    const result = await workerMaterializer.materialize(descriptor);
+    loadCount += 1;
+    workerLoadCount += 1;
+    workerPreparationMaximumMilliseconds = Math.max(
+      workerPreparationMaximumMilliseconds,
+      result.preparationMilliseconds,
+    );
+    workerMaterializationMaximumMilliseconds = Math.max(
+      workerMaterializationMaximumMilliseconds,
+      result.durationMilliseconds,
+    );
+    responseChunkCount += result.responseChunkCount;
+    responseIdleSliceCount += result.responseIdleSliceCount;
+    responseMaximumChunkBytes = Math.max(
+      responseMaximumChunkBytes,
+      result.maximumResponseChunkBytes,
+    );
+    responseMaximumIdleSliceMilliseconds = Math.max(
+      responseMaximumIdleSliceMilliseconds,
+      result.maximumResponseIdleSliceMilliseconds,
+    );
+    return result.playback;
+  }
+
+  return Object.freeze({
+    loadInitial,
+    loadFuture,
+    stats() {
+      return Object.freeze({
+        preparedPlaybackStreamLoadCount: loadCount,
+        preparedPlaybackWorkerAvailable: workerMaterializer !== null,
+        preparedPlaybackWorkerLoadCount: workerLoadCount,
+        preparedPlaybackWorkerPreparationMaximumMilliseconds:
+          Number(workerPreparationMaximumMilliseconds.toFixed(2)),
+        preparedPlaybackWorkerMaterializationMaximumMilliseconds:
+          Number(workerMaterializationMaximumMilliseconds.toFixed(2)),
+        preparedPlaybackResponseChunkCount: responseChunkCount,
+        preparedPlaybackResponseIdleSliceCount: responseIdleSliceCount,
+        preparedPlaybackResponseMaximumChunkBytes: responseMaximumChunkBytes,
+        preparedPlaybackResponseMaximumIdleSliceMilliseconds:
+          Number(responseMaximumIdleSliceMilliseconds.toFixed(3)),
+      });
+    },
+    destroy() {
+      workerMaterializer?.destroy();
+    },
+  });
+}
+
+function createWorkerMaterializer() {
+  if (typeof Worker !== "function") return null;
+  let worker;
+  try {
+    worker = new Worker(new URL("./preparedPlaybackWorker.mjs", import.meta.url), {
+      type: "module",
+      name: "csscloth-prepared-playback-materializer",
+    });
+  } catch {
+    return null;
+  }
+  const pending = new Map();
+  const responseQueue = [];
+  const requestIdle = globalThis.requestIdleCallback?.bind(globalThis) ??
+    ((callback) => setTimeout(() => callback({ didTimeout: true, timeRemaining: () => 0 }), 0));
+  const cancelIdle = globalThis.cancelIdleCallback?.bind(globalThis) ?? clearTimeout;
+  let idleRequest = null;
+  let nextRequestId = 0;
+  let destroyed = false;
+
+  function rejectAll(error) {
+    for (const request of pending.values()) request.reject(error);
+    pending.clear();
+    responseQueue.length = 0;
+    if (idleRequest !== null) cancelIdle(idleRequest);
+    idleRequest = null;
+  }
+
+  function scheduleResponseSlice() {
+    if (idleRequest !== null || responseQueue.length === 0) return;
+    idleRequest = requestIdle(processResponseSlice, { timeout: 500 });
+  }
+
+  function processResponseSlice() {
+    idleRequest = null;
+    const queued = responseQueue.shift();
+    if (!queued) return;
+    const { data, request } = queued;
+    if (pending.get(data.requestId) !== request) {
+      scheduleResponseSlice();
+      return;
+    }
+    const startedAt = performance.now();
+    try {
+      const response = request.response;
+      const expectedChunkIndex = data.kind === "cloth"
+        ? response.processedClothChunkCount
+        : response.processedShadowChunkCount;
+      const target = data.kind === "cloth" ? response.transforms : response.shadowTransformValues;
+      if (data.chunkIndex !== expectedChunkIndex || data.start !== target.length) {
+        throw new Error("Prepared Cloth worker response ordering drifted");
+      }
+      target.push(...data.transforms);
+      if (data.kind === "cloth") response.processedClothChunkCount += 1;
+      else response.processedShadowChunkCount += 1;
+      response.responseChunkCount += 1;
+      response.responseIdleSliceCount += 1;
+      response.receivedTransformBytes += data.transformByteLength;
+      response.maximumResponseChunkBytes = Math.max(
+        response.maximumResponseChunkBytes,
+        data.transformByteLength,
+      );
+      response.maximumResponseIdleSliceMilliseconds = Math.max(
+        response.maximumResponseIdleSliceMilliseconds,
+        performance.now() - startedAt,
+      );
+      maybeComplete(data.requestId, request);
+    } catch (error) {
+      pending.delete(data.requestId);
+      request.reject(error);
+    }
+    scheduleResponseSlice();
+  }
+
+  function maybeComplete(requestId, request) {
+    const response = request.response;
+    if (!response?.workerComplete ||
+        response.processedClothChunkCount !== response.clothChunkCount ||
+        response.processedShadowChunkCount !== response.shadowChunkCount) return;
+    if (response.transforms.length !== response.clothTransformCount ||
+        response.shadowTransformValues.length !== response.shadowTransformValueCount) {
+      throw new Error("Prepared Cloth worker response count drifted");
+    }
+    const playback = completeClothPreparedPlaybackMaterialization(
+      response.playback,
+      response.transforms,
+      response.shadowTransformValues,
+    );
+    pending.delete(requestId);
+    request.resolve(Object.freeze({
+      playback,
+      preparationMilliseconds: response.preparationMilliseconds,
+      durationMilliseconds: response.durationMilliseconds,
+      responseChunkCount: response.responseChunkCount,
+      responseIdleSliceCount: response.responseIdleSliceCount,
+      maximumResponseChunkBytes: response.maximumResponseChunkBytes,
+      maximumResponseIdleSliceMilliseconds: response.maximumResponseIdleSliceMilliseconds,
+    }));
+  }
+
+  worker.addEventListener("message", ({ data }) => {
+    if (data?.type === "error") {
+      const error = new Error(data.message);
+      if (data.stack) error.stack = data.stack;
+      if (data.requestId === null) rejectAll(error);
+      else {
+        const request = pending.get(data.requestId);
+        pending.delete(data.requestId);
+        request?.reject(error);
+      }
+      return;
+    }
+    const request = pending.get(data?.requestId);
+    if (!request) return;
+    if (data.type === "materialized-start") {
+      if (request.response !== null || data.playback?.transforms !== null ||
+          data.playback?.shadowTransformValues !== null ||
+          !Number.isSafeInteger(data.clothTransformCount) || data.clothTransformCount < 1 ||
+          !Number.isSafeInteger(data.shadowTransformValueCount) || data.shadowTransformValueCount < 1 ||
+          !Number.isSafeInteger(data.clothChunkCount) || data.clothChunkCount < 1 ||
+          !Number.isSafeInteger(data.shadowChunkCount) || data.shadowChunkCount < 1 ||
+          !Number.isFinite(data.preparationMilliseconds) || data.preparationMilliseconds < 0) {
+        rejectAll(new Error("Prepared Cloth worker response drifted"));
+        return;
+      }
+      request.response = {
+        playback: data.playback,
+        clothTransformCount: data.clothTransformCount,
+        shadowTransformValueCount: data.shadowTransformValueCount,
+        clothChunkCount: data.clothChunkCount,
+        shadowChunkCount: data.shadowChunkCount,
+        preparationMilliseconds: data.preparationMilliseconds,
+        durationMilliseconds: 0,
+        processedClothChunkCount: 0,
+        processedShadowChunkCount: 0,
+        responseChunkCount: 0,
+        responseIdleSliceCount: 0,
+        receivedTransformBytes: 0,
+        maximumResponseChunkBytes: 0,
+        maximumResponseIdleSliceMilliseconds: 0,
+        workerComplete: false,
+        transforms: [],
+        shadowTransformValues: [],
+      };
+      return;
+    }
+    if (data.type === "materialized-complete") {
+      if (!request.response || !Number.isFinite(data.durationMilliseconds) ||
+          data.durationMilliseconds < request.response.preparationMilliseconds) {
+        rejectAll(new Error("Prepared Cloth worker completion drifted"));
+        return;
+      }
+      request.response.durationMilliseconds = data.durationMilliseconds;
+      request.response.workerComplete = true;
+      maybeComplete(data.requestId, request);
+      return;
+    }
+    if (data.type !== "materialized-chunk" || !request.response ||
+        !new Set(["cloth", "shadow"]).has(data.kind) ||
+        !Number.isSafeInteger(data.chunkIndex) || data.chunkIndex < 0 ||
+        !Number.isSafeInteger(data.chunkCount) || data.chunkCount < 1 ||
+        !Number.isSafeInteger(data.start) || data.start < 0 ||
+        !Array.isArray(data.transforms) || data.transforms.length < 1 ||
+        data.transforms.length > RESPONSE_CHUNK_TRANSFORM_COUNT ||
+        data.transforms.some((transform) =>
+          typeof transform !== "string" || !transform.startsWith("matrix3d(")) ||
+        !Number.isSafeInteger(data.transformByteLength) || data.transformByteLength < 1) {
+      rejectAll(new Error("Prepared Cloth worker response drifted"));
+      return;
+    }
+    const expectedChunkCount = data.kind === "cloth"
+      ? request.response.clothChunkCount
+      : request.response.shadowChunkCount;
+    if (data.chunkCount !== expectedChunkCount) {
+      rejectAll(new Error("Prepared Cloth worker chunk count drifted"));
+      return;
+    }
+    responseQueue.push({ data, request });
+    scheduleResponseSlice();
+  });
+  worker.addEventListener("error", (event) => {
+    rejectAll(new Error(event.message || "Prepared Cloth worker failed"));
+  });
+
+  return Object.freeze({
+    materialize(descriptor) {
+      if (destroyed) throw new Error("Prepared Cloth worker is destroyed");
+      const requestId = nextRequestId;
+      nextRequestId += 1;
+      const result = new Promise((resolve, reject) => {
+        pending.set(requestId, { resolve, reject, response: null });
+      });
+      worker.postMessage({ type: "materialize", requestId, descriptor });
+      return result;
+    },
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      rejectAll(new Error("Prepared Cloth worker is destroyed"));
+      worker.terminate();
+    },
+  });
+}

--- a/src/adapters/cloth/src/csscloth/preparedPlaybackWorker.mjs
+++ b/src/adapters/cloth/src/csscloth/preparedPlaybackWorker.mjs
@@ -1,0 +1,109 @@
+import {
+  createClothPreparedPlaybackMaterialization,
+  loadClothPreparedPlaybackBytes,
+  materializeClothPreparedMatrixRange,
+} from "../shared/csscloth/preparedPlaybackTransport.mjs";
+
+const RESPONSE_CHUNK_TRANSFORM_COUNT = 480;
+
+let materializationTail = Promise.resolve();
+
+self.addEventListener("message", ({ data }) => {
+  if (data?.type !== "materialize" || !Number.isSafeInteger(data.requestId)) {
+    postWorkerError(new Error("Prepared Cloth worker request drifted"), null);
+    return;
+  }
+  materializationTail = materializationTail.then(
+    () => materializePlayback(data),
+    () => materializePlayback(data),
+  ).catch((error) => postWorkerError(error, data.requestId));
+});
+
+async function materializePlayback({ requestId, descriptor }) {
+  const startedAt = performance.now();
+  const bytes = await loadClothPreparedPlaybackBytes(descriptor);
+  const materialization = createClothPreparedPlaybackMaterialization(bytes, descriptor);
+  const playback = materialization.playback;
+  const clothChunkCount = Math.ceil(
+    materialization.clothTransformCount / RESPONSE_CHUNK_TRANSFORM_COUNT,
+  );
+  const shadowChunkCount = Math.ceil(
+    materialization.shadowTransformValueCount / RESPONSE_CHUNK_TRANSFORM_COUNT,
+  );
+  self.postMessage({
+    type: "materialized-start",
+    requestId,
+    playback,
+    clothTransformCount: materialization.clothTransformCount,
+    shadowTransformValueCount: materialization.shadowTransformValueCount,
+    clothChunkCount,
+    shadowChunkCount,
+    preparationMilliseconds: performance.now() - startedAt,
+  }, playbackTransferables(playback));
+  await streamMatrixKind(
+    requestId,
+    materialization,
+    "cloth",
+    materialization.clothTransformCount,
+    clothChunkCount,
+  );
+  await streamMatrixKind(
+    requestId,
+    materialization,
+    "shadow",
+    materialization.shadowTransformValueCount,
+    shadowChunkCount,
+  );
+  self.postMessage({
+    type: "materialized-complete",
+    requestId,
+    durationMilliseconds: performance.now() - startedAt,
+  });
+}
+
+async function streamMatrixKind(requestId, materialization, kind, count, chunkCount) {
+  for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
+    const start = chunkIndex * RESPONSE_CHUNK_TRANSFORM_COUNT;
+    const end = Math.min(count, start + RESPONSE_CHUNK_TRANSFORM_COUNT);
+    const transforms = materializeClothPreparedMatrixRange(materialization, kind, start, end);
+    const transformByteLength = transforms.reduce(
+      (total, transform) => total + transform.length * Uint16Array.BYTES_PER_ELEMENT,
+      0,
+    );
+    self.postMessage({
+      type: "materialized-chunk",
+      requestId,
+      kind,
+      chunkIndex,
+      chunkCount,
+      start,
+      transforms,
+      transformByteLength,
+    });
+    if (kind !== "shadow" || chunkIndex + 1 < chunkCount) {
+      await new Promise((resolve) => setTimeout(resolve, materialization.playback.frameMilliseconds));
+    }
+  }
+}
+
+function playbackTransferables(playback) {
+  return [
+    playback.lightingRows.buffer,
+    playback.shadowTransformOffsets.buffer,
+    playback.shadowTransformIndices.buffer,
+    playback.shadowVisibilityOffsets.buffer,
+    playback.shadowVisibilityIndices.buffer,
+    playback.shadowVisibilityValues.buffer,
+    playback.atlasStateOffsets.buffer,
+    playback.atlasSlots.buffer,
+  ];
+}
+
+function postWorkerError(error, requestId) {
+  self.postMessage({
+    type: "error",
+    requestId,
+    message: String(error?.message || error),
+    stack: String(error?.stack || ""),
+  });
+}

--- a/src/adapters/cloth/src/shared/csscloth/preparedPlaybackTransport.mjs
+++ b/src/adapters/cloth/src/shared/csscloth/preparedPlaybackTransport.mjs
@@ -87,6 +87,26 @@ export function encodeClothPreparedPlayback(playback) {
 }
 
 export function decodeClothPreparedPlayback(bytes, descriptor) {
+  const materialization = createClothPreparedPlaybackMaterialization(bytes, descriptor);
+  return completeClothPreparedPlaybackMaterialization(
+    materialization.playback,
+    materializeClothPreparedMatrixRange(
+      materialization,
+      "cloth",
+      0,
+      materialization.clothTransformCount,
+    ),
+    materializeClothPreparedMatrixRange(
+      materialization,
+      "shadow",
+      0,
+      materialization.shadowTransformValueCount,
+    ),
+    true,
+  );
+}
+
+export function createClothPreparedPlaybackMaterialization(bytes, descriptor) {
   if (!(bytes instanceof Uint8Array) || bytes.byteLength < HEADER_BYTES ||
       descriptor?.schema !== CSSCLOTH_PLAYBACK_SCHEMA ||
       descriptor?.encoding !== CSSCLOTH_PLAYBACK_ENCODING ||
@@ -134,29 +154,6 @@ export function decodeClothPreparedPlayback(bytes, descriptor) {
     }
   }
   if (stream.offset !== stream.end) throw new Error("Prepared Cloth matrix stream has trailing bytes");
-  const allTransforms = new Array(frameCount * transformCount);
-  const matrix = new Array(16).fill(0);
-  matrix[15] = 1;
-  for (let transformIndex = 0; transformIndex < allTransforms.length; transformIndex += 1) {
-    const valueOffset = transformIndex * MATRIX_COMPONENTS.length;
-    for (let componentIndex = 0; componentIndex < MATRIX_COMPONENTS.length; componentIndex += 1) {
-      matrix[MATRIX_COMPONENTS[componentIndex]] = quantized[valueOffset + componentIndex] / MATRIX_SCALE;
-    }
-    allTransforms[transformIndex] = `matrix3d(${formatMatrix3dValues(matrix, MATRIX_DECIMALS)})`;
-  }
-  const transforms = new Array(frameCount * triangleCount);
-  const shadowTransforms = new Array(frameCount * shadowTriangleCount);
-  for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
-    const combinedOffset = frameIndex * transformCount;
-    const clothOffset = frameIndex * triangleCount;
-    const shadowOffset = frameIndex * shadowTriangleCount;
-    for (let index = 0; index < triangleCount; index += 1) {
-      transforms[clothOffset + index] = allTransforms[combinedOffset + index];
-    }
-    for (let index = 0; index < shadowTriangleCount; index += 1) {
-      shadowTransforms[shadowOffset + index] = allTransforms[combinedOffset + triangleCount + index];
-    }
-  }
   const lightingStart = stream.end;
   const shadowVisibilityStart = lightingStart + lightingByteLength;
   const atlasMappingStart = shadowVisibilityStart + shadowVisibilityByteLength;
@@ -178,9 +175,10 @@ export function decodeClothPreparedPlayback(bytes, descriptor) {
     atlasOffset += 2;
   }
   const shadowSchedule = buildSparseShadowSchedule(
-    shadowTransforms,
+    quantized,
     bytes.subarray(shadowVisibilityStart, atlasMappingStart),
     frameCount,
+    triangleCount,
     shadowTriangleCount,
   );
   const lightingRows = new Uint16Array(frameCount * triangleCount);
@@ -189,48 +187,137 @@ export function decodeClothPreparedPlayback(bytes, descriptor) {
   }
   if (atlasOffset !== bytes.byteLength) throw new Error("Prepared Cloth atlas mapping has trailing bytes");
   return Object.freeze({
-    schema: CSSCLOTH_PLAYBACK_SCHEMA,
-    frameCount,
-    triangleCount,
-    shadowTriangleCount,
-    frameMilliseconds,
-    durationMilliseconds: frameCount * frameMilliseconds,
-    transforms: Object.freeze(transforms),
-    lightingRows,
-    shadowTransformOffsets: shadowSchedule.transformOffsets,
-    shadowTransformIndices: shadowSchedule.transformIndices,
-    shadowTransformValues: Object.freeze(shadowSchedule.transformValues),
-    shadowVisibilityOffsets: shadowSchedule.visibilityOffsets,
-    shadowVisibilityIndices: shadowSchedule.visibilityIndices,
-    shadowVisibilityValues: shadowSchedule.visibilityValues,
-    atlasStateOffsets,
-    atlasSlots,
-    decodedByteLength: bytes.byteLength,
+    playback: Object.freeze({
+      schema: CSSCLOTH_PLAYBACK_SCHEMA,
+      frameCount,
+      triangleCount,
+      shadowTriangleCount,
+      frameMilliseconds,
+      durationMilliseconds: frameCount * frameMilliseconds,
+      transforms: null,
+      lightingRows,
+      shadowTransformOffsets: shadowSchedule.transformOffsets,
+      shadowTransformIndices: shadowSchedule.transformIndices,
+      shadowTransformValues: null,
+      shadowVisibilityOffsets: shadowSchedule.visibilityOffsets,
+      shadowVisibilityIndices: shadowSchedule.visibilityIndices,
+      shadowVisibilityValues: shadowSchedule.visibilityValues,
+      atlasStateOffsets,
+      atlasSlots,
+      decodedByteLength: bytes.byteLength,
+    }),
+    quantized,
+    transformCount,
+    clothTransformCount: frameCount * triangleCount,
+    shadowTransformSourceIndices: shadowSchedule.transformSourceIndices,
+    shadowTransformValueCount: shadowSchedule.transformSourceIndices.length,
   });
 }
 
-function buildSparseShadowSchedule(transforms, visibility, frameCount, triangleCount) {
+export function materializeClothPreparedMatrixRange(materialization, kind, start, end) {
+  const sourceIndices = kind === "cloth"
+    ? null
+    : kind === "shadow"
+    ? materialization?.shadowTransformSourceIndices
+    : undefined;
+  const count = kind === "cloth"
+    ? materialization?.clothTransformCount
+    : sourceIndices?.length;
+  if (!(materialization?.quantized instanceof Float64Array) ||
+      !Number.isSafeInteger(materialization.transformCount) || materialization.transformCount < 1 ||
+      !Number.isSafeInteger(count) || !Number.isSafeInteger(start) || !Number.isSafeInteger(end) ||
+      start < 0 || end < start || end > count || sourceIndices === undefined) {
+    throw new TypeError("Prepared Cloth matrix materialization range is invalid");
+  }
+  const playback = materialization.playback;
+  const output = new Array(end - start);
+  const matrix = new Array(16).fill(0);
+  matrix[15] = 1;
+  for (let outputIndex = 0; outputIndex < output.length; outputIndex += 1) {
+    const matrixIndex = kind === "cloth"
+      ? clothCombinedTransformIndex(
+        start + outputIndex,
+        playback.triangleCount,
+        materialization.transformCount,
+      )
+      : sourceIndices[start + outputIndex];
+    const valueOffset = matrixIndex * MATRIX_COMPONENTS.length;
+    for (let componentIndex = 0; componentIndex < MATRIX_COMPONENTS.length; componentIndex += 1) {
+      matrix[MATRIX_COMPONENTS[componentIndex]] =
+        materialization.quantized[valueOffset + componentIndex] / MATRIX_SCALE;
+    }
+    output[outputIndex] = `matrix3d(${formatMatrix3dValues(matrix, MATRIX_DECIMALS)})`;
+  }
+  return output;
+}
+
+export function completeClothPreparedPlaybackMaterialization(
+  playback,
+  transforms,
+  shadowTransformValues,
+  freezeTransformArrays = false,
+) {
+  if (playback?.schema !== CSSCLOTH_PLAYBACK_SCHEMA ||
+      playback.transforms !== null || playback.shadowTransformValues !== null ||
+      !Array.isArray(transforms) ||
+      transforms.length !== playback.frameCount * playback.triangleCount ||
+      !Array.isArray(shadowTransformValues) ||
+      shadowTransformValues.length !== playback.shadowTransformIndices.length ||
+      !transforms[0]?.startsWith("matrix3d(") ||
+      !transforms.at(-1)?.startsWith("matrix3d(") ||
+      !shadowTransformValues[0]?.startsWith("matrix3d(") ||
+      !shadowTransformValues.at(-1)?.startsWith("matrix3d(")) {
+    throw new Error("Prepared Cloth matrix materialization drifted");
+  }
+  return Object.freeze({
+    ...playback,
+    transforms: freezeTransformArrays ? Object.freeze(transforms) : transforms,
+    shadowTransformValues: freezeTransformArrays
+      ? Object.freeze(shadowTransformValues)
+      : shadowTransformValues,
+  });
+}
+
+function clothCombinedTransformIndex(clothTransformIndex, triangleCount, transformCount) {
+  const frameIndex = Math.floor(clothTransformIndex / triangleCount);
+  return frameIndex * transformCount + clothTransformIndex % triangleCount;
+}
+
+function buildSparseShadowSchedule(
+  quantized,
+  visibility,
+  frameCount,
+  triangleCount,
+  shadowTriangleCount,
+) {
   const transformOffsets = new Uint32Array(frameCount + 1);
   const transformIndices = [];
-  const transformValues = [];
+  const transformSourceIndices = [];
   const visibilityOffsets = new Uint32Array(frameCount + 1);
   const visibilityIndices = [];
   const visibilityValues = [];
+  const transformCount = triangleCount + shadowTriangleCount;
   for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
     transformOffsets[frameIndex] = transformIndices.length;
     visibilityOffsets[frameIndex] = visibilityIndices.length;
-    const offset = frameIndex * triangleCount;
-    const previousOffset = (frameIndex - 1) * triangleCount;
-    for (let triangleIndex = 0; triangleIndex < triangleCount; triangleIndex += 1) {
-      if (frameIndex === 0 || transforms[offset + triangleIndex] !==
-          transforms[previousOffset + triangleIndex]) {
+    const visibilityOffset = frameIndex * shadowTriangleCount;
+    const previousVisibilityOffset = (frameIndex - 1) * shadowTriangleCount;
+    const transformOffset = frameIndex * transformCount + triangleCount;
+    const previousTransformOffset = (frameIndex - 1) * transformCount + triangleCount;
+    for (let triangleIndex = 0; triangleIndex < shadowTriangleCount; triangleIndex += 1) {
+      const sourceTransformIndex = transformOffset + triangleIndex;
+      if (frameIndex === 0 || !sameQuantizedMatrix(
+        quantized,
+        sourceTransformIndex,
+        previousTransformOffset + triangleIndex,
+      )) {
         transformIndices.push(triangleIndex);
-        transformValues.push(transforms[offset + triangleIndex]);
+        transformSourceIndices.push(sourceTransformIndex);
       }
-      if (frameIndex === 0 || visibility[offset + triangleIndex] !==
-          visibility[previousOffset + triangleIndex]) {
+      if (frameIndex === 0 || visibility[visibilityOffset + triangleIndex] !==
+          visibility[previousVisibilityOffset + triangleIndex]) {
         visibilityIndices.push(triangleIndex);
-        visibilityValues.push(visibility[offset + triangleIndex]);
+        visibilityValues.push(visibility[visibilityOffset + triangleIndex]);
       }
     }
   }
@@ -239,14 +326,28 @@ function buildSparseShadowSchedule(transforms, visibility, frameCount, triangleC
   return {
     transformOffsets,
     transformIndices: Uint16Array.from(transformIndices),
-    transformValues,
+    transformSourceIndices: Uint32Array.from(transformSourceIndices),
     visibilityOffsets,
     visibilityIndices: Uint16Array.from(visibilityIndices),
     visibilityValues: Uint8Array.from(visibilityValues),
   };
 }
 
+function sameQuantizedMatrix(quantized, leftMatrixIndex, rightMatrixIndex) {
+  const leftOffset = leftMatrixIndex * MATRIX_COMPONENTS.length;
+  const rightOffset = rightMatrixIndex * MATRIX_COMPONENTS.length;
+  for (let componentIndex = 0; componentIndex < MATRIX_COMPONENTS.length; componentIndex += 1) {
+    if (quantized[leftOffset + componentIndex] !== quantized[rightOffset + componentIndex]) return false;
+  }
+  return true;
+}
+
 export async function loadClothPreparedPlayback(descriptor) {
+  const bytes = await loadClothPreparedPlaybackBytes(descriptor);
+  return decodeClothPreparedPlayback(bytes, descriptor);
+}
+
+export async function loadClothPreparedPlaybackBytes(descriptor) {
   if (descriptor?.schema !== CSSCLOTH_PLAYBACK_SCHEMA ||
       descriptor?.encoding !== CSSCLOTH_PLAYBACK_ENCODING ||
       typeof descriptor.path !== "string" || !descriptor.path.startsWith("/csscloth/") ||
@@ -273,7 +374,7 @@ export async function loadClothPreparedPlayback(descriptor) {
       actualUncompressedSha256 !== descriptor.uncompressedSha256) {
     throw new Error("Prepared Cloth playback decoded identity drifted");
   }
-  return decodeClothPreparedPlayback(bytes, descriptor);
+  return bytes;
 }
 
 function validatePlayback(playback) {

--- a/src/adapters/cloth/test/csscloth-model.test.mjs
+++ b/src/adapters/cloth/test/csscloth-model.test.mjs
@@ -5,8 +5,10 @@ import { groundImageSlice, shadowImageSlice } from "../src/prepare/csscloth/rast
 import {
   CSSCLOTH_PLAYBACK_ENCODING,
   CSSCLOTH_PLAYBACK_SCHEMA,
+  createClothPreparedPlaybackMaterialization,
   decodeClothPreparedPlayback,
   encodeClothPreparedPlayback,
+  materializeClothPreparedMatrixRange,
 } from "../src/shared/csscloth/preparedPlaybackTransport.mjs";
 
 const prepared = buildClothPreparedModel();
@@ -73,6 +75,14 @@ test("prepared playback uses compact fixed-point transport", () => {
     shadowTriangleCount: playback.shadowTriangleCount,
     frameMilliseconds: playback.frameMilliseconds,
   });
+  const materialization = createClothPreparedPlaybackMaterialization(bytes, {
+    schema: CSSCLOTH_PLAYBACK_SCHEMA,
+    encoding: CSSCLOTH_PLAYBACK_ENCODING,
+    frameCount: playback.frameCount,
+    triangleCount: playback.triangleCount,
+    shadowTriangleCount: playback.shadowTriangleCount,
+    frameMilliseconds: playback.frameMilliseconds,
+  });
   assert.equal(decoded.transforms.length, 1440 * 200);
   assert.equal(decoded.lightingRows.length, 1440 * 200);
   assert.equal(decoded.atlasStateOffsets.length, 201);
@@ -83,6 +93,28 @@ test("prepared playback uses compact fixed-point transport", () => {
   assert.equal(decoded.shadowVisibilityOffsets[1], prepared.metrics.clothShadowLeafCount);
   assert.ok(decoded.shadowTransformValues.length < 1440 * prepared.metrics.clothShadowLeafCount);
   assert.ok(decoded.shadowVisibilityValues.length < 1440 * prepared.metrics.clothShadowLeafCount);
+  assert.deepEqual(
+    [...materialization.playback.shadowTransformOffsets],
+    [...decoded.shadowTransformOffsets],
+  );
+  assert.deepEqual(
+    [...materialization.playback.shadowTransformIndices],
+    [...decoded.shadowTransformIndices],
+  );
+  const sampledTransformIndex = 137 * 200 + 47;
+  assert.deepEqual(
+    materializeClothPreparedMatrixRange(
+      materialization,
+      "cloth",
+      sampledTransformIndex,
+      sampledTransformIndex + 1,
+    ),
+    [decoded.transforms[sampledTransformIndex]],
+  );
+  assert.deepEqual(
+    materializeClothPreparedMatrixRange(materialization, "shadow", 0, 480),
+    decoded.shadowTransformValues.slice(0, 480),
+  );
   const actual = decoded.transforms[137 * 200 + 47].match(/matrix3d\(([^)]+)\)/u)[1].split(",").map(Number);
   const expected = playback.frames[137].matrices[47];
   assert.ok(actual.every((value, index) => Math.abs(value - expected[index]) <= 0.000051));

--- a/src/adapters/cloth/test/csscloth-shell.test.mjs
+++ b/src/adapters/cloth/test/csscloth-shell.test.mjs
@@ -14,6 +14,8 @@ test("cloth uses the cssGraphics shell without source controls", async () => {
 
 test("runtime has no per-frame geometry or raster construction", async () => {
   const client = await readFile(new URL("src/csscloth/client.mjs", root), "utf8");
+  const playbackStream = await readFile(new URL("src/csscloth/preparedPlaybackStream.mjs", root), "utf8");
+  const playbackWorker = await readFile(new URL("src/csscloth/preparedPlaybackWorker.mjs", root), "utf8");
   const shadowTarget = await readFile(new URL("src/shared/csscloth/morphShadowPatch.mjs", root), "utf8");
   const textureTarget = await readFile(new URL("src/shared/csscloth/morphTexturePatch.mjs", root), "utf8");
   const styles = await readFile(new URL("src/csscloth/styles.css", root), "utf8");
@@ -36,7 +38,14 @@ test("runtime has no per-frame geometry or raster construction", async () => {
   assert.match(client, /createPolyMorphPreparedDomTarget/);
   assert.match(client, /mounted\.modelElement\.remove\(\)/u);
   assert.match(client, /cleanPreparedDom\(mounted, playback\.triangleCount\)/u);
-  assert.match(client, /loadClothPreparedPlayback/);
+  assert.match(client, /createClothPreparedPlaybackStream/);
+  assert.match(client, /loadPlayback: playbackStream\.loadFuture/u);
+  assert.match(playbackStream, /new Worker/u);
+  assert.match(playbackStream, /requestIdleCallback/u);
+  assert.match(playbackStream, /RESPONSE_CHUNK_TRANSFORM_COUNT = 480/u);
+  assert.match(playbackWorker, /materializeClothPreparedMatrixRange/u);
+  assert.match(playbackWorker, /setTimeout\(resolve, materialization\.playback\.frameMilliseconds\)/u);
+  assert.doesNotMatch(playbackWorker, /canvas|getContext|createElement|requestAnimationFrame/u);
   assert.match(client, /textureLeafSizing !== "raster"/);
   assert.doesNotMatch(client, /backgroundRepeat|backgroundSize/);
   assert.match(client, /runtimeGeometryConstructionCount: 0/);

--- a/src/adapters/cloth/tools/analyze-csscloth-cadence-trace.mjs
+++ b/src/adapters/cloth/tools/analyze-csscloth-cadence-trace.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+import { createReadStream } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { createGunzip } from "node:zlib";
+
+const tracePath = resolve(process.argv[2] ?? "");
+const browserSummaryPath = resolve(process.argv[3] ?? "");
+const outputPath = resolve(process.argv[4] ?? "csscloth-cadence-trace-analysis.json");
+if (!process.argv[2] || !process.argv[3]) {
+  throw new Error("Usage: analyze-csscloth-cadence-trace.mjs <Trace.json.gz> <browser-cadence.json> [output]");
+}
+
+const threadNames = new Map();
+const marks = new Map();
+const tasks = [];
+const work = [];
+const keptWork = new Set([
+  "FireAnimationFrame",
+  "FunctionCall",
+  "RunMicrotasks",
+  "UpdateLayoutTree",
+  "Layout",
+  "PrePaint",
+  "Paint",
+  "Commit",
+  "MajorGC",
+  "MinorGC",
+  "V8.GCFinalizeMC",
+  "V8.GCScavenger",
+]);
+
+await streamTraceEvents(tracePath, (event) => {
+  if (event?.ph === "M" && event.name === "thread_name") {
+    threadNames.set(`${event.pid}:${event.tid}`, event.args?.name ?? event.args?.data?.name ?? "");
+    return;
+  }
+  if (typeof event?.name === "string" && event.name.startsWith("csscloth-") &&
+      Number.isFinite(event.ts)) {
+    const timestamps = marks.get(event.name) ?? [];
+    timestamps.push(event.ts);
+    marks.set(event.name, timestamps);
+  }
+  if (event?.ph !== "X" || !Number.isFinite(event.ts) || !Number.isFinite(event.dur)) return;
+  const record = {
+    name: event.name,
+    pid: event.pid,
+    tid: event.tid,
+    startMicroseconds: event.ts,
+    durationMilliseconds: event.dur / 1_000,
+  };
+  if (event.dur >= 1_000) tasks.push(record);
+  if (keptWork.has(event.name) && event.dur >= 100) work.push(record);
+});
+
+const rendererMainKeys = [...threadNames.entries()]
+  .filter(([, name]) => name === "CrRendererMain")
+  .map(([key]) => key);
+const handoffTimestamps = uniqueSorted(marks.get("csscloth-bank-handoff") ?? []);
+const captureStarts = uniqueSorted(marks.get("csscloth-cadence-capture-start") ?? []);
+const captureEnds = uniqueSorted(marks.get("csscloth-cadence-capture-end") ?? []);
+const captureStart = captureStarts[0] ?? -Infinity;
+const captureEnd = captureEnds.at(-1) ?? Infinity;
+const mainEvents = tasks.filter((task) =>
+  rendererMainKeys.includes(`${task.pid}:${task.tid}`) &&
+  task.startMicroseconds >= captureStart - 250_000 &&
+  task.startMicroseconds <= captureEnd + 250_000);
+const mainTasks = mainEvents.filter((event) => /(?:^|::)RunTask$/u.test(event.name));
+const mainWork = work.filter((event) => rendererMainKeys.includes(`${event.pid}:${event.tid}`));
+const browserSummary = JSON.parse(await readFile(browserSummaryPath, "utf8"));
+const handoffs = handoffTimestamps.map((timestamp, index) => {
+  const nearTasks = mainTasks.filter((task) => overlapsWindow(task, timestamp, 250));
+  const nearWork = mainWork.filter((event) => overlapsWindow(event, timestamp, 33));
+  return {
+    index,
+    traceTimestampMicroseconds: timestamp,
+    browserCadence: browserSummary.handoffs[index]?.cadence ?? null,
+    maximumMainThreadTaskMilliseconds: maximumDuration(nearTasks),
+    mainThreadTasksAbove20Milliseconds: nearTasks.filter((task) =>
+      task.durationMilliseconds > 20),
+    mainThreadWork: nearWork
+      .sort((left, right) => right.durationMilliseconds - left.durationMilliseconds)
+      .slice(0, 12),
+  };
+});
+const analysis = {
+  schema: "csscloth-cadence-trace-analysis@1",
+  tracePath,
+  browserSummaryPath,
+  rendererMainThreads: rendererMainKeys.map((key) => ({ key, name: threadNames.get(key) })),
+  capture: { startMicroseconds: captureStart, endMicroseconds: captureEnd },
+  cadence: browserSummary.cadence,
+  handoffs,
+  maximumMainThreadTaskMilliseconds: maximumDuration(mainTasks),
+  mainThreadTasksAbove20Milliseconds: mainTasks
+    .filter((task) => task.durationMilliseconds > 20)
+    .sort((left, right) => right.durationMilliseconds - left.durationMilliseconds),
+  longestMainThreadEvents: mainEvents
+    .sort((left, right) => right.durationMilliseconds - left.durationMilliseconds)
+    .slice(0, 20),
+  retainedLeafCount: browserSummary.stats?.retainedLeafCount ?? null,
+  retainedDomStable: browserSummary.stats?.retainedDomStable ?? null,
+  bankHandoffCount: browserSummary.stats?.bankHandoffCount ?? null,
+  bankBoundaryWaitCount: browserSummary.stats?.bankBoundaryWaitCount ?? null,
+  errors: browserSummary.errors,
+};
+await writeFile(outputPath, `${JSON.stringify(analysis, null, 2)}\n`);
+console.log(JSON.stringify(analysis, null, 2));
+
+function maximumDuration(events) {
+  return Number(Math.max(0, ...events.map((event) => event.durationMilliseconds)).toFixed(3));
+}
+
+function overlapsWindow(event, timestamp, radiusMilliseconds) {
+  const radiusMicroseconds = radiusMilliseconds * 1_000;
+  const end = event.startMicroseconds + event.durationMilliseconds * 1_000;
+  return event.startMicroseconds <= timestamp + radiusMicroseconds &&
+    end >= timestamp - radiusMicroseconds;
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort((left, right) => left - right);
+}
+
+async function streamTraceEvents(path, onEvent) {
+  const input = createReadStream(path).pipe(createGunzip());
+  let prefix = "";
+  let inEvents = false;
+  let object = "";
+  let depth = 0;
+  let quoted = false;
+  let escaped = false;
+  for await (const chunk of input) {
+    const text = chunk.toString("utf8");
+    for (let index = 0; index < text.length; index += 1) {
+      const character = text[index];
+      if (!inEvents) {
+        prefix = `${prefix}${character}`.slice(-32);
+        if (prefix.endsWith('"traceEvents":[')) inEvents = true;
+        continue;
+      }
+      if (depth === 0) {
+        if (character === "{") {
+          object = character;
+          depth = 1;
+        } else if (character === "]") {
+          return;
+        }
+        continue;
+      }
+      object += character;
+      if (quoted) {
+        if (escaped) escaped = false;
+        else if (character === "\\") escaped = true;
+        else if (character === '"') quoted = false;
+        continue;
+      }
+      if (character === '"') quoted = true;
+      else if (character === "{") depth += 1;
+      else if (character === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          onEvent(JSON.parse(object));
+          object = "";
+        }
+      }
+    }
+  }
+  throw new Error("Chrome trace ended before traceEvents closed");
+}

--- a/src/adapters/cloth/tools/trace-csscloth-cadence.mjs
+++ b/src/adapters/cloth/tools/trace-csscloth-cadence.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+import { once } from "node:events";
+import { createWriteStream } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { chromium } from "playwright";
+
+const url = process.argv[2];
+const output = resolve(process.argv[3] ?? ".local/proofs/csscloth-cadence");
+const durationMilliseconds = Number(process.argv[4] ?? 52_000);
+if (!url || !Number.isFinite(durationMilliseconds) || durationMilliseconds < 40_000) {
+  throw new Error("Usage: trace-csscloth-cadence.mjs <url> [output-dir] [duration-ms >= 40000]");
+}
+
+const tracePath = resolve(output, "Trace.json.gz");
+const summaryPath = resolve(output, "browser-cadence.json");
+const screenshotPath = resolve(output, "final-frame.png");
+await mkdir(output, { recursive: true });
+
+const browser = await chromium.launch({
+  channel: "chrome",
+  headless: true,
+});
+try {
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(error.stack || error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  await page.goto(url, { waitUntil: "load", timeout: 30_000 });
+  await page.waitForFunction(() => globalThis.__cssClothDebug?.ready === true, null, {
+    timeout: 30_000,
+  });
+  await page.waitForTimeout(500);
+  const cdp = await page.context().newCDPSession(page);
+  await startTrace(cdp);
+  await page.evaluate(() => {
+    globalThis.__cssClothCadenceSamples = [];
+    globalThis.__cssClothLongTasks = [];
+    globalThis.__cssClothCadenceSampling = true;
+    globalThis.__cssClothLongTaskObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        globalThis.__cssClothLongTasks.push({
+          startTime: entry.startTime,
+          duration: entry.duration,
+        });
+      }
+    });
+    globalThis.__cssClothLongTaskObserver.observe({ type: "longtask", buffered: true });
+    let previous = performance.now();
+    const sample = (timestamp) => {
+      globalThis.__cssClothCadenceSamples.push({
+        timestamp,
+        interval: timestamp - previous,
+      });
+      previous = timestamp;
+      if (globalThis.__cssClothCadenceSampling) requestAnimationFrame(sample);
+    };
+    performance.mark("csscloth-cadence-capture-start");
+    requestAnimationFrame(sample);
+  });
+  await page.waitForTimeout(durationMilliseconds);
+  const browserEvidence = await page.evaluate(() => {
+    globalThis.__cssClothCadenceSampling = false;
+    globalThis.__cssClothLongTaskObserver.disconnect();
+    performance.mark("csscloth-cadence-capture-end");
+    const captureStart = performance.getEntriesByName("csscloth-cadence-capture-start").at(-1).startTime;
+    const captureEnd = performance.getEntriesByName("csscloth-cadence-capture-end").at(-1).startTime;
+    return {
+      captureStart,
+      captureEnd,
+      samples: globalThis.__cssClothCadenceSamples,
+      longTasks: globalThis.__cssClothLongTasks,
+      handoffs: performance.getEntriesByName("csscloth-bank-handoff").map((entry) => entry.startTime),
+      prefetchStarts: performance.getEntriesByName("csscloth-bank-prefetch-start")
+        .map((entry) => entry.startTime),
+      prefetchCompletes: performance.getEntriesByName("csscloth-bank-prefetch-complete")
+        .map((entry) => entry.startTime),
+      stats: globalThis.__cssClothDebug.stats(),
+      errors: [...globalThis.__cssClothDebug.errors],
+      documentLeafCount: document.querySelectorAll(
+        ".polycss-scene b, .polycss-scene i, .polycss-scene s, .polycss-scene u",
+      ).length,
+    };
+  });
+  await page.waitForTimeout(50);
+  await stopTrace(cdp, tracePath);
+  await page.screenshot({ path: screenshotPath });
+  const intervals = browserEvidence.samples.slice(1).map((sample) => sample.interval);
+  const summary = {
+    schema: "csscloth-cadence-trace@1",
+    url,
+    durationMilliseconds,
+    viewport: { width: 1440, height: 900 },
+    browser: { name: "Google Chrome", version: browser.version() },
+    errors: [...errors, ...browserEvidence.errors],
+    cadence: summarizeIntervals(intervals),
+    handoffs: browserEvidence.handoffs.map((timestamp) => ({
+      timestamp,
+      cadence: summarizeIntervals(browserEvidence.samples
+        .filter((sample) => Math.abs(sample.timestamp - timestamp) <= 250)
+        .map((sample) => sample.interval)),
+      longTasks: browserEvidence.longTasks.filter((task) =>
+        task.startTime <= timestamp + 250 && task.startTime + task.duration >= timestamp - 250),
+    })),
+    prefetchStarts: browserEvidence.prefetchStarts,
+    prefetchCompletes: browserEvidence.prefetchCompletes,
+    longTasks: browserEvidence.longTasks.filter((task) =>
+      task.startTime >= browserEvidence.captureStart && task.startTime <= browserEvidence.captureEnd),
+    stats: browserEvidence.stats,
+    documentLeafCount: browserEvidence.documentLeafCount,
+    outputs: { tracePath, summaryPath, screenshotPath },
+  };
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  console.log(JSON.stringify(summary, null, 2));
+} finally {
+  await browser.close();
+}
+
+function summarizeIntervals(values) {
+  const sorted = values.filter(Number.isFinite).sort((left, right) => left - right);
+  return {
+    count: sorted.length,
+    p50Milliseconds: quantile(sorted, 0.5),
+    p95Milliseconds: quantile(sorted, 0.95),
+    p99Milliseconds: quantile(sorted, 0.99),
+    maximumMilliseconds: sorted.at(-1) ?? null,
+    gapsAbove33Milliseconds: sorted.filter((value) => value > 33).length,
+  };
+}
+
+function quantile(sorted, percentile) {
+  if (sorted.length === 0) return null;
+  const index = (sorted.length - 1) * percentile;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return Number(sorted[lower].toFixed(3));
+  const value = sorted[lower] + (sorted[upper] - sorted[lower]) * (index - lower);
+  return Number(value.toFixed(3));
+}
+
+async function startTrace(cdp) {
+  await cdp.send("Tracing.start", {
+    categories: [
+      "blink.user_timing",
+      "cc",
+      "devtools.timeline",
+      "disabled-by-default-devtools.timeline.frame",
+      "toplevel",
+      "v8",
+      "v8.execute",
+    ].join(","),
+    options: "sampling-frequency=10000",
+    transferMode: "ReturnAsStream",
+    streamFormat: "json",
+    streamCompression: "gzip",
+  });
+}
+
+async function stopTrace(cdp, path) {
+  const completed = new Promise((resolveComplete) => {
+    cdp.once("Tracing.tracingComplete", resolveComplete);
+  });
+  await cdp.send("Tracing.end");
+  const { stream } = await completed;
+  if (!stream) throw new Error("Chrome trace did not return a stream");
+  const output = createWriteStream(path, { flags: "w" });
+  while (true) {
+    const result = await cdp.send("IO.read", { handle: stream });
+    const bytes = result.base64Encoded
+      ? Buffer.from(result.data, "base64")
+      : Buffer.from(result.data, "utf8");
+    if (!output.write(bytes)) await once(output, "drain");
+    if (result.eof) break;
+  }
+  output.end();
+  await once(output, "close");
+  await cdp.send("IO.close", { handle: stream });
+}


### PR DESCRIPTION
Fixes the 24-second desktop cadence freeze by moving future-bank decode and matrix materialization into a Worker. Matrix strings return in 480-transform chunks and are assembled in idle slices, so no enormous string payload lands in one main-thread task.

Preserves the prepared bank format, desktop visuals, 312 retained leaves, lighting, shadows, randomized starting bank, and 24-second handoffs.

Evidence:
- 52-second local production build trace covers two bank handoffs
- maximum handoff main-thread tasks: 2.763 ms and 1.737 ms
- maximum steady main-thread task: 7.130 ms (MinorGC)
- 0 RAF gaps above 33 ms; p95 8.9 ms on the 120 Hz trace host
- deterministic production/local frame comparison: 0 changed pixels out of 1,296,000
- `pnpm test:cloth`: 18/18
- `pnpm test:site`: 5/5
- `pnpm build:cloth:deploy`: pass