### PR TITLE
perf(cloth): publish sparse lighting updates

### DIFF
--- a/src/adapters/cloth/prepared-bank.lock.json
+++ b/src/adapters/cloth/prepared-bank.lock.json
@@ -3,8 +3,8 @@
   "tag": "csscloth-product-bank-v2",
   "asset": "csscloth-product-bank-v2.tar.gz",
   "url": "https://github.com/layoutit/cssGraphics/releases/download/csscloth-product-bank-v2/csscloth-product-bank-v2.tar.gz",
-  "archiveByteLength": 63988740,
-  "archiveSha256": "e5dd5932a0db3b0be04c8b2feb99825ad86ad152e58347b6bc41e8bb500ff4b3",
+  "archiveByteLength": 61884412,
+  "archiveSha256": "e8d32550e06fa6e1273f82fc40829983b1da2d45602db36f061c346eb906e70c",
   "bankCount": 8,
   "bankFrameCount": 1440,
   "durationMilliseconds": 192000,
@@ -12,6 +12,6 @@
   "mobileRetainedLeafCount": 158,
   "mobileClothTriangleCount": 72,
   "fileCount": 32,
-  "closureBytes": 64286783,
-  "closureSha256": "3107a4fe9d928d36809c69ccbc5eebced3ccc9c4d973bfbbe6cf54b80de3a2fa"
+  "closureBytes": 63325096,
+  "closureSha256": "a369c3024e0ec2cd475340e978d304a831ce5a4a57c10f050933209959acaff5"
 }

--- a/src/adapters/cloth/src/csscloth/client.mjs
+++ b/src/adapters/cloth/src/csscloth/client.mjs
@@ -57,6 +57,7 @@ export function mountClothClient(host) {
       loaded.resources,
       playback.triangleCount,
       metadata.renderer.logoAtlas,
+      metadata.renderer.lightingAtlas,
     );
     const player = createPlayer(mounted, loaded.model, playback, clothTexture, {
       bankDescriptors,
@@ -110,8 +111,7 @@ function createPlayer(mounted, model, initialPlayback, clothTexture, transport) 
   const shadowTarget = createPolyMorphPreparedShadowTarget(mounted, initialPlayback);
   const frameMilliseconds = initialPlayback.frameMilliseconds;
   const schedulerLeadMilliseconds = Math.min(8, frameMilliseconds / 2);
-  const currentLightingRows = new Uint32Array(initialPlayback.triangleCount);
-  currentLightingRows.fill(0xffff_ffff);
+  const absoluteLightingSlots = new Uint32Array(initialPlayback.triangleCount);
   let playback = initialPlayback;
   let currentBankIndex = transport.startingBankIndex;
   let prefetchedBankIndex = -1;
@@ -132,6 +132,8 @@ function createPlayer(mounted, model, initialPlayback, clothTexture, transport) 
   let applyCount = 0;
   let leafTransformWrites = 0;
   let atlasRowWrites = 0;
+  let lightingScheduleAssignments = 0;
+  let lightingAbsoluteSeekCount = 0;
   let bankHandoffCount = 0;
   let bankBoundaryWaitCount = 0;
   let preparedPlaybackLoadCount = 1;
@@ -146,18 +148,44 @@ function createPlayer(mounted, model, initialPlayback, clothTexture, transport) 
       leafTransformWrites += Number(target.leaves[triangleIndex].writeTransform(
         playback.transforms[frameOffset + triangleIndex],
       ));
-      const lightingRow = playback.lightingRows[frameOffset + triangleIndex];
-      if (currentLightingRows[triangleIndex] === lightingRow) continue;
-      const atlasSlot = playback.atlasSlots[
-        playback.atlasStateOffsets[triangleIndex] + lightingRow
-      ];
-      atlasRowWrites += Number(clothTexture.writeSlot(triangleIndex, atlasSlot));
-      currentLightingRows[triangleIndex] = lightingRow;
+    }
+    if (lastFrameIndex < 0 ? frameIndex === 0 : frameIndex === lastFrameIndex + 1) {
+      publishSequentialLighting(frameIndex);
+    } else {
+      publishAbsoluteLighting(frameIndex);
     }
     shadowTarget.publish(frameIndex);
     lastFrameIndex = frameIndex;
     applyCount += 1;
     return frameIndex;
+  }
+
+  function publishSequentialLighting(frameIndex) {
+    const start = playback.lightingOffsets[frameIndex];
+    const end = playback.lightingOffsets[frameIndex + 1];
+    for (let assignment = start; assignment < end; assignment += 1) {
+      const triangleIndex = playback.lightingIndices[assignment];
+      const slot = playback.lightingSlots[assignment];
+      atlasRowWrites += Number(clothTexture.writeSlot(triangleIndex, slot));
+    }
+    lightingScheduleAssignments += end - start;
+  }
+
+  function publishAbsoluteLighting(frameIndex) {
+    absoluteLightingSlots.fill(0xffff_ffff);
+    for (let sourceFrame = 0; sourceFrame <= frameIndex; sourceFrame += 1) {
+      const start = playback.lightingOffsets[sourceFrame];
+      const end = playback.lightingOffsets[sourceFrame + 1];
+      for (let assignment = start; assignment < end; assignment += 1) {
+        absoluteLightingSlots[playback.lightingIndices[assignment]] =
+          playback.lightingSlots[assignment];
+      }
+    }
+    for (let triangleIndex = 0; triangleIndex < playback.triangleCount; triangleIndex += 1) {
+      const slot = absoluteLightingSlots[triangleIndex];
+      atlasRowWrites += Number(clothTexture.writeSlot(triangleIndex, slot));
+    }
+    lightingAbsoluteSeekCount += 1;
   }
 
   function prefetchNextBank() {
@@ -201,7 +229,6 @@ function createPlayer(mounted, model, initialPlayback, clothTexture, transport) 
     prefetchedBankIndex = -1;
     prefetchingBankIndex = -1;
     prefetchPromise = null;
-    currentLightingRows.fill(0xffff_ffff);
     shadowTarget.setPlayback(playback);
     lastFrameIndex = -1;
     publish(0);
@@ -308,6 +335,9 @@ function createPlayer(mounted, model, initialPlayback, clothTexture, transport) 
       schedulerLateResetCount,
       leafTransformWrites,
       atlasRowWrites,
+      lightingScheduleAssignments,
+      lightingAbsoluteSeekCount,
+      runtimeLightingComparisonCount: 0,
       shadowTransformAssignments: shadow.transformAssignments,
       shadowVisibilityAssignments: shadow.visibilityAssignments,
       shadowTransformWrites: shadow.transformWrites,
@@ -380,7 +410,15 @@ function validatePlaybackBank(playback, descriptor, currentPlayback = playback) 
       playback.shadowTriangleCount !== descriptor.shadowTriangleCount ||
       playback.triangleCount !== currentPlayback.triangleCount ||
       playback.shadowTriangleCount !== currentPlayback.shadowTriangleCount ||
-      playback.frameMilliseconds !== currentPlayback.frameMilliseconds) {
+      playback.frameMilliseconds !== currentPlayback.frameMilliseconds ||
+      !(playback.lightingOffsets instanceof Uint32Array) ||
+      playback.lightingOffsets.length !== playback.frameCount + 1 ||
+      playback.lightingOffsets[0] !== 0 ||
+      playback.lightingOffsets[1] !== playback.triangleCount ||
+      !(playback.lightingIndices instanceof Uint16Array) ||
+      !(playback.lightingSlots instanceof Uint16Array) ||
+      playback.lightingIndices.length !== playback.lightingSlots.length ||
+      playback.lightingOffsets[playback.frameCount] !== playback.lightingIndices.length) {
     throw new Error("Cloth prepared playback bank binding drifted");
   }
 }

