### PR TITLE
fix(cyclone): balance prepared palette energy

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -8,12 +8,21 @@ desktop leaves or 996 mobile leaves. The
 selected profile plays 24 source-continuous logical chunks of 540 prepared
 16.667 ms
 transform states. The stream is transported as 216 one-second prepared blocks
-so decompression stays outside long animation frames. Source fixed-function
-lighting is sampled once per face at the first published frame into prepared
-opaque CSS colors. Exact cross-palette color tuples are deduplicated into a
-compact prepared slot table. Initial leaf colors are bound once. Later color
-writes are limited to the six leaves of a particle when the source restarts it
-with a new color. The mounted graph is camera, scene, particle roots, and leaves; the
+so decompression stays outside long animation frames. The source fixed-function
+light is sampled at each particle's original smooth vertex normals in the first
+published frame, then the three lit vertex colors of every triangle are averaged
+into one prepared opaque CSS face color. For every source-lit face state, the
+brightest result across the twelve hue rotations sets the shared sRGB energy.
+Every dimmer rotation is first exposed without changing hue or saturation. Only
+colors that reach the sRGB gamut ceiling before that shared target is met mix
+toward neutral by the minimum remaining amount. The energetic rotation is never
+dimmed.
+A preparation guard rejects banks whose final lit palette becomes predominantly
+dark or falls below that shared cross-rotation energy. Exact cross-palette color tuples
+are deduplicated into a compact prepared slot table. Initial leaf colors are
+bound once. Later color writes are limited to the six leaves of a particle when
+the source restarts it with a new color. The mounted graph is camera, scene,
+particle roots, and leaves; the
 PolyCSS Morph model wrapper is removed after adoption and its fixed transform is
 composed onto the existing scene node.
 There is no Canvas, SVG, WebGL, runtime random walk, geometry construction,
@@ -21,20 +30,18 @@ lighting calculation, color calculation, matrix formatting, image decode, atlas
 rasterization, or DOM growth.
 The prepared presentation maps the source's random saturation samples into a
 0.55-1.0 range and lifts the dark end of prepared HSV value to 0.75. The
-source's uniform random hue-target timing and its rule that
-particles change color only when they restart are preserved. At preparation,
-each source hue is assigned to one of three slots in the selected session palette.
-Five prepared solid-color variants provide blue-, yellow-, red-, magenta-,
-and green-centered palettes; each variant spans at most three adjacent hue
-families for the entire playback. The browser selects one prepared color table
-and performs no color calculation. The same source RNG draws preserve RNG cadence,
-trajectory geometry, restart timing, and coherent color bands, but prepared hue values are
-intentionally quantized and low lightness is intentionally lifted; these are not
-exact source colors.
+source's continuous hues, uniform random hue-target timing, and rule that
+particles change color only when they restart are preserved. Twelve prepared
+solid-color variants rotate every source hue by a fixed 30-degree step. The
+browser selects one complete prepared color table and performs no color
+calculation. The same source RNG draws preserve RNG cadence, trajectory geometry,
+restart timing, and coherent color bands. The session rotation and shared
+cross-rotation energy normalization are intentional presentation changes; they
+are not exact source colors.
 Startup is prebaked to ten audited 48-frame source windows. The selector gives
-each of the five prepared palette variants—blue, yellow, red, magenta, and
-green—exactly once per session-shuffled cycle before any family repeats, then
-chooses between two expressive browser-reviewed source windows in that family.
+each of the twelve hue rotations exactly once per session-shuffled cycle before
+any rotation repeats, then independently chooses one expressive browser-reviewed
+source window while excluding the previous exact window.
 It never phases individual particles around a full hue wheel. This is an
 intentional presentation rather than an exact native-color or random-start
 claim. Mobile/coarse-pointer devices and viewports below 600px select the
@@ -49,7 +56,7 @@ the reduced particle budget into tighter cyclone bands without runtime layout.
 
 The stream discards the source's dark startup by preparing 12 seconds before its
 first published frame. Its 12,960 states cover 216 seconds before repeating.
-Startup uses `crypto.getRandomValues` to shuffle the five-family session bag and
+Startup uses `crypto.getRandomValues` to shuffle the twelve-rotation session bag and
 to select an audited source window and frame, excluding the previous exact
 window. Playback
 then follows the original source order. Each hash-bound
