### PR TITLE
fix(cloth): allow Firefox triangle fallback

### DIFF
--- a/src/adapters/cloth/src/shared/csscloth/morphTexturePatch.mjs
+++ b/src/adapters/cloth/src/shared/csscloth/morphTexturePatch.mjs
@@ -12,10 +12,6 @@ export function createPolyMorphPreparedCornerTextureTarget(
   if (handles.some((handle) => !handle || handle.element.localName !== "u")) {
     throw new Error("Cloth requires PolyCSS corner-shape triangle leaves");
   }
-  if (!CSS.supports("corner-top-left-shape", "bevel") ||
-      !CSS.supports("corner-top-right-shape", "bevel")) {
-    throw new Error("Cloth requires CSS corner-shape support");
-  }
   const atlases = handles.map((handle) => handle.plan.fallback?.atlas);
   const resourcePath = atlases[0]?.resourcePath;
   if (!resourcePath || atlases.some((atlas) => !atlas || atlas.resourcePath !== resourcePath)) {

--- a/src/adapters/cloth/test/csscloth-shell.test.mjs
+++ b/src/adapters/cloth/test/csscloth-shell.test.mjs
@@ -57,6 +57,7 @@ test("runtime has no per-frame geometry or raster construction", async () => {
   assert.doesNotMatch(shadowTarget, /frameIndex \* playback\.shadowTriangleCount/u);
   assert.doesNotMatch(shadowTarget, /computeParametricShadowSilhouette|canvas|getContext|createElement|requestAnimationFrame/);
   assert.doesNotMatch(textureTarget, /style\.setProperty\("corner-bottom-right-shape"/u);
+  assert.doesNotMatch(textureTarget, /CSS\.supports/u);
   assert.match(textureTarget, /--csscloth-atlas/u);
   assert.match(textureTarget, /--csscloth-logo-atlas/u);
   assert.match(textureTarget, /--csscloth-logo-atlas-size/u);


### PR DESCRIPTION
Remove the adapter-level CSS corner-shape capability veto so Firefox can run the retained cloth playback with PolyCSS triangle leaves.

Verified:
- Firefox reaches ready state with 200 retained cloth leaves
- animation advances with no page or console errors
- cloth shell regression test passes