--- a/src/adapters/cloth/src/csscloth/preparedPlaybackWorker.mjs
+++ b/src/adapters/cloth/src/csscloth/preparedPlaybackWorker.mjs
@@ -88,14 +88,14 @@ async function streamMatrixKind(requestId, materialization, kind, count, chunkCo
 
 function playbackTransferables(playback) {
   return [
-    playback.lightingRows.buffer,
+    playback.lightingOffsets.buffer,
+    playback.lightingIndices.buffer,
+    playback.lightingSlots.buffer,
     playback.shadowTransformOffsets.buffer,
     playback.shadowTransformIndices.buffer,
     playback.shadowVisibilityOffsets.buffer,
     playback.shadowVisibilityIndices.buffer,
     playback.shadowVisibilityValues.buffer,
-    playback.atlasStateOffsets.buffer,
-    playback.atlasSlots.buffer,
   ];
 }
 

--- a/src/adapters/cloth/src/prepare/csscloth/modelBuilder.mjs
+++ b/src/adapters/cloth/src/prepare/csscloth/modelBuilder.mjs
@@ -233,6 +233,7 @@ export function buildClothPreparedModel({ profile = "desktop" } = {}) {
       clothRasterPageCount: rasterLayout.pages.length,
       clothRasterPagePixels: rasterLayout.pages.reduce((sum, page) => sum + page.width * page.height, 0),
       clothLightingStateCount: lighting.states.reduce((sum, states) => sum + states.length, 0),
+      clothLightingDistinctStateKeyCount: rasterLayout.slots.length,
       clothAtlasStoredStateCount: lighting.states.reduce((sum, states) => sum + states.length, 0),
       clothAtlasUniqueStateCount: rasterLayout.slots.length,
       clothAtlasDeduplicatedStateCount:

--- a/src/adapters/cloth/src/prepare/csscloth/rasterAtlas.mjs
+++ b/src/adapters/cloth/src/prepare/csscloth/rasterAtlas.mjs
@@ -22,6 +22,7 @@ export const CSSCLOTH_SHADOW_IMAGE_PATH = "assets/shadow.png";
 const RASTER_PAGE_WIDTH = 3072;
 const RASTER_PAGE_HEIGHT = 8192;
 const CLOTH_GUTTER = 1;
+const LOGO_RASTER_SCALE = 2;
 const GROUND_MAX_ANISOTROPY = 16;
 const GROUND_FIT_HORIZONTAL_BANDS = Object.freeze([-0.8, -0.8, 0.8, 0.8, 0.4, 0.2, 0.2, 0.4]);
 const GROUND_FIT_VERTICAL_BANDS = Object.freeze([1.3, 1.5, 1.5, 1.7, 1.9, 2, 2, 2]);
@@ -761,6 +762,7 @@ function buildSeparatedClothPages(
   }
   const uniqueTiles = [];
   const slotByState = new Map();
+  const slotByHash = new Map();
   const stateSlots = [];
   for (let triangleIndex = 0; triangleIndex < triangles.length; triangleIndex += 1) {
     const box = rasterBoxes[triangleIndex];
@@ -771,8 +773,6 @@ function buildSeparatedClothPages(
       const key = `${basisKey}:${state.join(",")}`;
       let slot = slotByState.get(key);
       if (slot === undefined) {
-        slot = uniqueTiles.length;
-        slotByState.set(key, slot);
         const tile = createRgba(box.width, box.height);
         paintClothTriangle(
           tile,
@@ -785,7 +785,14 @@ function buildSeparatedClothPages(
           box.width,
           box.height,
         );
-        uniqueTiles.push(tile);
+        const hash = hashOpaqueRgb(tile);
+        slot = slotByHash.get(hash);
+        if (slot === undefined) {
+          slot = uniqueTiles.length;
+          slotByHash.set(hash, slot);
+          uniqueTiles.push(tile);
+        }
+        slotByState.set(key, slot);
       }
       slots.push(slot);
     }
@@ -803,21 +810,20 @@ function buildSeparatedClothPages(
     copyTile(uniqueTiles[slot], pages[slice.pageIndex], slice.x, slice.y);
     copyAllGutters(pages[slice.pageIndex], slice.x, slice.y, slice.width, slice.height);
   }
-  const logoStateSlots = triangles.map((_, triangleIndex) => Object.freeze([triangleIndex]));
-  const logoLayout = buildClothSlotLayout(
-    rasterBoxes,
-    logoStateSlots,
-    triangles.length,
-    { preferSquare: true },
-  );
-  const logoPages = logoLayout.pages.map((page) => createRgba(page.width, page.height));
+  const logoRasterBoxes = rasterBoxes.map((box) => Object.freeze({
+    width: box.width * LOGO_RASTER_SCALE,
+    height: box.height * LOGO_RASTER_SCALE,
+  }));
+  const uniqueLogoTiles = [];
+  const logoSlotByHash = new Map();
+  const logoStateSlots = [];
   for (let triangleIndex = 0; triangleIndex < triangles.length; triangleIndex += 1) {
-    const box = rasterBoxes[triangleIndex];
-    const slice = logoLayout.slots[triangleIndex];
+    const box = logoRasterBoxes[triangleIndex];
+    const tile = createRgba(box.width, box.height);
     paintClothLogoTriangle(
-      logoPages[slice.pageIndex],
-      slice.x,
-      slice.y,
+      tile,
+      0,
+      0,
       logoMask,
       heartMask,
       logoColor,
@@ -830,7 +836,34 @@ function buildSeparatedClothPages(
       box.width,
       box.height,
     );
-    copyAllGutters(logoPages[slice.pageIndex], slice.x, slice.y, box.width, box.height);
+    const hash = hashOpaqueRgb(tile);
+    let slot = logoSlotByHash.get(hash);
+    if (slot === undefined) {
+      slot = uniqueLogoTiles.length;
+      logoSlotByHash.set(hash, slot);
+      uniqueLogoTiles.push(tile);
+    }
+    logoStateSlots.push(Object.freeze([slot]));
+  }
+  const logoLayout = buildClothSlotLayout(
+    logoRasterBoxes,
+    logoStateSlots,
+    uniqueLogoTiles.length,
+    { preferSquare: true, gutter: CLOTH_GUTTER * LOGO_RASTER_SCALE },
+  );
+  const logoPages = logoLayout.pages.map((page) => createRgba(page.width, page.height));
+  for (let slot = 0; slot < uniqueLogoTiles.length; slot += 1) {
+    const tile = uniqueLogoTiles[slot];
+    const slice = logoLayout.slots[slot];
+    copyTile(tile, logoPages[slice.pageIndex], slice.x, slice.y);
+    copyAllGutters(
+      logoPages[slice.pageIndex],
+      slice.x,
+      slice.y,
+      tile.width,
+      tile.height,
+      CLOTH_GUTTER * LOGO_RASTER_SCALE,
+    );
   }
   return Object.freeze({
     pages: Object.freeze(pages),
@@ -946,14 +979,22 @@ function paintClothLogoTriangle(
   }
 }
 
-function buildClothSlotLayout(rasterBoxes, stateSlots, slotCount, { preferSquare = false } = {}) {
+function buildClothSlotLayout(
+  rasterBoxes,
+  stateSlots,
+  slotCount,
+  { preferSquare = false, gutter = CLOTH_GUTTER } = {},
+) {
   const width = rasterBoxes[0].width;
   const height = rasterBoxes[0].height;
+  if (!Number.isSafeInteger(gutter) || gutter < 1) {
+    throw new RangeError("Cloth atlas gutter is invalid");
+  }
   if (rasterBoxes.some((box) => box.width !== width || box.height !== height)) {
     throw new RangeError("Cloth atlas deduplication requires one raster leaf size");
   }
-  const strideX = width + CLOTH_GUTTER * 2;
-  const strideY = height + CLOTH_GUTTER * 2;
+  const strideX = width + gutter * 2;
+  const strideY = height + gutter * 2;
   const columns = preferSquare
     ? resolveNearSquareColumns(slotCount, strideX, strideY)
     : Math.min(slotCount, Math.floor(RASTER_PAGE_WIDTH / strideX));
@@ -971,8 +1012,8 @@ function buildClothSlotLayout(rasterBoxes, stateSlots, slotCount, { preferSquare
   const slots = Object.freeze(Array.from({ length: slotCount }, (_, slot) => Object.freeze({
     pageIndex: 0,
     resourcePath: page.resourcePath,
-    x: (slot % columns) * strideX + CLOTH_GUTTER,
-    y: Math.floor(slot / columns) * strideY + CLOTH_GUTTER,
+    x: (slot % columns) * strideX + gutter,
+    y: Math.floor(slot / columns) * strideY + gutter,
     width,
     height,
     pageWidth,
@@ -1040,19 +1081,27 @@ function copyTile(source, target, left, top) {
   }
 }
 
-function copyAllGutters(page, left, top, width, height = width) {
-  for (let i = 0; i < height; i += 1) {
-    copyPixel(page, left, top + i, left - 1, top + i);
-    copyPixel(page, left + width - 1, top + i, left + width, top + i);
+function copyAllGutters(page, left, top, width, height = width, thickness = 1) {
+  for (let layer = 1; layer <= thickness; layer += 1) {
+    for (let i = 0; i < height; i += 1) {
+      copyPixel(page, left, top + i, left - layer, top + i);
+      copyPixel(page, left + width - 1, top + i, left + width - 1 + layer, top + i);
+    }
+    for (let i = 0; i < width; i += 1) {
+      copyPixel(page, left + i, top, left + i, top - layer);
+      copyPixel(page, left + i, top + height - 1, left + i, top + height - 1 + layer);
+    }
+    copyPixel(page, left, top, left - layer, top - layer);
+    copyPixel(page, left + width - 1, top, left + width - 1 + layer, top - layer);
+    copyPixel(page, left, top + height - 1, left - layer, top + height - 1 + layer);
+    copyPixel(
+      page,
+      left + width - 1,
+      top + height - 1,
+      left + width - 1 + layer,
+      top + height - 1 + layer,
+    );
   }
-  for (let i = 0; i < width; i += 1) {
-    copyPixel(page, left + i, top, left + i, top - 1);
-    copyPixel(page, left + i, top + height - 1, left + i, top + height);
-  }
-  copyPixel(page, left, top, left - 1, top - 1);
-  copyPixel(page, left + width - 1, top, left + width, top - 1);
-  copyPixel(page, left, top + height - 1, left - 1, top + height);
-  copyPixel(page, left + width - 1, top + height - 1, left + width, top + height);
 }
 
 function copyPixel(page, sourceX, sourceY, targetX, targetY) {

--- a/src/adapters/cloth/src/shared/csscloth/morphTexturePatch.mjs
+++ b/src/adapters/cloth/src/shared/csscloth/morphTexturePatch.mjs
@@ -1,6 +1,12 @@
 const CLOTH_ATLAS_GUTTER = 1;
 
-export function createPolyMorphPreparedCornerTextureTarget(mounted, resources, triangleCount, logoAtlas) {
+export function createPolyMorphPreparedCornerTextureTarget(
+  mounted,
+  resources,
+  triangleCount,
+  logoAtlas,
+  lightingAtlas,
+) {
   const handles = Array.from({ length: triangleCount }, (_, triangleIndex) =>
     mounted.leafHandles.get(`leaf-cloth-${String(triangleIndex).padStart(3, "0")}`));
   if (handles.some((handle) => !handle || handle.element.localName !== "u")) {
@@ -28,7 +34,10 @@ export function createPolyMorphPreparedCornerTextureTarget(mounted, resources, t
   const gutter = CLOTH_ATLAS_GUTTER;
   const stride = firstAtlas.width + gutter * 2;
   const columns = firstAtlas.pageWidth / stride;
-  if (!Number.isSafeInteger(columns) || columns < 1 || firstAtlas.height !== firstAtlas.width ||
+  const rowCount = firstAtlas.pageHeight / stride;
+  if (!Number.isSafeInteger(columns) || columns < 1 ||
+      !Number.isSafeInteger(rowCount) || rowCount < 1 ||
+      firstAtlas.height !== firstAtlas.width ||
       handles.some(({ plan }) => plan.width !== 28 || plan.height !== 28) ||
       atlases.some((atlas) => atlas.width !== firstAtlas.width || atlas.height !== firstAtlas.height ||
         atlas.pageWidth !== firstAtlas.pageWidth || atlas.pageHeight !== firstAtlas.pageHeight)) {
@@ -36,12 +45,30 @@ export function createPolyMorphPreparedCornerTextureTarget(mounted, resources, t
     URL.revokeObjectURL(logoUrl);
     throw new Error("Cloth prepared atlas grid is invalid");
   }
-  if (!Number.isSafeInteger(logoAtlas?.pageWidth) || logoAtlas.pageWidth < 1 ||
+  const logoRasterScale = logoAtlas?.rasterScale;
+  const logoStride = logoAtlas?.leafWidth + logoAtlas?.gutter * 2;
+  const logoRowCount = logoAtlas?.pageHeight / logoStride;
+  const logoSlotCount = logoAtlas?.columns * logoRowCount;
+  const lightingPositions = Array.from({ length: columns * rowCount }, (_, slot) =>
+    `${-(slot % columns * stride + gutter)}px ${-(Math.floor(slot / columns) * stride + gutter)}px`);
+  if (!Number.isSafeInteger(logoRasterScale) || logoRasterScale < 1 ||
+      !Number.isSafeInteger(logoAtlas?.pageWidth) || logoAtlas.pageWidth < 1 ||
       !Number.isSafeInteger(logoAtlas?.pageHeight) || logoAtlas.pageHeight < 1 ||
-      logoAtlas.leafWidth !== firstAtlas.width || logoAtlas.leafHeight !== firstAtlas.height ||
-      logoAtlas.gutter !== gutter || !Number.isSafeInteger(logoAtlas.columns) ||
-      logoAtlas.columns < 1 || logoAtlas.pageWidth !== logoAtlas.columns * stride ||
-      Math.ceil(handles.length / logoAtlas.columns) * stride !== logoAtlas.pageHeight) {
+      logoAtlas.leafWidth !== firstAtlas.width * logoRasterScale ||
+      logoAtlas.leafHeight !== firstAtlas.height * logoRasterScale ||
+      logoAtlas.gutter !== gutter * logoRasterScale ||
+      !Number.isSafeInteger(logoAtlas.columns) || logoAtlas.columns < 1 ||
+      !Number.isSafeInteger(logoRowCount) || logoRowCount < 1 ||
+      logoAtlas.pageWidth !== logoAtlas.columns * logoStride ||
+      !Array.isArray(logoAtlas.triangleSlots) ||
+      logoAtlas.triangleSlots.length !== handles.length ||
+      logoAtlas.triangleSlots.some((slot) =>
+        !Number.isSafeInteger(slot) || slot < 0 || slot >= logoSlotCount) ||
+      !Array.isArray(lightingAtlas?.triangleSlots) ||
+      lightingAtlas.triangleSlots.length !== handles.length ||
+      lightingAtlas.triangleSlots.some((slots) => !Array.isArray(slots) || slots.length < 1 ||
+        slots.some((slot) => !Number.isSafeInteger(slot) ||
+          slot < 0 || slot >= lightingPositions.length))) {
     URL.revokeObjectURL(url);
     URL.revokeObjectURL(logoUrl);
     throw new Error("Cloth prepared logo atlas grid is invalid");
@@ -54,20 +81,38 @@ export function createPolyMorphPreparedCornerTextureTarget(mounted, resources, t
   );
   mounted.cameraElement.style.setProperty(
     "--csscloth-logo-atlas-size",
-    `${logoAtlas.pageWidth}px ${logoAtlas.pageHeight}px`,
+    `${logoAtlas.pageWidth / logoRasterScale}px ${logoAtlas.pageHeight / logoRasterScale}px`,
   );
-  const positions = new Array(handles.length);
-  const logoPositions = new Array(handles.length);
+  const currentSlots = new Int32Array(handles.length);
+  currentSlots.fill(-1);
+  const backgroundPositions = new Array(handles.length);
 
   for (let index = 0; index < handles.length; index += 1) {
     const handle = handles[index];
     const atlas = atlases[index];
     const { element } = handle;
-    const position = `${-atlas.x}px ${-atlas.y}px`;
-    const logoPosition = `${-(index % logoAtlas.columns * stride + gutter)}px ${-(Math.floor(index / logoAtlas.columns) * stride + gutter)}px`;
-    positions[index] = position;
-    logoPositions[index] = logoPosition;
-    element.style.backgroundPosition = `${logoPosition}, ${position}`;
+    const slotColumn = (atlas.x - gutter) / stride;
+    const slotRow = (atlas.y - gutter) / stride;
+    const slot = slotRow * columns + slotColumn;
+    if (!Number.isSafeInteger(slotColumn) || !Number.isSafeInteger(slotRow) ||
+        slot < 0 || slot >= lightingPositions.length) {
+      throw new Error("Cloth prepared atlas slot is invalid");
+    }
+    const logoSlot = logoAtlas.triangleSlots[index];
+    const logoPosition = `${-(logoSlot % logoAtlas.columns * logoStride + logoAtlas.gutter) / logoRasterScale}px ${-(Math.floor(logoSlot / logoAtlas.columns) * logoStride + logoAtlas.gutter) / logoRasterScale}px`;
+    const positions = new Map();
+    for (const lightingSlot of lightingAtlas.triangleSlots[index]) {
+      if (!positions.has(lightingSlot)) {
+        positions.set(lightingSlot, `${logoPosition}, ${lightingPositions[lightingSlot]}`);
+      }
+    }
+    const position = positions.get(slot);
+    if (position === undefined) {
+      throw new Error("Cloth prepared initial atlas slot is invalid");
+    }
+    currentSlots[index] = slot;
+    backgroundPositions[index] = positions;
+    element.style.backgroundPosition = position;
   }
 
   return Object.freeze({
@@ -77,10 +122,13 @@ export function createPolyMorphPreparedCornerTextureTarget(mounted, resources, t
           !Number.isSafeInteger(slot) || slot < 0) {
         throw new RangeError("Cloth prepared atlas slot is out of range");
       }
-      const position = `${-(slot % columns * stride + gutter)}px ${-(Math.floor(slot / columns) * stride + gutter)}px`;
-      if (positions[index] === position) return false;
-      handles[index].element.style.backgroundPosition = `${logoPositions[index]}, ${position}`;
-      positions[index] = position;
+      if (currentSlots[index] === slot) return false;
+      const position = backgroundPositions[index].get(slot);
+      if (position === undefined) {
+        throw new RangeError("Cloth prepared atlas slot is out of range");
+      }
+      handles[index].element.style.backgroundPosition = position;
+      currentSlots[index] = slot;
       return true;
     },
     destroy() {

--- a/src/adapters/cloth/src/shared/csscloth/preparedPlaybackTransport.mjs
+++ b/src/adapters/cloth/src/shared/csscloth/preparedPlaybackTransport.mjs
@@ -1,11 +1,11 @@
 import { formatMatrix3dValues } from "@layoutit/polycss";
 
-export const CSSCLOTH_PLAYBACK_SCHEMA = "csscloth-prepared-playback@5";
+export const CSSCLOTH_PLAYBACK_SCHEMA = "csscloth-prepared-playback@6";
 export const CSSCLOTH_PLAYBACK_ENCODING =
-  "gzip-third-order-zigzag-varint-fixed4-affine12-u16-lighting-u16-atlas-shadow@5";
+  "gzip-third-order-zigzag-varint-fixed4-affine12-sparse-u16-lighting-shadow@6";
 
 const MAGIC = "CCLT";
-const VERSION = 5;
+const VERSION = 6;
 const HEADER_BYTES = 36;
 const PREDICTION_ORDER = 3;
 const MATRIX_DECIMALS = 4;
@@ -36,18 +36,12 @@ export function encodeClothPreparedPlayback(playback) {
       }
     }
   }
-  const lightingByteLength = playback.frameCount * playback.triangleCount * 2;
+  const lightingSchedule = buildSparseLightingSchedule(playback);
+  const lightingByteLength = lightingSchedule.offsets.byteLength +
+    lightingSchedule.indices.byteLength + lightingSchedule.slots.byteLength;
   const shadowVisibilityByteLength = playback.frameCount * playback.shadowTriangleCount;
-  const atlasStateOffsets = [0];
-  const atlasSlots = [];
-  for (const slots of playback.atlasStateSlots) {
-    atlasSlots.push(...slots);
-    atlasStateOffsets.push(atlasSlots.length);
-  }
-  const atlasMappingByteLength = (atlasStateOffsets.length + atlasSlots.length) * 2;
   const bytes = new Uint8Array(
-    HEADER_BYTES + matrixBytes.length + lightingByteLength + shadowVisibilityByteLength +
-      atlasMappingByteLength,
+    HEADER_BYTES + matrixBytes.length + lightingByteLength + shadowVisibilityByteLength,
   );
   const view = new DataView(bytes.buffer);
   for (let index = 0; index < MAGIC.length; index += 1) bytes[index] = MAGIC.charCodeAt(index);
@@ -61,27 +55,25 @@ export function encodeClothPreparedPlayback(playback) {
   view.setUint32(20, matrixBytes.length, true);
   view.setUint32(24, lightingByteLength, true);
   view.setUint16(28, playback.shadowTriangleCount, true);
-  view.setUint32(30, atlasMappingByteLength, true);
+  view.setUint32(30, lightingSchedule.indices.length, true);
   view.setUint16(34, 0, true);
   bytes.set(matrixBytes, HEADER_BYTES);
   let offset = HEADER_BYTES + matrixBytes.length;
-  for (const frame of playback.frames) {
-    for (const row of frame.lightingRows) {
-      view.setUint16(offset, row, true);
-      offset += 2;
-    }
+  for (const value of lightingSchedule.offsets) {
+    view.setUint32(offset, value, true);
+    offset += 4;
+  }
+  for (const value of lightingSchedule.indices) {
+    view.setUint16(offset, value, true);
+    offset += 2;
+  }
+  for (const value of lightingSchedule.slots) {
+    view.setUint16(offset, value, true);
+    offset += 2;
   }
   for (const frame of playback.frames) {
     bytes.set(frame.shadowVisibility, offset);
     offset += playback.shadowTriangleCount;
-  }
-  for (const value of atlasStateOffsets) {
-    view.setUint16(offset, value, true);
-    offset += 2;
-  }
-  for (const value of atlasSlots) {
-    view.setUint16(offset, value, true);
-    offset += 2;
   }
   return bytes;
 }
@@ -122,15 +114,17 @@ export function createClothPreparedPlaybackMaterialization(bytes, descriptor) {
   const frameMilliseconds = view.getFloat64(12, true);
   const matrixByteLength = view.getUint32(20, true);
   const lightingByteLength = view.getUint32(24, true);
-  const atlasMappingByteLength = view.getUint32(30, true);
+  const lightingAssignmentCount = view.getUint32(30, true);
   const shadowVisibilityByteLength = frameCount * shadowTriangleCount;
+  const expectedLightingByteLength = (frameCount + 1) * Uint32Array.BYTES_PER_ELEMENT +
+    lightingAssignmentCount * Uint16Array.BYTES_PER_ELEMENT * 2;
   if (view.getUint16(34, true) !== 0 || frameCount !== descriptor.frameCount ||
       triangleCount !== descriptor.triangleCount ||
       shadowTriangleCount !== descriptor.shadowTriangleCount ||
       frameMilliseconds !== descriptor.frameMilliseconds ||
-      lightingByteLength !== frameCount * triangleCount * 2 ||
-      HEADER_BYTES + matrixByteLength + lightingByteLength + shadowVisibilityByteLength +
-        atlasMappingByteLength !== bytes.byteLength) {
+      lightingByteLength !== expectedLightingByteLength ||
+      HEADER_BYTES + matrixByteLength + lightingByteLength + shadowVisibilityByteLength !==
+        bytes.byteLength) {
     throw new Error("Prepared Cloth playback counts drifted");
   }
   const transformCount = triangleCount + shadowTriangleCount;
@@ -156,36 +150,40 @@ export function createClothPreparedPlaybackMaterialization(bytes, descriptor) {
   if (stream.offset !== stream.end) throw new Error("Prepared Cloth matrix stream has trailing bytes");
   const lightingStart = stream.end;
   const shadowVisibilityStart = lightingStart + lightingByteLength;
-  const atlasMappingStart = shadowVisibilityStart + shadowVisibilityByteLength;
-  const atlasStateOffsets = new Uint16Array(triangleCount + 1);
-  let atlasOffset = atlasMappingStart;
-  for (let index = 0; index < atlasStateOffsets.length; index += 1) {
-    atlasStateOffsets[index] = view.getUint16(atlasOffset, true);
-    atlasOffset += 2;
+  const lightingOffsets = new Uint32Array(frameCount + 1);
+  let lightingOffset = lightingStart;
+  for (let index = 0; index < lightingOffsets.length; index += 1) {
+    lightingOffsets[index] = view.getUint32(lightingOffset, true);
+    lightingOffset += 4;
   }
-  const atlasStateCount = atlasStateOffsets[triangleCount];
-  if (atlasStateOffsets[0] !== 0 || atlasMappingByteLength !==
-      (atlasStateOffsets.length + atlasStateCount) * 2 ||
-      atlasStateOffsets.some((value, index) => index > 0 && value <= atlasStateOffsets[index - 1])) {
-    throw new Error("Prepared Cloth atlas mapping drifted");
+  if (lightingOffsets[0] !== 0 || lightingOffsets[1] !== triangleCount ||
+      lightingOffsets[frameCount] !== lightingAssignmentCount ||
+      lightingOffsets.some((value, index) => index > 0 && value < lightingOffsets[index - 1])) {
+    throw new Error("Prepared Cloth lighting schedule drifted");
   }
-  const atlasSlots = new Uint16Array(atlasStateCount);
-  for (let index = 0; index < atlasSlots.length; index += 1) {
-    atlasSlots[index] = view.getUint16(atlasOffset, true);
-    atlasOffset += 2;
+  const lightingIndices = new Uint16Array(lightingAssignmentCount);
+  for (let index = 0; index < lightingIndices.length; index += 1) {
+    lightingIndices[index] = view.getUint16(lightingOffset, true);
+    lightingOffset += 2;
+  }
+  if (lightingIndices.some((value) => value >= triangleCount)) {
+    throw new Error("Prepared Cloth lighting schedule addresses an invalid triangle");
+  }
+  const lightingSlots = new Uint16Array(lightingAssignmentCount);
+  for (let index = 0; index < lightingSlots.length; index += 1) {
+    lightingSlots[index] = view.getUint16(lightingOffset, true);
+    lightingOffset += 2;
   }
   const shadowSchedule = buildSparseShadowSchedule(
     quantized,
-    bytes.subarray(shadowVisibilityStart, atlasMappingStart),
+    bytes.subarray(shadowVisibilityStart),
     frameCount,
     triangleCount,
     shadowTriangleCount,
   );
-  const lightingRows = new Uint16Array(frameCount * triangleCount);
-  for (let index = 0; index < lightingRows.length; index += 1) {
-    lightingRows[index] = view.getUint16(lightingStart + index * 2, true);
+  if (lightingOffset !== shadowVisibilityStart) {
+    throw new Error("Prepared Cloth lighting schedule has trailing bytes");
   }
-  if (atlasOffset !== bytes.byteLength) throw new Error("Prepared Cloth atlas mapping has trailing bytes");
   return Object.freeze({
     playback: Object.freeze({
       schema: CSSCLOTH_PLAYBACK_SCHEMA,
@@ -195,15 +193,15 @@ export function createClothPreparedPlaybackMaterialization(bytes, descriptor) {
       frameMilliseconds,
       durationMilliseconds: frameCount * frameMilliseconds,
       transforms: null,
-      lightingRows,
+      lightingOffsets,
+      lightingIndices,
+      lightingSlots,
       shadowTransformOffsets: shadowSchedule.transformOffsets,
       shadowTransformIndices: shadowSchedule.transformIndices,
       shadowTransformValues: null,
       shadowVisibilityOffsets: shadowSchedule.visibilityOffsets,
       shadowVisibilityIndices: shadowSchedule.visibilityIndices,
       shadowVisibilityValues: shadowSchedule.visibilityValues,
-      atlasStateOffsets,
-      atlasSlots,
       decodedByteLength: bytes.byteLength,
     }),
     quantized,
@@ -281,6 +279,31 @@ export function completeClothPreparedPlaybackMaterialization(
 function clothCombinedTransformIndex(clothTransformIndex, triangleCount, transformCount) {
   const frameIndex = Math.floor(clothTransformIndex / triangleCount);
   return frameIndex * transformCount + clothTransformIndex % triangleCount;
+}
+
+function buildSparseLightingSchedule(playback) {
+  const offsets = new Uint32Array(playback.frameCount + 1);
+  const indices = [];
+  const slots = [];
+  const previousSlots = new Uint32Array(playback.triangleCount);
+  previousSlots.fill(0xffff_ffff);
+  for (let frameIndex = 0; frameIndex < playback.frameCount; frameIndex += 1) {
+    offsets[frameIndex] = indices.length;
+    const frame = playback.frames[frameIndex];
+    for (let triangleIndex = 0; triangleIndex < playback.triangleCount; triangleIndex += 1) {
+      const slot = playback.atlasStateSlots[triangleIndex][frame.lightingRows[triangleIndex]];
+      if (frameIndex !== 0 && previousSlots[triangleIndex] === slot) continue;
+      indices.push(triangleIndex);
+      slots.push(slot);
+      previousSlots[triangleIndex] = slot;
+    }
+  }
+  offsets[playback.frameCount] = indices.length;
+  return {
+    offsets,
+    indices: Uint16Array.from(indices),
+    slots: Uint16Array.from(slots),
+  };
 }
 
 function buildSparseShadowSchedule(

--- a/src/adapters/cloth/test/csscloth-model.test.mjs
+++ b/src/adapters/cloth/test/csscloth-model.test.mjs
@@ -29,6 +29,7 @@ test("prepared model keeps one retained triangle root per cloth face", () => {
   assert.equal(prepared.metrics.frameCount, 11_520);
   assert.equal(prepared.metrics.durationMilliseconds, 192_000);
   assert.equal(prepared.metrics.clothLightingStateCount, 60_269);
+  assert.equal(prepared.metrics.clothLightingDistinctStateKeyCount, 5_656);
   assert.equal(prepared.metrics.clothAtlasStoredStateCount, 60_269);
   assert.equal(prepared.metrics.clothAtlasUniqueStateCount, 5_656);
   assert.equal(prepared.metrics.clothAtlasDeduplicatedStateCount, 54_613);
@@ -84,9 +85,10 @@ test("prepared playback uses compact fixed-point transport", () => {
     frameMilliseconds: playback.frameMilliseconds,
   });
   assert.equal(decoded.transforms.length, 1440 * 200);
-  assert.equal(decoded.lightingRows.length, 1440 * 200);
-  assert.equal(decoded.atlasStateOffsets.length, 201);
-  assert.equal(decoded.atlasSlots.length, prepared.metrics.clothLightingStateCount);
+  assert.equal(decoded.lightingOffsets.length, 1441);
+  assert.equal(decoded.lightingOffsets[1], 200);
+  assert.equal(decoded.lightingIndices.length, decoded.lightingSlots.length);
+  assert.ok(decoded.lightingIndices.length < 1440 * 50);
   assert.equal(decoded.shadowTransformOffsets.length, 1441);
   assert.equal(decoded.shadowVisibilityOffsets.length, 1441);
   assert.equal(decoded.shadowTransformOffsets[1], prepared.metrics.clothShadowLeafCount);
@@ -100,6 +102,10 @@ test("prepared playback uses compact fixed-point transport", () => {
   assert.deepEqual(
     [...materialization.playback.shadowTransformIndices],
     [...decoded.shadowTransformIndices],
+  );
+  assert.deepEqual(
+    [...materialization.playback.lightingOffsets],
+    [...decoded.lightingOffsets],
   );
   const sampledTransformIndex = 137 * 200 + 47;
   assert.deepEqual(
@@ -125,6 +131,12 @@ test("prepared playback uses compact fixed-point transport", () => {
   assert.deepEqual(
     [...shadowState.visibility],
     playback.frames[137].shadowVisibility,
+  );
+  const lightingState = reconstructLightingState(decoded, 137);
+  assert.deepEqual(
+    [...lightingState],
+    playback.frames[137].lightingRows.map((row, triangleIndex) =>
+      playback.atlasStateSlots[triangleIndex][row]),
   );
 });
 
@@ -157,6 +169,17 @@ function reconstructShadowState(playback, frameIndex) {
     }
   }
   return { transforms, visibility };
+}
+
+function reconstructLightingState(playback, frameIndex) {
+  const slots = new Uint16Array(playback.triangleCount);
+  for (let sourceFrame = 0; sourceFrame <= frameIndex; sourceFrame += 1) {
+    for (let assignment = playback.lightingOffsets[sourceFrame];
+      assignment < playback.lightingOffsets[sourceFrame + 1]; assignment += 1) {
+      slots[playback.lightingIndices[assignment]] = playback.lightingSlots[assignment];
+    }
+  }
+  return slots;
 }
 
 test("the prepared shadow leaves share one small raster triangle", () => {

--- a/src/adapters/cloth/test/csscloth-shell.test.mjs
+++ b/src/adapters/cloth/test/csscloth-shell.test.mjs
@@ -44,6 +44,9 @@ test("runtime has no per-frame geometry or raster construction", async () => {
   assert.match(playbackStream, /requestIdleCallback/u);
   assert.match(playbackStream, /RESPONSE_CHUNK_TRANSFORM_COUNT = 480/u);
   assert.match(playbackWorker, /materializeClothPreparedMatrixRange/u);
+  assert.match(playbackWorker, /playback\.lightingOffsets\.buffer/u);
+  assert.match(playbackWorker, /playback\.lightingIndices\.buffer/u);
+  assert.match(playbackWorker, /playback\.lightingSlots\.buffer/u);
   assert.match(playbackWorker, /setTimeout\(resolve, materialization\.playback\.frameMilliseconds\)/u);
   assert.doesNotMatch(playbackWorker, /canvas|getContext|createElement|requestAnimationFrame/u);
   assert.match(client, /textureLeafSizing !== "raster"/);
@@ -57,8 +60,9 @@ test("runtime has no per-frame geometry or raster construction", async () => {
   assert.match(textureTarget, /--csscloth-atlas/u);
   assert.match(textureTarget, /--csscloth-logo-atlas/u);
   assert.match(textureTarget, /--csscloth-logo-atlas-size/u);
-  assert.match(textureTarget, /logoPositions/u);
+  assert.match(textureTarget, /logoAtlas\.triangleSlots/u);
   assert.match(client, /metadata\.renderer\.logoAtlas/u);
+  assert.match(client, /metadata\.renderer\.lightingAtlas/u);
   assert.match(styles, /body > \.polycss-camera > \.polycss-scene > u/u);
   assert.match(styles, /background-image: var\(--csscloth-logo-atlas\), var\(--csscloth-atlas\)/u);
   assert.match(styles, /background-size: var\(--csscloth-logo-atlas-size\), var\(--csscloth-atlas-size\)/u);
@@ -71,7 +75,16 @@ test("runtime has no per-frame geometry or raster construction", async () => {
   assert.match(styles, /corner-top-left-shape: bevel/u);
   assert.match(styles, /corner-top-right-shape: bevel/u);
   assert.match(client, /target\.leaves\[triangleIndex\]\.writeTransform/u);
+  assert.match(client, /playback\.lightingOffsets\[frameIndex\]/u);
+  assert.match(client, /publishAbsoluteLighting/u);
+  assert.match(client, /runtimeLightingComparisonCount: 0/u);
+  assert.doesNotMatch(client, /playback\.lightingRows/u);
+  assert.doesNotMatch(client, /currentLightingRows/u);
   assert.doesNotMatch(styles, /transform: matrix3d\(1, 0, 0, 0, 0, 1/u);
+  assert.match(textureTarget, /const lightingPositions = Array\.from/u);
+  assert.match(textureTarget, /const backgroundPositions = new Array/u);
+  assert.match(textureTarget, /element\.style\.backgroundPosition = position/u);
+  assert.doesNotMatch(textureTarget, /writeSlot\([\s\S]*?`\$\{/u);
   assert.doesNotMatch(textureTarget, /canvas|getContext|createElement|requestAnimationFrame/u);
 });
 

--- a/src/adapters/cloth/tools/prepare-csscloth.mjs
+++ b/src/adapters/cloth/tools/prepare-csscloth.mjs
@@ -26,6 +26,7 @@ import {
   CSSCLOTH_BANK_COUNT,
   CSSCLOTH_BANK_FRAME_COUNT,
   CSSCLOTH_OUTPUT_FRAME_MILLISECONDS,
+  CSSCLOTH_RASTER_LEAF_SIZE,
   CSSCLOTH_STREAM_FRAME_COUNT,
 } from "../src/prepare/csscloth/sourceModel.mjs";
 
@@ -124,6 +125,8 @@ async function prepareProfile(profile, profileRoot, publicRoot) {
         leafHeight: logoSlice.height,
         gutter: logoSlice.x,
         columns: logoPage.width / (logoSlice.width + logoSlice.x * 2),
+        rasterScale: logoSlice.width / CSSCLOTH_RASTER_LEAF_SIZE,
+        triangleSlots: raster.clothLogoLayout.stateSlots.map((slots) => slots[0]),
       })
     : undefined;
   const packageRoot = join(profileRoot, "model", prepared.model.identity.id);
@@ -152,6 +155,9 @@ async function prepareProfile(profile, profileRoot, publicRoot) {
       representation: "retained-cloth-and-shadow-triangles-with-compact-prepared-raster-playback",
       textureLeafSizing: "raster",
       logoAtlas,
+      lightingAtlas: {
+        triangleSlots: raster.clothLayout.stateSlots,
+      },
       runtimeGeometryConstruction: false,
       runtimeDomGrowth: false,
       runtimeAtlasRasterization: false,

--- a/src/adapters/cloth/tools/productBank.mjs
+++ b/src/adapters/cloth/tools/productBank.mjs
@@ -13,6 +13,14 @@ export async function inspectCssclothProductBank(root) {
     triangleCount: 200,
     shadowTriangleCount: 51,
     retainedLeafCount: 312,
+    lightingStateCount: 60_269,
+    lightingStateKeyCount: 5_656,
+    lightingTileCount: 3_793,
+    lightingDeduplicatedCount: 56_476,
+    lightingAtlasPixels: 1_860 * 1_860,
+    logoAtlasWidth: 420,
+    logoAtlasHeight: 420,
+    logoTileCount: 43,
   });
   assert(desktop.prepared.presentation?.responsiveProfile?.media === "(max-width: 600px)",
     "mobile media query");
@@ -86,6 +94,35 @@ async function inspectProfile(productRoot, prefix, expectedPaths, expected) {
     `${expected.profile} runtime DOM contract`);
   assert(prepared.renderer.runtimeAtlasRasterization === false,
     `${expected.profile} runtime atlas contract`);
+  const logoAtlas = prepared.renderer.logoAtlas;
+  const lightingAtlas = prepared.renderer.lightingAtlas;
+  assert(logoAtlas?.rasterScale === 2 && logoAtlas.leafWidth === 56 &&
+    logoAtlas.leafHeight === 56 && logoAtlas.gutter === 2 &&
+    Array.isArray(logoAtlas.triangleSlots) &&
+    logoAtlas.triangleSlots.length === expected.triangleCount,
+    `${expected.profile} 2x logo atlas`);
+  assert(Array.isArray(lightingAtlas?.triangleSlots) &&
+    lightingAtlas.triangleSlots.length === expected.triangleCount &&
+    lightingAtlas.triangleSlots.every((slots) => Array.isArray(slots) && slots.length > 0),
+    `${expected.profile} lighting atlas slots`);
+  if (expected.lightingStateCount !== undefined) {
+    assert(prepared.metrics.clothLightingStateCount === expected.lightingStateCount,
+      `${expected.profile} lighting occurrences`);
+    assert(prepared.metrics.clothAtlasStoredStateCount === expected.lightingStateCount,
+      `${expected.profile} lighting stored states`);
+    assert(prepared.metrics.clothAtlasUniqueStateCount === expected.lightingTileCount,
+      `${expected.profile} lighting raster tiles`);
+    assert(prepared.metrics.clothAtlasDeduplicatedStateCount === expected.lightingDeduplicatedCount,
+      `${expected.profile} lighting deduplicated occurrences`);
+    assert(prepared.metrics.clothRasterPagePixels === expected.lightingAtlasPixels,
+      `${expected.profile} lighting atlas pixels`);
+    assert(prepared.metrics.clothLightingDistinctStateKeyCount === expected.lightingStateKeyCount,
+      `${expected.profile} lighting state keys`);
+    assert(logoAtlas.pageWidth === expected.logoAtlasWidth &&
+      logoAtlas.pageHeight === expected.logoAtlasHeight &&
+      new Set(logoAtlas.triangleSlots).size === expected.logoTileCount,
+      `${expected.profile} logo atlas metrics`);
+  }
 
   for (const [bankIndex, bank] of banks.entries()) {
     assert(bank?.bankIndex === bankIndex, `${expected.profile} bank ${bankIndex} index`);
@@ -93,11 +130,11 @@ async function inspectProfile(productRoot, prefix, expectedPaths, expected) {
       `${expected.profile} bank ${bankIndex} counts`);
     assert(bank.shadowTriangleCount === expected.shadowTriangleCount,
       `${expected.profile} bank ${bankIndex} shadow count`);
-    assert(bank.schema === "csscloth-prepared-playback@5",
+    assert(bank.schema === "csscloth-prepared-playback@6",
       `${expected.profile} bank ${bankIndex} schema`);
     assert(bank.encoding ===
-      "gzip-third-order-zigzag-varint-fixed4-affine12-u16-lighting-u16-atlas-shadow@5",
-    `${expected.profile} bank ${bankIndex} encoding`);
+      "gzip-third-order-zigzag-varint-fixed4-affine12-sparse-u16-lighting-shadow@6",
+      `${expected.profile} bank ${bankIndex} encoding`);
     const path = productPath(bank.path);
     const bytes = await readFile(join(productRoot, path));
     assert(bytes.byteLength === bank.compressedByteLength,


### PR DESCRIPTION
## Summary
- prepare compact per-frame sparse lighting schedules while keeping frame 0 absolute
- preserve PR #117 Worker chunking and idle-slice bank materialization
- deduplicate exact lighting and 2x wordmark atlas tiles

## Verification
- `pnpm test:cloth`
- `pnpm test:cloth:assets`
- `pnpm build:cloth`
- `pnpm build`
- desktop and mobile deterministic captures: 0 changed pixels against the accepted experiment
- 52-second production build trace: two handoffs, no handoff task above 5.1 ms, no handoff cadence gap above 9.1 ms, p95 8.9 ms at 120 Hz
- remaining single 58.3 ms gap was V8 major GC at +7.8 s, away from either handoff

## Prepared asset
- `csscloth-product-bank-v2.tar.gz`: 61,884,412 bytes
- SHA-256: `e8d32550e06fa6e1273f82fc40829983b1da2d45602db36f061c346eb906e70c`