@@ -85,8 +92,8 @@ pnpm dev:cyclone
 ```
 
 The retained-DOM route is publication-qualified within its documented PolyCSS
-constraints. The first published frame qualifies the prepared flat-face light
-field. During motion the face shading stays attached to each particle
+constraints. The first published frame qualifies the prepared source-vertex-
+averaged solid-face light field. During motion the face shading stays attached to each particle
 while source color restarts remain exact; this is an intentional performance
 adaptation. The complete dense scene is not claimed to be pixel-identical to
 OpenGL because OpenGL resolves intersecting particles with a per-fragment depth

--- a/src/adapters/cyclone/src/csscyclone/client.mjs
+++ b/src/adapters/cyclone/src/csscyclone/client.mjs
@@ -12,7 +12,7 @@ import {
   CSSCYCLONE_PREPARED_PROFILES,
   selectCyclonePreparedProfile,
 } from "./profileSelection.mjs";
-import { selectCycloneStartupPaletteFamily } from "./startupPaletteSelection.mjs";
+import { selectCycloneStartupPaletteVariant } from "./startupPaletteSelection.mjs";
 
 const LAST_START_SELECTION_STORAGE_KEY = "csscyclone:last-start-selection";
 
@@ -50,18 +50,19 @@ export async function mountCycloneClient(host) {
         profile.presentation?.preparedStream?.id !== catalog.streamId ||
         profile.playback?.chunkCount !== catalog.chunkCount ||
         profile.playback?.preparedBlockCount !== catalog.blockCount ||
-        profile.lighting?.maximumColorFamilyCount !== catalog.maximumColorFamilyCount ||
-        profile.lighting?.paletteFamilies?.some((family, index) =>
-          family !== catalog.startupPaletteFamilies[index])) {
+        !Array.isArray(profile.lighting?.paletteVariantIds) ||
+        profile.lighting.paletteVariantIds.length !== catalog.startupPaletteVariantIds.length ||
+        profile.lighting.paletteVariantIds.some((variantId, index) =>
+          variantId !== catalog.startupPaletteVariantIds[index])) {
       throw new Error("Cyclone prepared model binding drifted");
     }
     const route = new URLSearchParams(globalThis.location?.search ?? "");
     const paletteSelection = route.has("chunk") || route.has("frame")
       ? null
-      : selectCycloneStartupPaletteFamily(catalog.startupPaletteFamilies);
+      : selectCycloneStartupPaletteVariant(catalog.startupPaletteVariantIds);
     const selection = selectInitialCyclonePosition(catalog, {
       previousSelectionId: readPreviousStartSelection(catalog.startupSelections),
-      preferredPaletteFamily: paletteSelection?.paletteFamily ?? null,
+      preferredPaletteVariantId: paletteSelection?.paletteVariantId ?? null,
     });
     rememberStartSelection(selection.selectionId);
     const initialStreamFrameIndex = selection.chunkIndex * catalog.chunkFrameCount + selection.frameIndex;
@@ -82,7 +83,7 @@ export async function mountCycloneClient(host) {
       blockLoader.load(initialBlockIndex, { offMainThread: true }),
       Promise.all(startupLookaheadBlockIndices.map((streamBlockIndex) =>
         blockLoader.load(streamBlockIndex, { offMainThread: true }))),
-      loadCyclonePreparedLightingColors(profile.lighting, selection.paletteFamily),
+      loadCyclonePreparedLightingColors(profile.lighting, selection.paletteVariantId),
       blockLoader.prime(residentBlockIndices),
     ]);
     lightingColors = loadedLightingColors;
@@ -204,7 +205,8 @@ function installDebugApi(state) {
           initialChunkIndex: state.selection.chunkIndex,
           initialFrameIndex: state.selection.frameIndex,
           startupSelectionId: state.selection.selectionId ?? null,
-          startupPaletteFamily: state.selection.paletteFamily ?? null,
+          startupPaletteVariantId: state.selection.paletteVariantId ?? null,
+          startupSourcePaletteFamily: state.selection.sourcePaletteFamily ?? null,
           startupSelectionMode: state.selection.mode,
           ...state.blockLoader.stats(),
           ...state.player.stats(),

--- a/src/adapters/cyclone/src/csscyclone/preparedLightingColors.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedLightingColors.mjs
@@ -1,17 +1,17 @@
-export function loadCyclonePreparedLightingColors(lighting, paletteFamily) {
-  const variant = lighting?.variants?.find((entry) => entry?.paletteFamily === paletteFamily);
-  if (lighting?.schema !== "csscyclone-prepared-flat-lighting-colors@9" ||
-      lighting.maximumColorFamilyCount !== 3 ||
-      lighting.paletteHueSlotCount !== 3 ||
+export async function loadCyclonePreparedLightingColors(lighting, paletteVariantId) {
+  const variant = lighting?.variants?.find((entry) => entry?.paletteVariantId === paletteVariantId);
+  if (lighting?.schema !== "csscyclone-prepared-energy-balanced-continuous-hue-vertex-lighting-colors@15" ||
       lighting.preparedMinimumSaturation !== 0.55 ||
       lighting.preparedMinimumValue !== 0.75 ||
-      !Array.isArray(lighting.paletteFamilies) ||
-      !lighting.paletteFamilies.includes(paletteFamily) ||
-      lighting.variants?.length !== lighting.paletteFamilies.length ||
-      variant?.hueSlots?.length !== lighting.maximumColorFamilyCount ||
-      !Array.isArray(variant?.colors) ||
-      variant.colors.length !== lighting.uniqueColorCount ||
-      variant.colors.some((color) => !/^#[a-f0-9]{6}$/u.test(color)) ||
+      !isFinalLitColorProfileValid(lighting.finalLitColorProfile, lighting.paletteVariantIds) ||
+      !Array.isArray(lighting.paletteVariantIds) ||
+      lighting.paletteVariantCount !== lighting.paletteVariantIds.length ||
+      !lighting.paletteVariantIds.includes(paletteVariantId) ||
+      lighting.variants?.length !== lighting.paletteVariantIds.length ||
+      typeof variant?.hueRotation !== "number" ||
+      typeof variant?.assetUrl !== "string" ||
+      !Number.isSafeInteger(variant?.byteLength) || variant.byteLength < 1 ||
+      !/^[a-f0-9]{64}$/u.test(variant?.sha256 ?? "") ||
       !Number.isSafeInteger(lighting.colorEntryCount) || lighting.colorEntryCount < 1 ||
       !Number.isSafeInteger(lighting.uniqueColorCount) || lighting.uniqueColorCount < 1 ||
       lighting.uniqueColorCount > lighting.colorEntryCount ||
@@ -32,13 +32,65 @@ export function loadCyclonePreparedLightingColors(lighting, paletteFamily) {
   if (colorSlotIndices.some((slotIndex) => slotIndex >= lighting.uniqueColorCount)) {
     throw new Error("Prepared Cyclone lighting color slot drifted");
   }
+  const bytes = new Uint8Array(await fetchBytes(variant.assetUrl));
+  await verifyBytes(bytes, variant.byteLength, variant.sha256);
+  const preparedVariant = JSON.parse(new TextDecoder().decode(bytes));
+  if (preparedVariant?.schema !== "csscyclone-prepared-lighting-color-variant@1" ||
+      preparedVariant.streamId !== lighting.streamId ||
+      preparedVariant.paletteVariantId !== paletteVariantId ||
+      preparedVariant.hueRotation !== variant.hueRotation ||
+      preparedVariant.uniqueColorCount !== lighting.uniqueColorCount ||
+      !Array.isArray(preparedVariant.colors) ||
+      preparedVariant.colors.length !== lighting.uniqueColorCount ||
+      preparedVariant.colors.some((color) => !/^#[a-f0-9]{6}$/u.test(color))) {
+    throw new Error("Prepared Cyclone lighting color variant is invalid");
+  }
   return Object.freeze({
-    paletteFamily,
-    hueSlots: variant.hueSlots,
-    colors: variant.colors,
+    paletteVariantId,
+    hueRotation: variant.hueRotation,
+    colors: Object.freeze(preparedVariant.colors),
     colorSlotIndices,
     destroy() {},
   });
+}
+
+async function fetchBytes(url) {
+  const response = await fetch(url, { cache: "force-cache" });
+  if (!response.ok) {
+    throw new Error(`Prepared Cyclone lighting color asset failed: ${response.status} ${url}`);
+  }
+  return response.arrayBuffer();
+}
+
+async function verifyBytes(bytes, expectedLength, expectedSha256) {
+  if (bytes.byteLength !== expectedLength) {
+    throw new Error("Prepared Cyclone lighting color asset byte length drifted");
+  }
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+  const actualSha256 = [...digest]
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+  if (actualSha256 !== expectedSha256) {
+    throw new Error("Prepared Cyclone lighting color asset hash drifted");
+  }
+}
+
+function isFinalLitColorProfileValid(profile, paletteVariantIds) {
+  return profile?.schema === "csscyclone-prepared-final-lit-color-profile@1" &&
+    profile.darkFaceValueThreshold === 0.4 &&
+    profile.maximumDarkFaceShare === 0.25 &&
+    profile.minimumMedianLitValue === 0.5 &&
+    profile.minimumCrossVariantEnergyRatio === 1 &&
+    profile.srgbLumaWeights?.length === 3 &&
+    profile.srgbLumaWeights.every((value, index) =>
+      value === [0.2126, 0.7152, 0.0722][index]) &&
+    profile.variants?.length === paletteVariantIds?.length &&
+    profile.variants.every((variant, index) =>
+      variant?.paletteVariantId === paletteVariantIds[index] &&
+      variant.medianLitValue >= profile.minimumMedianLitValue &&
+      variant.darkFaceShare <= profile.maximumDarkFaceShare &&
+      variant.minimumCrossVariantEnergyRatio >=
+        profile.minimumCrossVariantEnergyRatio);
 }
 
 function decodeColorSlotIndices(encoded, bytesPerIndex, count) {

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -7,7 +7,7 @@ import {
 
 const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@3";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@2";
-const LIGHTING_SCHEMA = "csscyclone-prepared-flat-lighting-colors@9";
+const LIGHTING_SCHEMA = "csscyclone-prepared-energy-balanced-continuous-hue-vertex-lighting-colors@15";
 const SOURCE_FIELD_OF_VIEW_DEGREES = 80;
 const MOBILE_FIELD_OF_VIEW_DEGREES = 90;
 const MOBILE_MAX_WIDTH = 600;
@@ -369,8 +369,8 @@ export function createCyclonePreparedPlayer({
       preparedContinuousHandoffCount,
       preparedTerminalWrapCount,
       preparedLightingColorSlotCount: lightingColors.colors.length,
-      preparedLightingPaletteFamily: lightingColors.paletteFamily,
-      preparedLightingMaximumColorFamilyCount: lighting.maximumColorFamilyCount,
+      preparedLightingPaletteVariantId: lightingColors.paletteVariantId,
+      preparedLightingPaletteVariantCount: lighting.paletteVariantCount,
       preparedLightingColorStateCount: lighting.colorStateCount,
       preparedLightingColorRestartCount: lighting.colorRestartCount,
       runtimeGeometryConstructionCount: 0,
@@ -418,7 +418,7 @@ function validateBinding(
   loadBlock,
 ) {
   const lightingVariant = lighting?.variants?.find((variant) =>
-    variant?.paletteFamily === lightingColors?.paletteFamily);
+    variant?.paletteVariantId === lightingColors?.paletteVariantId);
   if (modelTransform !== STYLESHEET_MODEL_TRANSFORM ||
       catalog?.schema !== CATALOG_SCHEMA ||
       catalog.blockCount !== catalog.entries?.length ||
@@ -444,10 +444,8 @@ function validateBinding(
       lighting.facesPerParticle * mounted.model.render.shapes.length !== lighting.leafCount ||
       lighting.colorSlotIndexCount !== lighting.colorEntryCount ||
       lighting.colorEntryCount !== lighting.colorStateCount * lighting.facesPerParticle ||
-      lighting.maximumColorFamilyCount !== 3 ||
-      lighting.paletteHueSlotCount !== 3 ||
-      lightingColors?.hueSlots?.length !== lighting.maximumColorFamilyCount ||
-      lightingColors?.colors !== lightingVariant?.colors ||
+      !lightingVariant ||
+      lightingColors?.colors?.length !== lighting.uniqueColorCount ||
       lightingColors?.colorSlotIndices?.length !== lighting.colorEntryCount ||
       lighting.runtime?.lightingCalculations !== 0 ||
       lighting.runtime?.imageConstruction !== 0 ||

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -13,8 +13,10 @@ const RUNTIME_MATERIALIZED_LOOKAHEAD_BLOCK_COUNT = 2;
 const STARTUP_MATERIALIZED_LOOKAHEAD_BLOCK_COUNT = 2;
 const STARTUP_HUE_SECTOR_NAMES = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
 const STARTUP_PALETTE_FAMILIES = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
+const STARTUP_PALETTE_VARIANT_IDS = Object.freeze(Array.from({ length: 12 }, (_, index) =>
+  `rotate-${String(index * 30).padStart(3, "0")}`));
 const STARTUP_SILHOUETTE_SAMPLING = "browser-reviewed-expressive-source-windows";
-const STARTUP_SELECTION = "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat";
+const STARTUP_SELECTION = "session-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat";
 
 export async function loadCyclonePreparedCatalog(descriptor) {
   if (typeof descriptor?.catalogUrl !== "string" ||
@@ -32,57 +34,57 @@ export async function loadCyclonePreparedCatalog(descriptor) {
 export function selectInitialCyclonePosition(catalog, {
   search = globalThis.location?.search ?? "",
   previousSelectionId = null,
-  preferredPaletteFamily = null,
+  preferredPaletteVariantId = null,
   randomUint32Pair = cryptoRandomUint32Pair,
 } = {}) {
   validateCatalog(catalog);
   const params = new URLSearchParams(search);
   const requestedChunk = params.get("chunk");
   const requestedFrame = params.get("frame");
-  const requestedPaletteFamily = params.get("palette");
+  const requestedPaletteVariantId = params.get("palette");
   if (requestedChunk !== null || requestedFrame !== null) {
     const chunkIndex = requestedChunk === null ? 0 : Number(requestedChunk);
     const frameIndex = requestedFrame === null ? 0 : Number(requestedFrame);
-    const paletteFamily = requestedPaletteFamily ?? catalog.startupPaletteFamilies[0];
+    const paletteVariantId = requestedPaletteVariantId ?? catalog.startupPaletteVariantIds[0];
     validatePosition(catalog, chunkIndex, frameIndex);
-    if (!catalog.startupPaletteFamilies.includes(paletteFamily)) {
-      throw new RangeError("Requested Cyclone palette family is invalid");
+    if (!catalog.startupPaletteVariantIds.includes(paletteVariantId)) {
+      throw new RangeError("Requested Cyclone palette variant is invalid");
     }
-    return Object.freeze({ paletteFamily, chunkIndex, frameIndex, mode: "explicit" });
+    return Object.freeze({ paletteVariantId, chunkIndex, frameIndex, mode: "explicit" });
   }
   if (previousSelectionId !== null &&
       (typeof previousSelectionId !== "string" ||
         !catalog.startupSelections.some((selection) => selection.id === previousSelectionId))) {
     throw new RangeError("Previous Cyclone start selection is invalid");
   }
-  if (preferredPaletteFamily !== null &&
-      !catalog.startupPaletteFamilies.includes(preferredPaletteFamily)) {
-    throw new RangeError("Preferred Cyclone palette family is invalid");
+  if (preferredPaletteVariantId !== null &&
+      !catalog.startupPaletteVariantIds.includes(preferredPaletteVariantId)) {
+    throw new RangeError("Preferred Cyclone palette variant is invalid");
   }
   const values = randomUint32Pair();
   if (!Array.isArray(values) || values.length !== 2 ||
       values.some((value) => !Number.isSafeInteger(value) || value < 0 || value > 0xffffffff)) {
     throw new RangeError("Cyclone startup random values must be two uint32 values");
   }
-  const paletteFamilyIndex = values[0] % catalog.startupPaletteFamilies.length;
-  const paletteFamily = preferredPaletteFamily ?? catalog.startupPaletteFamilies[paletteFamilyIndex];
-  const familySelections = catalog.startupSelections.filter((selection) =>
-    selection.paletteFamily === paletteFamily);
-  let selectionIndex = (preferredPaletteFamily === null
-    ? Math.floor(values[0] / catalog.startupPaletteFamilies.length)
-    : values[0]) % familySelections.length;
-  if (familySelections[selectionIndex].id === previousSelectionId && familySelections.length > 1) {
-    selectionIndex = (selectionIndex + 1) % familySelections.length;
+  const paletteVariantId = preferredPaletteVariantId ??
+    catalog.startupPaletteVariantIds[values[0] % catalog.startupPaletteVariantIds.length];
+  let selectionIndex = (preferredPaletteVariantId === null
+    ? Math.floor(values[0] / catalog.startupPaletteVariantIds.length)
+    : values[0]) % catalog.startupSelections.length;
+  if (catalog.startupSelections[selectionIndex].id === previousSelectionId &&
+      catalog.startupSelections.length > 1) {
+    selectionIndex = (selectionIndex + 1) % catalog.startupSelections.length;
   }
-  const selection = familySelections[selectionIndex];
+  const selection = catalog.startupSelections[selectionIndex];
   const frameIndex = selection.startFrameIndex + values[1] % selection.frameCount;
   return Object.freeze({
     selectionId: selection.id,
-    paletteFamily,
+    paletteVariantId,
+    sourcePaletteFamily: selection.paletteFamily,
     chunkIndex: selection.chunkIndex,
     frameIndex,
-    mode: preferredPaletteFamily !== null
-      ? "session-shuffled-palette-crypto-random-source-window"
+    mode: preferredPaletteVariantId !== null
+      ? "session-shuffled-hue-rotation-crypto-random-source-window"
       : previousSelectionId === null
       ? "crypto-random-balanced-source-palette"
       : "crypto-random-balanced-source-palette-no-repeat",
@@ -628,6 +630,10 @@ function validateCatalog(catalog) {
       catalog.startupPaletteFamilies.length !== STARTUP_PALETTE_FAMILIES.length ||
       catalog.startupPaletteFamilies.some((family, index) =>
         family !== STARTUP_PALETTE_FAMILIES[index]) ||
+      !Array.isArray(catalog.startupPaletteVariantIds) ||
+      catalog.startupPaletteVariantIds.length !== STARTUP_PALETTE_VARIANT_IDS.length ||
+      catalog.startupPaletteVariantIds.some((variantId, index) =>
+        variantId !== STARTUP_PALETTE_VARIANT_IDS[index]) ||
       !Array.isArray(catalog.startupSelections) || catalog.startupSelections.length < 2 ||
       new Set(catalog.startupSelections.map((selection) => selection?.id)).size !==
         catalog.startupSelections.length ||

--- a/src/adapters/cyclone/src/csscyclone/startupPaletteSelection.mjs
+++ b/src/adapters/cyclone/src/csscyclone/startupPaletteSelection.mjs
@@ -1,21 +1,21 @@
-const STORAGE_KEY = "csscyclone:startup-palette-shuffle@1";
-const STORAGE_SCHEMA = "csscyclone-startup-palette-shuffle@1";
+const STORAGE_KEY = "csscyclone:startup-palette-variant-shuffle@2";
+const STORAGE_SCHEMA = "csscyclone-startup-palette-variant-shuffle@2";
 
-export function selectCycloneStartupPaletteFamily(paletteFamilies, options = {}) {
-  const families = [...(paletteFamilies ?? [])];
-  if (families.length < 2 || new Set(families).size !== families.length ||
-      families.some((family) => typeof family !== "string" || family.length < 1)) {
-    throw new Error("Cyclone startup palette shuffle requires distinct prepared families");
+export function selectCycloneStartupPaletteVariant(paletteVariantIds, options = {}) {
+  const variantIds = [...(paletteVariantIds ?? [])];
+  if (variantIds.length < 2 || new Set(variantIds).size !== variantIds.length ||
+      variantIds.some((variantId) => typeof variantId !== "string" || variantId.length < 1)) {
+    throw new Error("Cyclone startup palette shuffle requires distinct prepared variants");
   }
-  const signature = families.join("\n");
+  const signature = variantIds.join("\n");
   const storage = options.storage ?? safeSessionStorage();
   const randomUint32 = options.randomUint32 ?? cryptoRandomUint32;
-  const restored = readState(storage, signature, families);
-  let remaining = restored?.remainingPaletteFamilies ?? [];
-  const lastPaletteFamily = restored?.lastPaletteFamily ?? null;
+  const restored = readState(storage, signature, variantIds);
+  let remaining = restored?.remainingPaletteVariantIds ?? [];
+  const lastPaletteVariantId = restored?.lastPaletteVariantId ?? null;
 
   if (remaining.length === 0) {
-    remaining = [...families];
+    remaining = [...variantIds];
     for (let index = remaining.length - 1; index > 0; index -= 1) {
       const value = randomUint32();
       if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
@@ -24,44 +24,45 @@ export function selectCycloneStartupPaletteFamily(paletteFamilies, options = {})
       const swapIndex = value % (index + 1);
       [remaining[index], remaining[swapIndex]] = [remaining[swapIndex], remaining[index]];
     }
-    if (lastPaletteFamily && remaining.at(-1) === lastPaletteFamily) {
+    if (lastPaletteVariantId && remaining.at(-1) === lastPaletteVariantId) {
       [remaining[0], remaining[remaining.length - 1]] =
         [remaining[remaining.length - 1], remaining[0]];
     }
   }
 
-  const paletteFamily = remaining.pop();
-  if (!paletteFamily || paletteFamily === lastPaletteFamily) {
-    throw new Error("Cyclone startup palette shuffle repeated its previous family");
+  const paletteVariantId = remaining.pop();
+  if (!paletteVariantId || paletteVariantId === lastPaletteVariantId) {
+    throw new Error("Cyclone startup palette shuffle repeated its previous variant");
   }
   writeState(storage, {
     schema: STORAGE_SCHEMA,
     paletteSignature: signature,
-    lastPaletteFamily: paletteFamily,
-    remainingPaletteFamilies: remaining,
+    lastPaletteVariantId: paletteVariantId,
+    remainingPaletteVariantIds: remaining,
   });
   return Object.freeze({
-    paletteFamily,
-    remainingPaletteFamilyCount: remaining.length,
+    paletteVariantId,
+    remainingPaletteVariantCount: remaining.length,
     sessionPersistence: Boolean(storage),
   });
 }
 
-function readState(storage, signature, families) {
+function readState(storage, signature, variantIds) {
   if (!storage) return null;
   try {
     const value = JSON.parse(storage.getItem(STORAGE_KEY));
-    const remaining = value?.remainingPaletteFamilies;
-    const allowed = new Set(families);
+    const remaining = value?.remainingPaletteVariantIds;
+    const allowed = new Set(variantIds);
     if (value?.schema !== STORAGE_SCHEMA || value.paletteSignature !== signature ||
-        (value.lastPaletteFamily !== null && !allowed.has(value.lastPaletteFamily)) ||
+        (value.lastPaletteVariantId !== null && !allowed.has(value.lastPaletteVariantId)) ||
         !Array.isArray(remaining) || new Set(remaining).size !== remaining.length ||
-        remaining.some((family) => !allowed.has(family) || family === value.lastPaletteFamily)) {
+        remaining.some((variantId) =>
+          !allowed.has(variantId) || variantId === value.lastPaletteVariantId)) {
       return null;
     }
     return Object.freeze({
-      lastPaletteFamily: value.lastPaletteFamily,
-      remainingPaletteFamilies: [...remaining],
+      lastPaletteVariantId: value.lastPaletteVariantId,
+      remainingPaletteVariantIds: [...remaining],
     });
   } catch {
     return null;

--- a/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/modelBuilder.mjs
@@ -48,10 +48,6 @@ const CSSCYCLONE_FACE_PLANS = Object.freeze(CSSCYCLONE_FACE_INDICES.map((localIn
 export const CSSCYCLONE_FACE_TILE_VERTEX_ORDERS = Object.freeze(
   CSSCYCLONE_FACE_PLANS.map(({ tileVertexOrder }) => tileVertexOrder),
 );
-export const CSSCYCLONE_FACE_NORMALS = Object.freeze(
-  CSSCYCLONE_FACE_PLANS.map(({ matrix }) => Object.freeze(matrix.slice(8, 11))),
-);
-
 export function buildCyclonePreparedModel({
   source = buildCycloneSourceSequence(),
   modelId = CSSCYCLONE_MODEL_ID,

--- a/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
@@ -1,18 +1,19 @@
 import {
   CSSCYCLONE_FACE_INDICES,
-  CSSCYCLONE_FACE_NORMALS,
+  CSSCYCLONE_PARTICLE_VERTICES,
 } from "./modelBuilder.mjs";
 import { CSSCYCLONE_PRESENTATION } from "./sourceModel.mjs";
 
 const PREPARED_MINIMUM_SATURATION = CSSCYCLONE_PRESENTATION.minimumSaturation;
 const PREPARED_MINIMUM_VALUE = 0.75;
-const PALETTE_CENTER_HUES = Object.freeze({
-  blue: 2 / 3,
-  yellow: 1 / 6,
-  red: 0,
-  magenta: 5 / 6,
-  green: 1 / 3,
-});
+const PREPARED_DARK_FACE_VALUE = 0.4;
+const PREPARED_MAXIMUM_DARK_FACE_SHARE = 0.25;
+const PREPARED_MINIMUM_MEDIAN_LIT_VALUE = 0.5;
+const SRGB_LUMA_WEIGHTS = Object.freeze([0.2126, 0.7152, 0.0722]);
+const PREPARED_MINIMUM_CROSS_VARIANT_ENERGY_RATIO = 1;
+const SOURCE_VERTEX_NORMALS = Object.freeze(
+  CSSCYCLONE_PARTICLE_VERTICES.map((vertex) => Object.freeze(normalize(vertex))),
+);
 const LIGHT_DIRECTION = normalize([400, -200, 400]);
 const HALF_VECTOR = normalize([
   LIGHT_DIRECTION[0],
@@ -20,14 +21,16 @@ const HALF_VECTOR = normalize([
   LIGHT_DIRECTION[2] + 1,
 ]);
 
-export function createCyclonePreparedLightingStream() {
+export function createCyclonePreparedLightingStream({
+  enforceFinalColorProfile = true,
+} = {}) {
   let particleCount = null;
   let expectedChunkCount = null;
   let chunkFrameCount = null;
   let streamId = null;
   let nextChunkIndex = 0;
   let sourceStreamFrameCount = 0;
-  let frozenFaceNormals = null;
+  let frozenVertexNormals = null;
   let currentColorStateIndices = null;
   let previousColors = null;
   let colorRestartCount = 0;
@@ -78,7 +81,7 @@ export function createCyclonePreparedLightingStream() {
   }
 
   async function finalize({ allowPartial = false } = {}) {
-    if (particleCount === null || frozenFaceNormals === null || colorStates.length === 0) {
+    if (particleCount === null || frozenVertexNormals === null || colorStates.length === 0) {
       throw new Error("Prepared Cyclone lighting stream has no source chunks");
     }
     if (!allowPartial && nextChunkIndex !== expectedChunkCount) {
@@ -90,9 +93,10 @@ export function createCyclonePreparedLightingStream() {
       chunkFrameCount,
       streamId,
       sourceStreamFrameCount,
-      frozenFaceNormals,
+      frozenVertexNormals,
       colorStates,
       colorRestartCount,
+      enforceFinalColorProfile: enforceFinalColorProfile && !allowPartial,
     });
   }
 
@@ -103,9 +107,9 @@ export function createCyclonePreparedLightingStream() {
     streamId = source.bank.streamId;
     currentColorStateIndices = Array(particleCount).fill(-1);
     previousColors = Array(particleCount).fill(null);
-    frozenFaceNormals = source.frames[0].particles.map((particle) => {
+    frozenVertexNormals = source.frames[0].particles.map((particle) => {
       const normalMatrix = inverseTranspose3(particle.matrix);
-      return CSSCYCLONE_FACE_NORMALS.map((normal) => transform3(normalMatrix, normal));
+      return SOURCE_VERTEX_NORMALS.map((normal) => transform3(normalMatrix, normal));
     });
   }
 
@@ -125,35 +129,64 @@ async function buildPreparedLightingColors({
   chunkFrameCount,
   streamId,
   sourceStreamFrameCount,
-  frozenFaceNormals,
+  frozenVertexNormals,
   colorStates,
   colorRestartCount,
+  enforceFinalColorProfile,
 }) {
   const leafCount = particleCount * CSSCYCLONE_FACE_INDICES.length;
   const tileCount = colorStates.length * CSSCYCLONE_FACE_INDICES.length;
-  if (CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount !== 3 ||
-      CSSCYCLONE_PRESENTATION.maximumColorFamilyCount !== 3 ||
-      CSSCYCLONE_PRESENTATION.startupPaletteFamilies.some((family) =>
-        !Object.hasOwn(PALETTE_CENTER_HUES, family))) {
-    throw new Error("Cyclone prepared three-family palette configuration drifted");
+  const paletteVariants = CSSCYCLONE_PRESENTATION.preparedPaletteVariants;
+  if (!Array.isArray(paletteVariants) || paletteVariants.length !== 12 ||
+      new Set(paletteVariants.map(({ id }) => id)).size !== paletteVariants.length ||
+      paletteVariants.some(({ id, hueRotation }, index) =>
+        id !== `rotate-${String(index * 30).padStart(3, "0")}` ||
+        hueRotation !== index / paletteVariants.length)) {
+    throw new Error("Cyclone prepared hue-rotation palette configuration drifted");
   }
-  const logicalVariants = [];
-  for (const paletteFamily of CSSCYCLONE_PRESENTATION.startupPaletteFamilies) {
-    const hueSlots = preparedPaletteHues(paletteFamily);
+  const sourceLitVariants = paletteVariants.map((paletteVariant) => {
     const colors = [];
     for (let stateIndex = 0; stateIndex < colorStates.length; stateIndex += 1) {
       const state = colorStates[stateIndex];
-      const baseColor = prepareCyclonePaletteColor(state.baseColor, paletteFamily);
+      const baseColor = prepareCyclonePaletteColor(state.baseColor, paletteVariant.id);
+      const vertexColors = frozenVertexNormals[state.particleIndex].map((normal) => shadeVertex({
+        baseColor,
+        normal,
+      }));
       for (let faceIndex = 0; faceIndex < CSSCYCLONE_FACE_INDICES.length; faceIndex += 1) {
-        const faceColor = shadeVertex({
-          baseColor,
-          normal: frozenFaceNormals[state.particleIndex][faceIndex],
-        });
-        colors.push(rgbHex(faceColor));
+        const sourceLitColor = averageVertexColors(
+          vertexColors,
+          CSSCYCLONE_FACE_INDICES[faceIndex],
+        );
+        colors.push(sourceLitColor);
       }
     }
-    logicalVariants.push(Object.freeze({ paletteFamily, hueSlots, colors: Object.freeze(colors) }));
-  }
+    return Object.freeze({
+      paletteVariantId: paletteVariant.id,
+      hueRotation: paletteVariant.hueRotation,
+      colors: Object.freeze(colors),
+    });
+  });
+  const targetEnergies = Object.freeze(sourceLitVariants[0].colors.map((unused, colorIndex) =>
+    Math.max(...sourceLitVariants.map((variant) => srgbLuma(variant.colors[colorIndex])))));
+  const logicalVariants = sourceLitVariants.map((variant) => {
+    const energyRatios = [];
+    const colors = variant.colors.map((color, colorIndex) => {
+      const faceColor = balanceSrgbEnergy(color, targetEnergies[colorIndex]);
+      energyRatios.push(srgbLuma(faceColor) / targetEnergies[colorIndex]);
+      return rgbHex(faceColor);
+    });
+    return Object.freeze({
+      paletteVariantId: variant.paletteVariantId,
+      hueRotation: variant.hueRotation,
+      colors: Object.freeze(colors),
+      energyRatios: Object.freeze(energyRatios),
+    });
+  });
+  const finalLitColorProfile = buildFinalLitColorProfile(
+    logicalVariants,
+    enforceFinalColorProfile,
+  );
   const deduplication = deduplicateExactCrossVariantColors(logicalVariants, tileCount);
   const uniqueColorCount = deduplication.uniqueSourceColorIndices.length;
   const colorSlotIndexBytes = uniqueColorCount <= 0xffff ? 2 : 4;
@@ -162,25 +195,24 @@ async function buildPreparedLightingColors({
     colorSlotIndexBytes,
   );
   const variants = logicalVariants.map((variant) => Object.freeze({
-    paletteFamily: variant.paletteFamily,
-    hueSlots: variant.hueSlots,
+    paletteVariantId: variant.paletteVariantId,
+    hueRotation: variant.hueRotation,
     colors: Object.freeze(deduplication.uniqueSourceColorIndices.map((index) =>
       variant.colors[index])),
   }));
   const contract = deepFreeze({
-    schema: "csscyclone-prepared-flat-lighting-colors@9",
-    technique: "prepared-flat-face-session-three-family-solid-colors-with-dark-color-floor-sparse-source-color-restarts-and-exact-cross-variant-deduplication",
+    schema: "csscyclone-prepared-energy-balanced-continuous-hue-vertex-lighting-colors@15",
+    technique: "prepared-source-smooth-vertex-lighting-averaged-per-solid-face-with-cross-variant-maximum-srgb-energy-balanced-session-hue-rotation-variants-sparse-source-color-restarts-and-exact-cross-variant-deduplication",
     source: "src/cyclone/cyclone.cpp#particle::update+initSaver",
     streamId,
     encoding: "CSS-sRGB-hex-plus-little-endian-color-slot-indices-base64",
     lossless: true,
-    paletteFamilyCount: CSSCYCLONE_PRESENTATION.startupPaletteFamilies.length,
-    paletteFamilies: CSSCYCLONE_PRESENTATION.startupPaletteFamilies,
-    paletteHueSlotCount: CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount,
+    paletteVariantCount: paletteVariants.length,
+    paletteVariantIds: Object.freeze(paletteVariants.map(({ id }) => id)),
     paletteAssignment: CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
     preparedMinimumSaturation: PREPARED_MINIMUM_SATURATION,
     preparedMinimumValue: PREPARED_MINIMUM_VALUE,
-    maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
+    finalLitColorProfile,
     variants: Object.freeze(variants),
     colorEntryCount: tileCount,
     uniqueColorCount,
@@ -205,10 +237,10 @@ async function buildPreparedLightingColors({
     sourceHueTimingExact: true,
     sourceHueValuesExact: false,
     dynamicLightOrientation: false,
-    sampling: "one-prepared-solid-srgb-color-per-face-state",
-    interpolation: "browser-perspective-transformed-stream-frame-zero-flat-face-color",
+    sampling: "three-source-smooth-vertex-light-samples-averaged-per-solid-face-state",
+    interpolation: "browser-solid-face-average-of-stream-frame-zero-source-vertex-lighting",
     material: Object.freeze({
-      ambientAndDiffuse: "prepared-session-three-family-palette-from-source-particle-rgb",
+      ambientAndDiffuse: "prepared-session-hue-rotation-of-source-particle-rgb",
       specular: Object.freeze([0.7, 0.7, 0.7, 1]),
       shininess: 20,
     }),
@@ -295,15 +327,10 @@ function validateSourceChunk(source) {
   }
 }
 
-function preparedPaletteHues(paletteFamily) {
-  const centerHue = PALETTE_CENTER_HUES[paletteFamily];
-  return Object.freeze([-1, 0, 1].map((offset) => {
-    const hue = centerHue + offset / 6;
-    return hue < 0 ? hue + 1 : hue >= 1 ? hue - 1 : hue;
-  }));
-}
-
-export function prepareCyclonePaletteColor(baseColor, paletteFamily) {
+export function prepareCyclonePaletteColor(baseColor, paletteVariantId) {
+  const paletteVariant = CSSCYCLONE_PRESENTATION.preparedPaletteVariants.find(({ id }) =>
+    id === paletteVariantId);
+  if (!paletteVariant) throw new RangeError("Cyclone prepared palette variant is invalid");
   const maximum = Math.max(...baseColor);
   const minimum = Math.min(...baseColor);
   const chroma = maximum - minimum;
@@ -318,12 +345,9 @@ export function prepareCyclonePaletteColor(baseColor, paletteFamily) {
     else hue = (baseColor[0] - baseColor[1]) / chroma + 4;
     hue = (hue / 6 + 1) % 1;
   }
-  const hueSlotIndex = Math.min(
-    CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount - 1,
-    Math.floor(hue * CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount),
-  );
+  const rotatedHue = (hue + paletteVariant.hueRotation) % 1;
   return hsvToRgb(
-    preparedPaletteHues(paletteFamily)[hueSlotIndex],
+    rotatedHue,
     saturation,
     Math.max(PREPARED_MINIMUM_VALUE, maximum),
   );
@@ -357,6 +381,101 @@ function shadeVertex({ baseColor, normal }) {
       baseColor[channel] * diffuse +
       0.7 * specular) * 255,
   ));
+}
+
+function averageVertexColors(vertexColors, vertexIndices) {
+  return [0, 1, 2].map((channel) => clampByte(
+    vertexIndices.reduce((sum, vertexIndex) =>
+      sum + vertexColors[vertexIndex][channel], 0) / vertexIndices.length,
+  ));
+}
+
+function balanceSrgbEnergy(color, targetEnergy) {
+  const sourceValue = Math.max(...color);
+  if (sourceValue === 0) return color;
+  if (srgbLuma(color) >= targetEnergy) return color;
+  const maximumExposure = 255 / sourceValue;
+  const fullyExposed = exposeSrgb(color, maximumExposure);
+  if (srgbLuma(fullyExposed) >= targetEnergy) {
+    const exposure = solveMinimumMix(1, maximumExposure, (candidate) =>
+      srgbLuma(exposeSrgb(color, candidate)) >= targetEnergy);
+    return exposeSrgb(color, exposure);
+  }
+  const exposedValue = Math.max(...fullyExposed);
+  const neutralMix = solveMinimumMix(0, 1, (candidate) =>
+    srgbLuma(mixTowardNeutral(fullyExposed, exposedValue, candidate)) >= targetEnergy);
+  return mixTowardNeutral(fullyExposed, exposedValue, neutralMix);
+}
+
+function exposeSrgb(color, exposure) {
+  return color.map((channel) => Math.min(255, Math.ceil(channel * exposure)));
+}
+
+function mixTowardNeutral(color, neutralValue, mix) {
+  return color.map((channel) => Math.min(
+    neutralValue,
+    Math.ceil(channel + (neutralValue - channel) * mix),
+  ));
+}
+
+function solveMinimumMix(low, high, reachesTarget) {
+  for (let iteration = 0; iteration < 16; iteration += 1) {
+    const middle = (low + high) / 2;
+    if (reachesTarget(middle)) high = middle;
+    else low = middle;
+  }
+  return high;
+}
+
+function buildFinalLitColorProfile(variants, enforce) {
+  const profiles = variants.map((variant) => {
+    const values = variant.colors.map(colorValue).sort((left, right) => left - right);
+    const energyRatios = [...variant.energyRatios]
+      .sort((left, right) => left - right);
+    const darkFaceCount = values.filter((value) => value < PREPARED_DARK_FACE_VALUE).length;
+    return Object.freeze({
+      paletteVariantId: variant.paletteVariantId,
+      medianLitValue: roundMetric(values[Math.floor((values.length - 1) / 2)]),
+      darkFaceShare: roundMetric(darkFaceCount / values.length),
+      minimumCrossVariantEnergyRatio: roundMetric(energyRatios[0]),
+      medianCrossVariantEnergyRatio: roundMetric(
+        energyRatios[Math.floor((energyRatios.length - 1) / 2)],
+      ),
+    });
+  });
+  const invalidProfiles = profiles.filter((profile) =>
+    profile.medianLitValue < PREPARED_MINIMUM_MEDIAN_LIT_VALUE ||
+    profile.darkFaceShare > PREPARED_MAXIMUM_DARK_FACE_SHARE ||
+    profile.minimumCrossVariantEnergyRatio <
+      PREPARED_MINIMUM_CROSS_VARIANT_ENERGY_RATIO);
+  if (enforce && invalidProfiles.length > 0) {
+    throw new Error(`Prepared Cyclone final lit colors are too dark: ${JSON.stringify(invalidProfiles)}`);
+  }
+  return deepFreeze({
+    schema: "csscyclone-prepared-final-lit-color-profile@1",
+    darkFaceValueThreshold: PREPARED_DARK_FACE_VALUE,
+    maximumDarkFaceShare: PREPARED_MAXIMUM_DARK_FACE_SHARE,
+    minimumMedianLitValue: PREPARED_MINIMUM_MEDIAN_LIT_VALUE,
+    srgbLumaWeights: SRGB_LUMA_WEIGHTS,
+    minimumCrossVariantEnergyRatio: PREPARED_MINIMUM_CROSS_VARIANT_ENERGY_RATIO,
+    variants: profiles,
+  });
+}
+
+function colorValue(color) {
+  return Math.max(
+    Number.parseInt(color.slice(1, 3), 16),
+    Number.parseInt(color.slice(3, 5), 16),
+    Number.parseInt(color.slice(5, 7), 16),
+  ) / 255;
+}
+
+function srgbLuma(color) {
+  return dot(color, SRGB_LUMA_WEIGHTS);
+}
+
+function roundMetric(value) {
+  return Number(value.toFixed(6));
 }
 
 function rgbHex(color) {

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -62,14 +62,22 @@ export const CSSCYCLONE_BANKS = Object.freeze({
 
 export const CSSCYCLONE_BANK = CSSCYCLONE_BANKS.desktop;
 
+const PREPARED_PALETTE_VARIANTS = Object.freeze(Array.from({ length: 12 }, (_, index) => {
+  const degrees = index * 30;
+  return Object.freeze({
+    id: `rotate-${String(degrees).padStart(3, "0")}`,
+    hueRotation: index / 12,
+  });
+}));
+
 export const CSSCYCLONE_PRESENTATION = Object.freeze({
   radialOrbitScale: 0.75,
   saturationSampling: "floor-0.55-plus-0.45-sqrt-uniform",
   minimumSaturation: 0.55,
   hueSampling: "source-uniform-random-targets",
   particleColorAssignment: "source-hue-at-particle-restart",
-  preparedPaletteHueSlotCount: 3,
-  preparedPaletteAssignment: "source-hue-quantized-to-session-three-family-variant",
+  preparedPaletteAssignment: "source-continuous-hue-plus-session-prepared-rotation",
+  preparedPaletteVariants: PREPARED_PALETTE_VARIANTS,
   maximumColorFamilyCount: 3,
   startupPaletteFamilies: Object.freeze(["blue", "yellow", "red", "magenta", "green"]),
   startupSelections: Object.freeze([

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -56,7 +56,7 @@ function fixture({
     transforms: ["a", "b", "c", "d", "e", "f", "g", "h"],
   };
   const lighting = {
-    schema: "csscyclone-prepared-flat-lighting-colors@9",
+    schema: "csscyclone-prepared-energy-balanced-continuous-hue-vertex-lighting-colors@15",
     streamId: "stream",
     chunkCount: 1,
     chunkFrameCount: blockCount * 4,
@@ -69,9 +69,8 @@ function fixture({
     deduplicatedColorCount: 0,
     colorDeduplication: "exact-cross-palette-css-srgb-tuples",
     colorSlotIndexCount: 1,
-    paletteHueSlotCount: 3,
-    maximumColorFamilyCount: 3,
-    variants: [{ paletteFamily: "blue", colors: ["#123456"] }],
+    paletteVariantCount: 1,
+    variants: [{ paletteVariantId: "rotate-000", colors: ["#123456"] }],
     runtime: { lightingCalculations: 0, imageConstruction: 0 },
   };
   const blocks = Array.from({ length: blockCount }, (_, streamBlockIndex) => {
@@ -145,8 +144,8 @@ function fixture({
     initialFrameIndex: 0,
     lighting,
     lightingColors: {
-      paletteFamily: "blue",
-      hueSlots: [0.5, 2 / 3, 5 / 6],
+      paletteVariantId: "rotate-000",
+      hueRotation: 0,
       colors: lighting.variants[0].colors,
       colorSlotIndices: new Uint16Array([0]),
       destroy: identity,

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -67,11 +67,15 @@ test("pins the current Really Slick Cyclone source profile", () => {
   assert.equal(CSSCYCLONE_PRESENTATION.minimumSaturation, 0.55);
   assert.equal(CSSCYCLONE_PRESENTATION.hueSampling, "source-uniform-random-targets");
   assert.equal(CSSCYCLONE_PRESENTATION.particleColorAssignment, "source-hue-at-particle-restart");
-  assert.equal(CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount, 3);
   assert.equal(
     CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
-    "source-hue-quantized-to-session-three-family-variant",
+    "source-continuous-hue-plus-session-prepared-rotation",
   );
+  assert.equal(CSSCYCLONE_PRESENTATION.preparedPaletteVariants.length, 12);
+  assert.deepEqual(CSSCYCLONE_PRESENTATION.preparedPaletteVariants[4], {
+    id: "rotate-120",
+    hueRotation: 1 / 3,
+  });
   assert.equal(CSSCYCLONE_PRESENTATION.maximumColorFamilyCount, 3);
   assert.deepEqual(
     CSSCYCLONE_PRESENTATION.startupPaletteFamilies,
@@ -323,11 +327,11 @@ test("round-trips exact prepared matrices through compact source-state blocks", 
   );
 });
 
-test("prepares flat face lighting without a runtime lighting timeline", async () => {
+test("prepares source-vertex-averaged face lighting without a runtime lighting timeline", async () => {
   const bank = { ...CSSCYCLONE_BANK, particleCount: 3, warmupFrames: 20, frameCount: 4 };
   const source = buildCycloneSourceSequence({ bank });
   const prepared = await buildCyclonePreparedLighting({ source });
-  assert.equal(prepared.contract.schema, "csscyclone-prepared-flat-lighting-colors@9");
+  assert.equal(prepared.contract.schema, "csscyclone-prepared-energy-balanced-continuous-hue-vertex-lighting-colors@15");
   assert.equal(prepared.contract.leafCount, 18);
   assert.equal(prepared.contract.colorStateCount, 3);
   assert.equal(prepared.contract.colorRestartCount, 0);
@@ -341,13 +345,37 @@ test("prepares flat face lighting without a runtime lighting timeline", async ()
   assert.equal(prepared.contract.colorSlotIndexCount, 18);
   assert.ok([2, 4].includes(prepared.contract.colorSlotIndexBytes));
   assert.ok(prepared.contract.colorSlotIndicesBase64.length > 0);
-  assert.equal(prepared.contract.paletteFamilyCount, 5);
-  assert.equal(prepared.contract.paletteHueSlotCount, 3);
-  assert.equal(prepared.contract.maximumColorFamilyCount, 3);
+  assert.equal(prepared.contract.paletteVariantCount, 12);
+  assert.equal(prepared.contract.paletteVariantIds.length, 12);
   assert.equal(prepared.contract.preparedMinimumSaturation, 0.55);
   assert.equal(prepared.contract.preparedMinimumValue, 0.75);
-  assert.equal(prepared.contract.variants.length, 5);
-  assert.ok(prepared.contract.variants.every((variant) => variant.hueSlots.length === 3));
+  assert.equal(
+    prepared.contract.sampling,
+    "three-source-smooth-vertex-light-samples-averaged-per-solid-face-state",
+  );
+  assert.equal(
+    prepared.contract.interpolation,
+    "browser-solid-face-average-of-stream-frame-zero-source-vertex-lighting",
+  );
+  assert.equal(
+    prepared.contract.finalLitColorProfile.schema,
+    "csscyclone-prepared-final-lit-color-profile@1",
+  );
+  assert.equal(prepared.contract.finalLitColorProfile.darkFaceValueThreshold, 0.4);
+  assert.equal(prepared.contract.finalLitColorProfile.maximumDarkFaceShare, 0.25);
+  assert.equal(prepared.contract.finalLitColorProfile.minimumMedianLitValue, 0.5);
+  assert.deepEqual(
+    prepared.contract.finalLitColorProfile.srgbLumaWeights,
+    [0.2126, 0.7152, 0.0722],
+  );
+  assert.equal(prepared.contract.finalLitColorProfile.minimumCrossVariantEnergyRatio, 1);
+  assert.ok(prepared.contract.finalLitColorProfile.variants.every((variant) =>
+    variant.minimumCrossVariantEnergyRatio >= 1));
+  assert.equal(prepared.contract.finalLitColorProfile.variants.length, 12);
+  assert.equal(prepared.contract.variants.length, 12);
+  assert.ok(prepared.contract.variants.every((variant, index) =>
+    variant.paletteVariantId === prepared.contract.paletteVariantIds[index] &&
+    variant.hueRotation === index / 12));
   assert.equal(prepared.contract.sourceStreamFrameCount, 4);
   assert.equal(prepared.contract.chunkCount, 1);
   assert.equal(prepared.chunk.frameParticleColorStateIndices.length, 4);
@@ -357,9 +385,9 @@ test("prepares flat face lighting without a runtime lighting timeline", async ()
   assert.ok(prepared.contract.variants.every((variant) =>
     variant.colors.length === prepared.contract.uniqueColorCount &&
     variant.colors.every((color) => /^#[a-f0-9]{6}$/u.test(color))));
-  const liftedBlack = prepareCyclonePaletteColor([0, 0, 0], "yellow");
+  const liftedBlack = prepareCyclonePaletteColor([0, 0, 0], "rotate-060");
   assert.equal(Math.max(...liftedBlack), 0.75);
-  const liftedRedBlack = prepareCyclonePaletteColor([0, 0, 0], "red");
+  const liftedRedBlack = prepareCyclonePaletteColor([0, 0, 0], "rotate-000");
   assert.equal(Math.max(...liftedRedBlack), 0.75);
   assert.equal(Number((1 - Math.min(...liftedBlack) / Math.max(...liftedBlack)).toFixed(2)), 0.55);
 });
@@ -408,7 +436,7 @@ test("prepares one shared lighting color-slot space across consecutive chunks", 
     frameCount: 20,
     chunkCount: 2,
   };
-  const stream = createCyclonePreparedLightingStream();
+  const stream = createCyclonePreparedLightingStream({ enforceFinalColorProfile: false });
   const lightingChunks = [...buildCycloneSourceChunks({ bank })].map(stream.add);
   const prepared = await stream.finalize();
   assert.equal(prepared.contract.chunkCount, 2);

--- a/src/adapters/cyclone/test/csscyclone-startup-palette-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-startup-palette-selection.test.mjs
@@ -1,25 +1,26 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { selectCycloneStartupPaletteFamily } from "../src/csscyclone/startupPaletteSelection.mjs";
+import { selectCycloneStartupPaletteVariant } from "../src/csscyclone/startupPaletteSelection.mjs";
 
-const families = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
+const variantIds = Object.freeze(Array.from({ length: 12 }, (_, index) =>
+  `rotate-${String(index * 30).padStart(3, "0")}`));
 
-test("visits every prepared three-family palette once before repeating across reloads", () => {
+test("visits every prepared hue rotation once before repeating across reloads", () => {
   const storage = fixtureStorage();
   let randomValue = 0;
   const options = { storage, randomUint32: () => randomValue++ };
-  const firstCycle = Array.from({ length: families.length }, () =>
-    selectCycloneStartupPaletteFamily(families, options).paletteFamily);
-  const secondCycle = Array.from({ length: families.length }, () =>
-    selectCycloneStartupPaletteFamily(families, options).paletteFamily);
-  assert.equal(new Set(firstCycle).size, families.length);
-  assert.equal(new Set(secondCycle).size, families.length);
+  const firstCycle = Array.from({ length: variantIds.length }, () =>
+    selectCycloneStartupPaletteVariant(variantIds, options).paletteVariantId);
+  const secondCycle = Array.from({ length: variantIds.length }, () =>
+    selectCycloneStartupPaletteVariant(variantIds, options).paletteVariantId);
+  assert.equal(new Set(firstCycle).size, variantIds.length);
+  assert.equal(new Set(secondCycle).size, variantIds.length);
   assert.notEqual(secondCycle[0], firstCycle.at(-1));
 });
 
 test("rejects a broken palette bank or random source", () => {
-  assert.throws(() => selectCycloneStartupPaletteFamily(["red", "red"]), /distinct prepared families/u);
-  assert.throws(() => selectCycloneStartupPaletteFamily(families, {
+  assert.throws(() => selectCycloneStartupPaletteVariant(["red", "red"]), /distinct prepared variants/u);
+  assert.throws(() => selectCycloneStartupPaletteVariant(variantIds, {
     storage: fixtureStorage(),
     randomUint32: () => -1,
   }), /must be uint32/u);

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -8,6 +8,8 @@ import {
 const hash = "0".repeat(64);
 const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
 const startupPaletteFamilies = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
+const startupPaletteVariantIds = Object.freeze(Array.from({ length: 12 }, (_, index) =>
+  `rotate-${String(index * 30).padStart(3, "0")}`));
 const startupSelections = Object.freeze([
   Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 17, startFrameIndex: 249, frameCount: 48 }),
   Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 23, startFrameIndex: 492, frameCount: 48 }),
@@ -46,11 +48,12 @@ const catalog = Object.freeze({
   streamFrameCount: 12_960,
   streamDurationMilliseconds: 216_000,
   startupPaletteFamilies,
+  startupPaletteVariantIds,
   startupSelections,
   startupSilhouetteSampling: "browser-reviewed-expressive-source-windows",
   startupSilhouetteSampleFrameOffsets: Object.freeze([0, 12, 24, 36, 47]),
   maximumColorFamilyCount: 3,
-  selection: "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat",
+  selection: "session-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat",
   startupColorProfile: Object.freeze({
     schema: "csscyclone-prepared-startup-color-profile@2",
     metric: "prepared-source-particle-rgb-hsv-dominant-family-per-curated-window",
@@ -109,41 +112,44 @@ test("slices worker transform responses before publishing a materialized block",
   assert.ok(yieldCount > 0);
 });
 
-test("selects a balanced prepared source-palette window once", () => {
+test("selects an independent prepared hue rotation and source window", () => {
   assert.deepEqual(selectInitialCyclonePosition(catalog, {
     randomUint32Pair: () => [7, 901],
   }), {
-    selectionId: "red-b",
-    paletteFamily: "red",
-    chunkIndex: 13,
-    frameIndex: 141,
+    selectionId: "blue-a",
+    paletteVariantId: "rotate-210",
+    sourcePaletteFamily: "blue",
+    chunkIndex: 17,
+    frameIndex: 286,
     mode: "crypto-random-balanced-source-palette",
   });
 });
 
 test("does not immediately repeat the previous prepared window", () => {
   assert.deepEqual(selectInitialCyclonePosition(catalog, {
-    previousSelectionId: "red-b",
+    previousSelectionId: "blue-a",
     randomUint32Pair: () => [7, 901],
   }), {
-    selectionId: "red-a",
-    paletteFamily: "red",
-    chunkIndex: 19,
-    frameIndex: 208,
+    selectionId: "blue-b",
+    paletteVariantId: "rotate-210",
+    sourcePaletteFamily: "blue",
+    chunkIndex: 23,
+    frameIndex: 529,
     mode: "crypto-random-balanced-source-palette-no-repeat",
   });
 });
 
-test("uses the session-shuffled family while retaining a random curated source window", () => {
+test("uses the session-shuffled hue rotation with an independent curated source window", () => {
   assert.deepEqual(selectInitialCyclonePosition(catalog, {
-    preferredPaletteFamily: "green",
+    preferredPaletteVariantId: "rotate-120",
     randomUint32Pair: () => [7, 901],
   }), {
-    selectionId: "green-b",
-    paletteFamily: "green",
-    chunkIndex: 15,
-    frameIndex: 238,
-    mode: "session-shuffled-palette-crypto-random-source-window",
+    selectionId: "magenta-b",
+    paletteVariantId: "rotate-120",
+    sourcePaletteFamily: "magenta",
+    chunkIndex: 12,
+    frameIndex: 451,
+    mode: "session-shuffled-hue-rotation-crypto-random-source-window",
   });
 });
 
@@ -154,20 +160,23 @@ test("rejects a previous start outside the prepared window pool", () => {
   }), /Previous Cyclone start selection is invalid/u);
 });
 
-test("gives each prepared three-family palette variant equal selection coverage", () => {
-  const selected = Array.from({ length: 10 }, (_, value) => selectInitialCyclonePosition(catalog, {
+test("covers every prepared hue rotation and curated source window independently", () => {
+  const selected = Array.from({ length: 120 }, (_, value) => selectInitialCyclonePosition(catalog, {
     randomUint32Pair: () => [value, value],
   }));
-  assert.deepEqual([...new Set(selected.map(({ paletteFamily }) => paletteFamily))], startupPaletteFamilies);
+  assert.deepEqual(
+    [...new Set(selected.map(({ paletteVariantId }) => paletteVariantId))],
+    startupPaletteVariantIds,
+  );
   assert.deepEqual([...new Set(selected.map(({ selectionId }) => selectionId))].sort(),
     [...startupSelections.map(({ id }) => id)].sort());
 });
 
 test("accepts an explicit chunk and frame for deterministic browser proof", () => {
   assert.deepEqual(selectInitialCyclonePosition(catalog, {
-    search: "?chunk=23&frame=539&palette=green",
+    search: "?chunk=23&frame=539&palette=rotate-120",
   }), {
-    paletteFamily: "green",
+    paletteVariantId: "rotate-120",
     chunkIndex: 23,
     frameIndex: 539,
     mode: "explicit",

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -38,6 +38,9 @@ const runtimeLookaheadBlockCount = 11;
 const runtimeMaterializedLookaheadBlockCount = 2;
 const startupMaterializedLookaheadBlockCount = 2;
 const startupPaletteFamilies = CSSCYCLONE_PRESENTATION.startupPaletteFamilies;
+const startupPaletteVariantIds = Object.freeze(
+  CSSCYCLONE_PRESENTATION.preparedPaletteVariants.map(({ id }) => id),
+);
 const startupSilhouetteSampleFrameOffsets = CSSCYCLONE_PRESENTATION.startupSilhouetteSampleFrameOffsets;
 const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
 const profileConfigs = Object.freeze([
@@ -200,6 +203,10 @@ async function prepareProfile(profile) {
     startupSelections,
   );
   const preparedLighting = await lightingStream.finalize();
+  const preparedLightingAssets = await writePreparedLightingVariantAssets(
+    preparedLighting.contract,
+    profile,
+  );
   const catalogBytes = Buffer.from(`${JSON.stringify({
     schema: "csscyclone-prepared-stream-catalog@3",
     streamId: bank.id,
@@ -227,12 +234,13 @@ async function prepareProfile(profile) {
     streamFrameCount: bank.chunkCount * bank.frameCount,
     streamDurationMilliseconds: bank.chunkCount * bank.frameCount / bank.framesPerSecond * 1_000,
     startupPaletteFamilies,
+    startupPaletteVariantIds,
     startupSelections,
     startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
     startupSilhouetteSampleFrameOffsets,
     maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
     startupColorProfile,
-    selection: "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat",
+    selection: "session-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat",
     playbackOrder: "source-continuous-ascending-chunks-with-one-terminal-stream-wrap",
     runtimeLookaheadBlockCount,
     runtimeMaterializedLookaheadBlockCount,
@@ -266,8 +274,8 @@ async function prepareProfile(profile) {
         minimumSaturation: CSSCYCLONE_PRESENTATION.minimumSaturation,
         hueSampling: CSSCYCLONE_PRESENTATION.hueSampling,
         particleColorAssignment: CSSCYCLONE_PRESENTATION.particleColorAssignment,
-        preparedPaletteHueSlotCount: CSSCYCLONE_PRESENTATION.preparedPaletteHueSlotCount,
         preparedPaletteAssignment: CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
+        preparedPaletteVariantCount: startupPaletteVariantIds.length,
         maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
       }),
       preparedStream: Object.freeze({
@@ -280,12 +288,13 @@ async function prepareProfile(profile) {
         streamFrameCount: bank.chunkCount * bank.frameCount,
         streamDurationMilliseconds: bank.chunkCount * bank.frameCount / bank.framesPerSecond * 1_000,
         startupPaletteFamilies,
+        startupPaletteVariantIds,
         startupSelections,
         startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
         startupSilhouetteSampleFrameOffsets,
         maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
         startupColorProfile,
-        startupSelection: "session-crypto-shuffled-palette-family-source-window-no-immediate-repeat",
+        startupSelection: "session-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat",
         handoff: "source-continuous-twelve-block-decoded-window",
       }),
       productParticleCount: bank.particleCount,
@@ -324,7 +333,7 @@ async function prepareProfile(profile) {
       startupMaterializedBlockCount: startupMaterializedLookaheadBlockCount + 1,
       maximumRuntimeMaterializedBlockCount: runtimeMaterializedLookaheadBlockCount + 1,
     }),
-    lighting: preparedLighting.contract,
+    lighting: preparedLightingAssets.contract,
   });
   return Object.freeze({
     profile,
@@ -341,7 +350,39 @@ async function prepareProfile(profile) {
       residentBlockWindowCount,
       maximumResidentBlockWindowDecodedBytes,
       ...preparedLighting.metrics,
+      preparedLightingVariantAssetBytes: preparedLightingAssets.byteLength,
     }),
+  });
+}
+
+async function writePreparedLightingVariantAssets(lighting, profile) {
+  const assetRoot = profile.blockRoot.replace(/\/blocks$/u, "/lighting");
+  const variants = [];
+  let byteLength = 0;
+  for (const variant of lighting.variants) {
+    const bytes = Buffer.from(`${JSON.stringify({
+      schema: "csscyclone-prepared-lighting-color-variant@1",
+      streamId: lighting.streamId,
+      paletteVariantId: variant.paletteVariantId,
+      hueRotation: variant.hueRotation,
+      uniqueColorCount: lighting.uniqueColorCount,
+      colors: variant.colors,
+    })}\n`);
+    const digest = sha256(bytes);
+    const assetUrl = `${assetRoot}/${variant.paletteVariantId}-${digest}.json`;
+    await writeBytes(join(stagingRoot, assetUrl.replace(/^\/csscyclone\//u, "")), bytes);
+    variants.push(Object.freeze({
+      paletteVariantId: variant.paletteVariantId,
+      hueRotation: variant.hueRotation,
+      assetUrl,
+      byteLength: bytes.byteLength,
+      sha256: digest,
+    }));
+    byteLength += bytes.byteLength;
+  }
+  return Object.freeze({
+    contract: Object.freeze({ ...lighting, variants: Object.freeze(variants) }),
+    byteLength,
   });
 }
 


### PR DESCRIPTION
## Summary
- preserve continuous prepared hues while balancing every rotation to the brightest energy for each prepared face state
- use smooth source-vertex lighting averaged into retained solid faces
- load one hash-bound prepared color table per session and cycle all twelve rotations before repeating

## Verification
- `pnpm test:cyclone`
- `pnpm prepare:cyclone`
- `pnpm build:cyclone`
- `pnpm typecheck`
- `pnpm verify:source-only`
- 12 same-frame browser captures: 0.06% crop-energy spread
- retained 1,920-leaf desktop DOM, zero runtime lighting calculations, zero DOM growth