### PR TITLE
perf(cloth): compress lighting atlas as WebP

### DIFF
--- a/src/adapters/cloth/prepared-bank.lock.json
+++ b/src/adapters/cloth/prepared-bank.lock.json
@@ -1,10 +1,10 @@
 {
   "schema": "csscloth-prepared-bank-lock@2",
-  "tag": "csscloth-product-bank-v5",
-  "asset": "csscloth-product-bank-v5.tar.gz",
-  "url": "https://github.com/layoutit/cssGraphics/releases/download/csscloth-product-bank-v5/csscloth-product-bank-v5.tar.gz",
-  "archiveByteLength": 4930433,
-  "archiveSha256": "c065f50d70a19fd720673d44522e6514264c07fec98a9d6bb3e3345f1eb8a950",
+  "tag": "csscloth-product-bank-v6",
+  "asset": "csscloth-product-bank-v6.tar.gz",
+  "url": "https://github.com/layoutit/cssGraphics/releases/download/csscloth-product-bank-v6/csscloth-product-bank-v6.tar.gz",
+  "archiveByteLength": 3608667,
+  "archiveSha256": "27e8a3a10924123a96701b1dcc19a82ceb281c04090e9964e85e260a9221fd69",
   "bankCount": 8,
   "bankFrameCount": 1440,
   "durationMilliseconds": 192000,
@@ -12,6 +12,6 @@
   "mobileRetainedLeafCount": 158,
   "mobileClothTriangleCount": 72,
   "fileCount": 32,
-  "closureBytes": 6380302,
-  "closureSha256": "849d8f4d5ed48e2814f9560e4342543fc0be06941896286efd58ab8048a361cc"
+  "closureBytes": 5044091,
+  "closureSha256": "9f9b94921c51cc8a015a58740a025afaa0a458c8f69170b86d65e7899a816ce7"
 }

--- a/src/adapters/cloth/src/csscloth/client.mjs
+++ b/src/adapters/cloth/src/csscloth/client.mjs
@@ -26,7 +26,7 @@ const CLOTH_PREPARED_PROFILES = Object.freeze({
   }),
 });
 const CLOTH_PACKAGE_RESOURCE_PATHS = Object.freeze([
-  "assets/cloth-0.png",
+  "assets/cloth-0.webp",
   "assets/cloth-logo-0.png",
   "assets/ground.avif",
   "assets/shadow.png",

--- a/src/adapters/cloth/src/prepare/csscloth/rasterAtlas.mjs
+++ b/src/adapters/cloth/src/prepare/csscloth/rasterAtlas.mjs
@@ -34,7 +34,7 @@ const CSS_PURPLE = Object.freeze([0x66, 0x33, 0x99]);
 const CSS_WHITE = Object.freeze([0xff, 0xff, 0xff]);
 
 export function clothRasterPagePath(pageIndex) {
-  return `assets/cloth-${pageIndex}.png`;
+  return `assets/cloth-${pageIndex}.webp`;
 }
 
 export function clothLogoRasterPagePath(pageIndex) {
@@ -212,7 +212,7 @@ export async function buildClothRasterPages({
       triangles,
     );
     const [clothPages, clothLogoPages] = await Promise.all([
-      Promise.all(separated.pages.map(encodeOpaqueRgbPng)),
+      Promise.all(separated.pages.map(encodeOpaqueRgbWebp)),
       Promise.all(separated.logoPages.map(encodeRgbaPng)),
     ]);
     return Object.freeze({
@@ -234,8 +234,8 @@ export async function buildClothRasterPages({
   );
   const encodedClothPages = await Promise.all(clothPages.map((page) => (
     backingColor
-      ? encodeRgbaPng(buildLightingOverlayPage(page, backingColor))
-      : encodeOpaqueRgbPng(page)
+      ? encodeRgbaWebp(buildLightingOverlayPage(page, backingColor))
+      : encodeOpaqueRgbWebp(page)
   )));
   return Object.freeze({
     clothPages: Object.freeze(encodedClothPages),
@@ -1158,9 +1158,15 @@ function encodeRgbaPng(image) {
     .toBuffer();
 }
 
-function encodeOpaqueRgbPng(image) {
+function encodeRgbaWebp(image) {
+  return sharp(image.data, { raw: { width: image.width, height: image.height, channels: 4 } })
+    .webp({ lossless: true, quality: 100, effort: 6 })
+    .toBuffer();
+}
+
+function encodeOpaqueRgbWebp(image) {
   return sharp(image.data, { raw: { width: image.width, height: image.height, channels: 4 } })
     .removeAlpha()
-    .png({ compressionLevel: 9, adaptiveFiltering: false, palette: false })
+    .webp({ lossless: true, quality: 100, effort: 6 })
     .toBuffer();
 }

--- a/src/adapters/cloth/src/shared/csscloth/morphTexturePatch.mjs
+++ b/src/adapters/cloth/src/shared/csscloth/morphTexturePatch.mjs
@@ -19,7 +19,7 @@ export function createPolyMorphPreparedCornerTextureTarget(
   }
   const resource = resources.get(resourcePath);
   if (!resource) throw new Error(`Cloth prepared atlas is missing: ${resourcePath}`);
-  const logoResourcePath = resourcePath.replace(/\/cloth-(\d+)\.png$/u, "/cloth-logo-$1.png");
+  const logoResourcePath = resourcePath.replace(/\/cloth-(\d+)\.webp$/u, "/cloth-logo-$1.png");
   const logoResource = resources.get(logoResourcePath);
   if (!logoResource) throw new Error(`Cloth prepared logo atlas is missing: ${logoResourcePath}`);
   const url = URL.createObjectURL(new Blob([resource.bytes], { type: resource.descriptor.mediaType }));

--- a/src/adapters/cloth/tools/prepare-csscloth.mjs
+++ b/src/adapters/cloth/tools/prepare-csscloth.mjs
@@ -66,7 +66,7 @@ async function prepareProfile(profile, profileRoot, publicRoot) {
     ...raster.clothPages.map((bytes, index) => ({
       path: clothRasterPagePath(index),
       role: "image",
-      mediaType: "image/png",
+      mediaType: "image/webp",
       bytes,
     })),
     ...raster.clothLogoPages.map((bytes, index) => ({


### PR DESCRIPTION
## Summary
- encode the desktop and mobile lighting atlases as exact lossless WebP
- keep the separate logo atlas, grass, shadows, retained DOM, and playback unchanged
- publish and bind csscloth product bank v6

## Payload
- desktop lighting atlas: 1,484,833 -> 780,494 bytes (-47.4%)
- mobile lighting atlas: 1,376,152 -> 744,006 bytes (-45.9%)
- product-bank archive: 4,930,433 -> 3,608,667 bytes

## Verification
- decoded RGB is byte-identical in Sharp, Chromium, Firefox, and WebKit
- `pnpm test:cloth` (20/20)
- `pnpm build:cloth:deploy`
- production-layout browser smoke: ready, no errors, stable retained DOM, no lighting PNG request