### PR TITLE
fix(cyclone): coordinate reload palettes

### DIFF
--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -31,7 +31,7 @@ rasterization, or DOM growth.
 The prepared presentation maps the source's random saturation samples into a
 0.55-1.0 range and lifts the dark end of prepared HSV value to 0.75. Each
 session variant contains at most three coordinated hue families: two primaries
-and one secondary, all within a 30-degree analogous range. Source hue ranks
+and one secondary, separated by 30-degree steps across a 60-degree analogous range. Source hue ranks
 assign 40% of particle colors to each primary and 20% to the secondary. The source's uniform
 random hue-target timing and rule that particles change color only when they
 restart remain unchanged. Twelve prepared variants use explicit audited

--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -11,14 +11,14 @@ transform states. The stream is transported as 216 one-second prepared blocks
 so decompression stays outside long animation frames. The source fixed-function
 light is sampled at each particle's original smooth vertex normals in the first
 published frame, then the three lit vertex colors of every triangle are averaged
-into one prepared opaque CSS face color. For every source-lit face state, the
-brightest result across the twelve hue rotations sets the shared sRGB energy.
-Every dimmer rotation is first exposed without changing hue or saturation. Only
-colors that reach the sRGB gamut ceiling before that shared target is met mix
-toward neutral by the minimum remaining amount. The energetic rotation is never
-dimmed.
+into one prepared opaque CSS face color. Every face is normalized to the
+encoded-sRGB midpoint between its green and yellow channel references.
+Higher-energy hues are dimmed without changing their channel ratio. Lower-energy hues are first
+exposed without changing hue or saturation; only colors that reach the sRGB
+gamut ceiling before the target mix toward neutral by the minimum remaining
+amount.
 A preparation guard rejects banks whose final lit palette becomes predominantly
-dark or falls below that shared cross-rotation energy. Exact cross-palette color tuples
+dark or falls outside that prepared energy range. Exact cross-palette color tuples
 are deduplicated into a compact prepared slot table. Initial leaf colors are
 bound once. Later color writes are limited to the six leaves of a particle when
 the source restarts it with a new color. The mounted graph is camera, scene,
@@ -29,19 +29,21 @@ There is no Canvas, SVG, WebGL, runtime random walk, geometry construction,
 lighting calculation, color calculation, matrix formatting, image decode, atlas
 rasterization, or DOM growth.
 The prepared presentation maps the source's random saturation samples into a
-0.55-1.0 range and lifts the dark end of prepared HSV value to 0.75. The
-source's continuous hues, uniform random hue-target timing, and rule that
-particles change color only when they restart are preserved. Twelve prepared
-solid-color variants rotate every source hue by a fixed 30-degree step. The
-browser selects one complete prepared color table and performs no color
-calculation. The same source RNG draws preserve RNG cadence, trajectory geometry,
-restart timing, and coherent color bands. The session rotation and shared
-cross-rotation energy normalization are intentional presentation changes; they
-are not exact source colors.
+0.55-1.0 range and lifts the dark end of prepared HSV value to 0.75. Each
+session variant contains at most three coordinated hue families: two primaries
+30 degrees apart and one split-complementary accent. Source hue ranks assign 40%
+of particle colors to each primary and 20% to the accent. The source's uniform
+random hue-target timing and rule that particles change color only when they
+restart remain unchanged. Twelve prepared variants rotate the coordinated
+three-color palette by a fixed 30-degree step. The browser selects one complete
+prepared color table and performs no color calculation. The same source RNG
+draws preserve RNG cadence, trajectory geometry, restart timing, and coherent
+color bands. The session palette and midpoint energy normalization are
+intentional presentation changes; they are not exact source colors.
 Startup is prebaked to ten audited 48-frame source windows. A 24-load
 session-shuffled cycle includes every hue rotation without adjacent repeats,
-but weights blue, cyan, and green rotations 19 times, limits the brown-dominant
-rotation to once, and keeps red-family rotations sparse. It independently
+but weights green-through-blue palettes most heavily, limits the orange/brown-
+heavy palette to once, and keeps red-family palettes sparse. It independently
 chooses one expressive browser-reviewed source window while excluding the
 previous exact window.
 It never phases individual particles around a full hue wheel. This is an

--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -38,10 +38,12 @@ calculation. The same source RNG draws preserve RNG cadence, trajectory geometry
 restart timing, and coherent color bands. The session rotation and shared
 cross-rotation energy normalization are intentional presentation changes; they
 are not exact source colors.
-Startup is prebaked to ten audited 48-frame source windows. The selector gives
-each of the twelve hue rotations exactly once per session-shuffled cycle before
-any rotation repeats, then independently chooses one expressive browser-reviewed
-source window while excluding the previous exact window.
+Startup is prebaked to ten audited 48-frame source windows. A 24-load
+session-shuffled cycle includes every hue rotation without adjacent repeats,
+but weights blue, cyan, and green rotations 19 times, limits the brown-dominant
+rotation to once, and keeps red-family rotations sparse. It independently
+chooses one expressive browser-reviewed source window while excluding the
+previous exact window.
 It never phases individual particles around a full hue wheel. This is an
 intentional presentation rather than an exact native-color or random-start
 claim. Mobile/coarse-pointer devices and viewports below 600px select the

--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -31,11 +31,11 @@ rasterization, or DOM growth.
 The prepared presentation maps the source's random saturation samples into a
 0.55-1.0 range and lifts the dark end of prepared HSV value to 0.75. Each
 session variant contains at most three coordinated hue families: two primaries
-30 degrees apart and one split-complementary accent. Source hue ranks assign 40%
-of particle colors to each primary and 20% to the accent. The source's uniform
+and one secondary, all within a 30-degree analogous range. Source hue ranks
+assign 40% of particle colors to each primary and 20% to the secondary. The source's uniform
 random hue-target timing and rule that particles change color only when they
 restart remain unchanged. Twelve prepared variants use explicit audited
-three-hue sets; none contains an orange- or yellow-dominant primary pair. The
+three-hue sets; none combines opposing families such as red and blue. The
 browser selects one complete prepared color table and performs no color calculation. The same source RNG
 draws preserve RNG cadence, trajectory geometry, restart timing, and coherent
 color bands. The session palette and midpoint energy normalization are

--- a/src/adapters/cyclone/README.md
+++ b/src/adapters/cyclone/README.md
@@ -34,16 +34,16 @@ session variant contains at most three coordinated hue families: two primaries
 30 degrees apart and one split-complementary accent. Source hue ranks assign 40%
 of particle colors to each primary and 20% to the accent. The source's uniform
 random hue-target timing and rule that particles change color only when they
-restart remain unchanged. Twelve prepared variants rotate the coordinated
-three-color palette by a fixed 30-degree step. The browser selects one complete
-prepared color table and performs no color calculation. The same source RNG
+restart remain unchanged. Twelve prepared variants use explicit audited
+three-hue sets; none contains an orange- or yellow-dominant primary pair. The
+browser selects one complete prepared color table and performs no color calculation. The same source RNG
 draws preserve RNG cadence, trajectory geometry, restart timing, and coherent
 color bands. The session palette and midpoint energy normalization are
 intentional presentation changes; they are not exact source colors.
 Startup is prebaked to ten audited 48-frame source windows. A 24-load
-session-shuffled cycle includes every hue rotation without adjacent repeats,
-but weights green-through-blue palettes most heavily, limits the orange/brown-
-heavy palette to once, and keeps red-family palettes sparse. It independently
+session-shuffled cycle includes every prepared palette without adjacent
+repeats: 16 loads use green-through-blue primaries, four use violet primaries,
+and four use magenta-through-red primaries. It independently
 chooses one expressive browser-reviewed source window while excluding the
 previous exact window.
 It never phases individual particles around a full hue wheel. This is an

--- a/src/adapters/cyclone/src/csscyclone/client.mjs
+++ b/src/adapters/cyclone/src/csscyclone/client.mjs
@@ -59,7 +59,9 @@ export async function mountCycloneClient(host) {
     const route = new URLSearchParams(globalThis.location?.search ?? "");
     const paletteSelection = route.has("chunk") || route.has("frame")
       ? null
-      : selectCycloneStartupPaletteVariant(catalog.startupPaletteVariantIds);
+      : selectCycloneStartupPaletteVariant(catalog.startupPaletteVariantIds, {
+        weights: catalog.startupPaletteVariantWeights,
+      });
     const selection = selectInitialCyclonePosition(catalog, {
       previousSelectionId: readPreviousStartSelection(catalog.startupSelections),
       preferredPaletteVariantId: paletteSelection?.paletteVariantId ?? null,

--- a/src/adapters/cyclone/src/csscyclone/preparedLightingColors.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedLightingColors.mjs
@@ -1,6 +1,6 @@
 export async function loadCyclonePreparedLightingColors(lighting, paletteVariantId) {
   const variant = lighting?.variants?.find((entry) => entry?.paletteVariantId === paletteVariantId);
-  if (lighting?.schema !== "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@16" ||
+  if (lighting?.schema !== "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@17" ||
       lighting.preparedMinimumSaturation !== 0.55 ||
       lighting.preparedMinimumValue !== 0.75 ||
       !isFinalLitColorProfileValid(lighting.finalLitColorProfile, lighting.paletteVariantIds) ||
@@ -9,6 +9,9 @@ export async function loadCyclonePreparedLightingColors(lighting, paletteVariant
       !lighting.paletteVariantIds.includes(paletteVariantId) ||
       lighting.variants?.length !== lighting.paletteVariantIds.length ||
       typeof variant?.hueRotation !== "number" ||
+      variant?.preparedHues?.length !== 3 ||
+      new Set(variant.preparedHues).size !== variant.preparedHues.length ||
+      variant.preparedHues.some((hue) => typeof hue !== "number" || hue < 0 || hue >= 1) ||
       typeof variant?.assetUrl !== "string" ||
       !Number.isSafeInteger(variant?.byteLength) || variant.byteLength < 1 ||
       !/^[a-f0-9]{64}$/u.test(variant?.sha256 ?? "") ||
@@ -39,6 +42,7 @@ export async function loadCyclonePreparedLightingColors(lighting, paletteVariant
       preparedVariant.streamId !== lighting.streamId ||
       preparedVariant.paletteVariantId !== paletteVariantId ||
       preparedVariant.hueRotation !== variant.hueRotation ||
+      !sameNumbers(preparedVariant.preparedHues, variant.preparedHues) ||
       preparedVariant.uniqueColorCount !== lighting.uniqueColorCount ||
       !Array.isArray(preparedVariant.colors) ||
       preparedVariant.colors.length !== lighting.uniqueColorCount ||
@@ -48,10 +52,16 @@ export async function loadCyclonePreparedLightingColors(lighting, paletteVariant
   return Object.freeze({
     paletteVariantId,
     hueRotation: variant.hueRotation,
+    preparedHues: Object.freeze([...variant.preparedHues]),
     colors: Object.freeze(preparedVariant.colors),
     colorSlotIndices,
     destroy() {},
   });
+}
+
+function sameNumbers(left, right) {
+  return Array.isArray(left) && left.length === right.length &&
+    left.every((value, index) => value === right[index]);
 }
 
 async function fetchBytes(url) {

--- a/src/adapters/cyclone/src/csscyclone/preparedLightingColors.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedLightingColors.mjs
@@ -1,6 +1,6 @@
 export async function loadCyclonePreparedLightingColors(lighting, paletteVariantId) {
   const variant = lighting?.variants?.find((entry) => entry?.paletteVariantId === paletteVariantId);
-  if (lighting?.schema !== "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@18" ||
+  if (lighting?.schema !== "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@19" ||
       lighting.preparedMinimumSaturation !== 0.55 ||
       lighting.preparedMinimumValue !== 0.75 ||
       !isFinalLitColorProfileValid(lighting.finalLitColorProfile, lighting.paletteVariantIds) ||

--- a/src/adapters/cyclone/src/csscyclone/preparedLightingColors.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedLightingColors.mjs
@@ -1,6 +1,6 @@
 export async function loadCyclonePreparedLightingColors(lighting, paletteVariantId) {
   const variant = lighting?.variants?.find((entry) => entry?.paletteVariantId === paletteVariantId);
-  if (lighting?.schema !== "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@17" ||
+  if (lighting?.schema !== "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@18" ||
       lighting.preparedMinimumSaturation !== 0.55 ||
       lighting.preparedMinimumValue !== 0.75 ||
       !isFinalLitColorProfileValid(lighting.finalLitColorProfile, lighting.paletteVariantIds) ||

--- a/src/adapters/cyclone/src/csscyclone/preparedLightingColors.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedLightingColors.mjs
@@ -1,6 +1,6 @@
 export async function loadCyclonePreparedLightingColors(lighting, paletteVariantId) {
   const variant = lighting?.variants?.find((entry) => entry?.paletteVariantId === paletteVariantId);
-  if (lighting?.schema !== "csscyclone-prepared-energy-balanced-continuous-hue-vertex-lighting-colors@15" ||
+  if (lighting?.schema !== "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@16" ||
       lighting.preparedMinimumSaturation !== 0.55 ||
       lighting.preparedMinimumValue !== 0.75 ||
       !isFinalLitColorProfileValid(lighting.finalLitColorProfile, lighting.paletteVariantIds) ||
@@ -76,11 +76,13 @@ async function verifyBytes(bytes, expectedLength, expectedSha256) {
 }
 
 function isFinalLitColorProfileValid(profile, paletteVariantIds) {
-  return profile?.schema === "csscyclone-prepared-final-lit-color-profile@1" &&
+  return profile?.schema === "csscyclone-prepared-final-lit-color-profile@2" &&
     profile.darkFaceValueThreshold === 0.4 &&
-    profile.maximumDarkFaceShare === 0.25 &&
+    profile.maximumDarkFaceShare === 0.2 &&
     profile.minimumMedianLitValue === 0.5 &&
-    profile.minimumCrossVariantEnergyRatio === 1 &&
+    profile.targetSrgbEnergyRatio === 0.8215 &&
+    profile.minimumTargetEnergyRatio === 1 &&
+    profile.maximumTargetEnergyRatio === 1.03 &&
     profile.srgbLumaWeights?.length === 3 &&
     profile.srgbLumaWeights.every((value, index) =>
       value === [0.2126, 0.7152, 0.0722][index]) &&
@@ -89,8 +91,8 @@ function isFinalLitColorProfileValid(profile, paletteVariantIds) {
       variant?.paletteVariantId === paletteVariantIds[index] &&
       variant.medianLitValue >= profile.minimumMedianLitValue &&
       variant.darkFaceShare <= profile.maximumDarkFaceShare &&
-      variant.minimumCrossVariantEnergyRatio >=
-        profile.minimumCrossVariantEnergyRatio);
+      variant.minimumTargetEnergyRatio >= profile.minimumTargetEnergyRatio &&
+      variant.maximumTargetEnergyRatio <= profile.maximumTargetEnergyRatio);
 }
 
 function decodeColorSlotIndices(encoded, bytesPerIndex, count) {

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -7,7 +7,7 @@ import {
 
 const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@3";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@2";
-const LIGHTING_SCHEMA = "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@16";
+const LIGHTING_SCHEMA = "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@17";
 const SOURCE_FIELD_OF_VIEW_DEGREES = 80;
 const MOBILE_FIELD_OF_VIEW_DEGREES = 90;
 const MOBILE_MAX_WIDTH = 600;

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -7,7 +7,7 @@ import {
 
 const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@3";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@2";
-const LIGHTING_SCHEMA = "csscyclone-prepared-energy-balanced-continuous-hue-vertex-lighting-colors@15";
+const LIGHTING_SCHEMA = "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@16";
 const SOURCE_FIELD_OF_VIEW_DEGREES = 80;
 const MOBILE_FIELD_OF_VIEW_DEGREES = 90;
 const MOBILE_MAX_WIDTH = 600;

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -7,7 +7,7 @@ import {
 
 const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@3";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@2";
-const LIGHTING_SCHEMA = "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@18";
+const LIGHTING_SCHEMA = "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@19";
 const SOURCE_FIELD_OF_VIEW_DEGREES = 80;
 const MOBILE_FIELD_OF_VIEW_DEGREES = 90;
 const MOBILE_MAX_WIDTH = 600;

--- a/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedPlayback.mjs
@@ -7,7 +7,7 @@ import {
 
 const CATALOG_SCHEMA = "csscyclone-prepared-stream-catalog@3";
 const BLOCK_SCHEMA = "csscyclone-prepared-stream-block@2";
-const LIGHTING_SCHEMA = "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@17";
+const LIGHTING_SCHEMA = "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@18";
 const SOURCE_FIELD_OF_VIEW_DEGREES = 80;
 const MOBILE_FIELD_OF_VIEW_DEGREES = 90;
 const MOBILE_MAX_WIDTH = 600;

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -15,7 +15,7 @@ const STARTUP_HUE_SECTOR_NAMES = Object.freeze(["red", "yellow", "green", "cyan"
 const STARTUP_PALETTE_FAMILIES = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
 const STARTUP_PALETTE_VARIANT_IDS = Object.freeze(Array.from({ length: 12 }, (_, index) =>
   `rotate-${String(index * 30).padStart(3, "0")}`));
-const STARTUP_PALETTE_VARIANT_WEIGHTS = Object.freeze([3, 3, 3, 3, 2, 1, 1, 1, 1, 1, 2, 3]);
+const STARTUP_PALETTE_VARIANT_WEIGHTS = Object.freeze([3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1]);
 const STARTUP_SILHOUETTE_SAMPLING = "browser-reviewed-expressive-source-windows";
 const STARTUP_SELECTION = "session-weighted-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat";
 

--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -15,8 +15,9 @@ const STARTUP_HUE_SECTOR_NAMES = Object.freeze(["red", "yellow", "green", "cyan"
 const STARTUP_PALETTE_FAMILIES = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
 const STARTUP_PALETTE_VARIANT_IDS = Object.freeze(Array.from({ length: 12 }, (_, index) =>
   `rotate-${String(index * 30).padStart(3, "0")}`));
+const STARTUP_PALETTE_VARIANT_WEIGHTS = Object.freeze([3, 3, 3, 3, 2, 1, 1, 1, 1, 1, 2, 3]);
 const STARTUP_SILHOUETTE_SAMPLING = "browser-reviewed-expressive-source-windows";
-const STARTUP_SELECTION = "session-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat";
+const STARTUP_SELECTION = "session-weighted-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat";
 
 export async function loadCyclonePreparedCatalog(descriptor) {
   if (typeof descriptor?.catalogUrl !== "string" ||
@@ -84,7 +85,7 @@ export function selectInitialCyclonePosition(catalog, {
     chunkIndex: selection.chunkIndex,
     frameIndex,
     mode: preferredPaletteVariantId !== null
-      ? "session-shuffled-hue-rotation-crypto-random-source-window"
+      ? "session-weighted-shuffled-hue-rotation-crypto-random-source-window"
       : previousSelectionId === null
       ? "crypto-random-balanced-source-palette"
       : "crypto-random-balanced-source-palette-no-repeat",
@@ -634,6 +635,10 @@ function validateCatalog(catalog) {
       catalog.startupPaletteVariantIds.length !== STARTUP_PALETTE_VARIANT_IDS.length ||
       catalog.startupPaletteVariantIds.some((variantId, index) =>
         variantId !== STARTUP_PALETTE_VARIANT_IDS[index]) ||
+      !Array.isArray(catalog.startupPaletteVariantWeights) ||
+      catalog.startupPaletteVariantWeights.length !== STARTUP_PALETTE_VARIANT_WEIGHTS.length ||
+      catalog.startupPaletteVariantWeights.some((weight, index) =>
+        weight !== STARTUP_PALETTE_VARIANT_WEIGHTS[index]) ||
       !Array.isArray(catalog.startupSelections) || catalog.startupSelections.length < 2 ||
       new Set(catalog.startupSelections.map((selection) => selection?.id)).size !==
         catalog.startupSelections.length ||

--- a/src/adapters/cyclone/src/csscyclone/startupPaletteSelection.mjs
+++ b/src/adapters/cyclone/src/csscyclone/startupPaletteSelection.mjs
@@ -1,5 +1,5 @@
-const STORAGE_KEY = "csscyclone:startup-palette-variant-shuffle@2";
-const STORAGE_SCHEMA = "csscyclone-startup-palette-variant-shuffle@2";
+const STORAGE_KEY = "csscyclone:startup-palette-variant-shuffle@3";
+const STORAGE_SCHEMA = "csscyclone-startup-palette-variant-shuffle@3";
 
 export function selectCycloneStartupPaletteVariant(paletteVariantIds, options = {}) {
   const variantIds = [...(paletteVariantIds ?? [])];
@@ -7,27 +7,26 @@ export function selectCycloneStartupPaletteVariant(paletteVariantIds, options = 
       variantIds.some((variantId) => typeof variantId !== "string" || variantId.length < 1)) {
     throw new Error("Cyclone startup palette shuffle requires distinct prepared variants");
   }
-  const signature = variantIds.join("\n");
+  const weights = [...(options.weights ?? [])];
+  if (weights.length !== variantIds.length ||
+      weights.some((weight) => !Number.isSafeInteger(weight) || weight < 1)) {
+    throw new Error("Cyclone startup palette shuffle requires positive prepared weights");
+  }
+  const signature = variantIds.map((variantId, index) =>
+    `${variantId}:${weights[index]}`).join("\n");
   const storage = options.storage ?? safeSessionStorage();
   const randomUint32 = options.randomUint32 ?? cryptoRandomUint32;
-  const restored = readState(storage, signature, variantIds);
+  const restored = readState(storage, signature, variantIds, weights);
   let remaining = restored?.remainingPaletteVariantIds ?? [];
   const lastPaletteVariantId = restored?.lastPaletteVariantId ?? null;
 
   if (remaining.length === 0) {
-    remaining = [...variantIds];
-    for (let index = remaining.length - 1; index > 0; index -= 1) {
-      const value = randomUint32();
-      if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
-        throw new RangeError("Cyclone startup palette shuffle value must be uint32");
-      }
-      const swapIndex = value % (index + 1);
-      [remaining[index], remaining[swapIndex]] = [remaining[swapIndex], remaining[index]];
-    }
-    if (lastPaletteVariantId && remaining.at(-1) === lastPaletteVariantId) {
-      [remaining[0], remaining[remaining.length - 1]] =
-        [remaining[remaining.length - 1], remaining[0]];
-    }
+    remaining = buildWeightedCycle(
+      variantIds,
+      weights,
+      lastPaletteVariantId,
+      randomUint32,
+    ).reverse();
   }
 
   const paletteVariantId = remaining.pop();
@@ -47,18 +46,57 @@ export function selectCycloneStartupPaletteVariant(paletteVariantIds, options = 
   });
 }
 
-function readState(storage, signature, variantIds) {
+function buildWeightedCycle(variantIds, weights, previousVariantId, randomUint32) {
+  const counts = new Map(variantIds.map((variantId, index) => [variantId, weights[index]]));
+  const cycle = [];
+  let previous = previousVariantId;
+  let remainingCount = weights.reduce((sum, weight) => sum + weight, 0);
+  while (remainingCount > 0) {
+    let maximumCount = 0;
+    let candidates = [];
+    for (const variantId of variantIds) {
+      const count = counts.get(variantId);
+      if (variantId === previous || count < maximumCount) continue;
+      if (count > maximumCount) {
+        maximumCount = count;
+        candidates = [];
+      }
+      if (count === maximumCount && count > 0) candidates.push(variantId);
+    }
+    if (candidates.length === 0) {
+      throw new Error("Cyclone startup palette weights cannot avoid an adjacent repeat");
+    }
+    const selected = candidates[readRandomUint32(randomUint32) % candidates.length];
+    cycle.push(selected);
+    counts.set(selected, counts.get(selected) - 1);
+    previous = selected;
+    remainingCount -= 1;
+  }
+  return cycle;
+}
+
+function readState(storage, signature, variantIds, weights) {
   if (!storage) return null;
   try {
     const value = JSON.parse(storage.getItem(STORAGE_KEY));
     const remaining = value?.remainingPaletteVariantIds;
     const allowed = new Set(variantIds);
+    const maximumCounts = new Map(variantIds.map((variantId, index) =>
+      [variantId, weights[index]]));
+    const remainingCounts = new Map();
     if (value?.schema !== STORAGE_SCHEMA || value.paletteSignature !== signature ||
         (value.lastPaletteVariantId !== null && !allowed.has(value.lastPaletteVariantId)) ||
-        !Array.isArray(remaining) || new Set(remaining).size !== remaining.length ||
-        remaining.some((variantId) =>
-          !allowed.has(variantId) || variantId === value.lastPaletteVariantId)) {
+        !Array.isArray(remaining) || remaining.some((variantId) => !allowed.has(variantId))) {
       return null;
+    }
+    for (const variantId of remaining) {
+      remainingCounts.set(variantId, (remainingCounts.get(variantId) ?? 0) + 1);
+      if (remainingCounts.get(variantId) > maximumCounts.get(variantId)) return null;
+    }
+    let previous = value.lastPaletteVariantId;
+    for (const variantId of [...remaining].reverse()) {
+      if (variantId === previous) return null;
+      previous = variantId;
     }
     return Object.freeze({
       lastPaletteVariantId: value.lastPaletteVariantId,
@@ -67,6 +105,14 @@ function readState(storage, signature, variantIds) {
   } catch {
     return null;
   }
+}
+
+function readRandomUint32(randomUint32) {
+  const value = randomUint32();
+  if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
+    throw new RangeError("Cyclone startup palette shuffle value must be uint32");
+  }
+  return value;
 }
 
 function writeState(storage, value) {

--- a/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
@@ -7,10 +7,19 @@ import { CSSCYCLONE_PRESENTATION } from "./sourceModel.mjs";
 const PREPARED_MINIMUM_SATURATION = CSSCYCLONE_PRESENTATION.minimumSaturation;
 const PREPARED_MINIMUM_VALUE = 0.75;
 const PREPARED_DARK_FACE_VALUE = 0.4;
-const PREPARED_MAXIMUM_DARK_FACE_SHARE = 0.25;
+const PREPARED_MAXIMUM_DARK_FACE_SHARE = 0.2;
 const PREPARED_MINIMUM_MEDIAN_LIT_VALUE = 0.5;
 const SRGB_LUMA_WEIGHTS = Object.freeze([0.2126, 0.7152, 0.0722]);
-const PREPARED_MINIMUM_CROSS_VARIANT_ENERGY_RATIO = 1;
+const PREPARED_GREEN_REFERENCE_ENERGY_RATIO = SRGB_LUMA_WEIGHTS[1];
+const PREPARED_YELLOW_REFERENCE_ENERGY_RATIO = SRGB_LUMA_WEIGHTS[0] + SRGB_LUMA_WEIGHTS[1];
+const PREPARED_TARGET_ENERGY_RATIO = Number(((
+  PREPARED_GREEN_REFERENCE_ENERGY_RATIO + PREPARED_YELLOW_REFERENCE_ENERGY_RATIO
+) / 2).toFixed(4));
+const PREPARED_MINIMUM_TARGET_ENERGY_RATIO = 1;
+const PREPARED_MAXIMUM_TARGET_ENERGY_RATIO = 1.03;
+const PREPARED_PRIMARY_HUE_SPREAD = 1 / 24;
+const PREPARED_COMPLEMENTARY_HUE_OFFSET = 5 / 12;
+const PREPARED_COMPLEMENTARY_ACCENT_SHARE = 0.2;
 const SOURCE_VERTEX_NORMALS = Object.freeze(
   CSSCYCLONE_PARTICLE_VERTICES.map((vertex) => Object.freeze(normalize(vertex))),
 );
@@ -167,13 +176,12 @@ async function buildPreparedLightingColors({
       colors: Object.freeze(colors),
     });
   });
-  const targetEnergies = Object.freeze(sourceLitVariants[0].colors.map((unused, colorIndex) =>
-    Math.max(...sourceLitVariants.map((variant) => srgbLuma(variant.colors[colorIndex])))));
   const logicalVariants = sourceLitVariants.map((variant) => {
     const energyRatios = [];
-    const colors = variant.colors.map((color, colorIndex) => {
-      const faceColor = balanceSrgbEnergy(color, targetEnergies[colorIndex]);
-      energyRatios.push(srgbLuma(faceColor) / targetEnergies[colorIndex]);
+    const colors = variant.colors.map((color) => {
+      const targetEnergy = Math.max(...color) * PREPARED_TARGET_ENERGY_RATIO;
+      const faceColor = normalizeSrgbEnergy(color, targetEnergy);
+      energyRatios.push(srgbLuma(faceColor) / targetEnergy);
       return rgbHex(faceColor);
     });
     return Object.freeze({
@@ -201,8 +209,8 @@ async function buildPreparedLightingColors({
       variant.colors[index])),
   }));
   const contract = deepFreeze({
-    schema: "csscyclone-prepared-energy-balanced-continuous-hue-vertex-lighting-colors@15",
-    technique: "prepared-source-smooth-vertex-lighting-averaged-per-solid-face-with-cross-variant-maximum-srgb-energy-balanced-session-hue-rotation-variants-sparse-source-color-restarts-and-exact-cross-variant-deduplication",
+    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@16",
+    technique: "prepared-source-smooth-vertex-lighting-averaged-per-solid-face-with-three-color-split-complementary-session-palettes-mid-green-yellow-reference-srgb-energy-normalization-sparse-source-color-restarts-and-exact-cross-variant-deduplication",
     source: "src/cyclone/cyclone.cpp#particle::update+initSaver",
     streamId,
     encoding: "CSS-sRGB-hex-plus-little-endian-color-slot-indices-base64",
@@ -240,7 +248,7 @@ async function buildPreparedLightingColors({
     sampling: "three-source-smooth-vertex-light-samples-averaged-per-solid-face-state",
     interpolation: "browser-solid-face-average-of-stream-frame-zero-source-vertex-lighting",
     material: Object.freeze({
-      ambientAndDiffuse: "prepared-session-hue-rotation-of-source-particle-rgb",
+      ambientAndDiffuse: "prepared-session-three-color-complementary-palette",
       specular: Object.freeze([0.7, 0.7, 0.7, 1]),
       shininess: 20,
     }),
@@ -345,9 +353,20 @@ export function prepareCyclonePaletteColor(baseColor, paletteVariantId) {
     else hue = (baseColor[0] - baseColor[1]) / chroma + 4;
     hue = (hue / 6 + 1) % 1;
   }
-  const rotatedHue = (hue + paletteVariant.hueRotation) % 1;
+  const primaryHue = (paletteVariant.hueRotation + 1 / 3) % 1;
+  const preparedHues = [
+    (primaryHue - PREPARED_PRIMARY_HUE_SPREAD + 1) % 1,
+    (primaryHue + PREPARED_PRIMARY_HUE_SPREAD) % 1,
+    (primaryHue + PREPARED_COMPLEMENTARY_HUE_OFFSET) % 1,
+  ];
+  const primaryShare = (1 - PREPARED_COMPLEMENTARY_ACCENT_SHARE) / 2;
+  const preparedHue = hue < primaryShare
+    ? preparedHues[0]
+    : hue < primaryShare * 2
+      ? preparedHues[1]
+      : preparedHues[2];
   return hsvToRgb(
-    rotatedHue,
+    preparedHue,
     saturation,
     Math.max(PREPARED_MINIMUM_VALUE, maximum),
   );
@@ -390,10 +409,14 @@ function averageVertexColors(vertexColors, vertexIndices) {
   ));
 }
 
-function balanceSrgbEnergy(color, targetEnergy) {
+function normalizeSrgbEnergy(color, targetEnergy) {
   const sourceValue = Math.max(...color);
   if (sourceValue === 0) return color;
-  if (srgbLuma(color) >= targetEnergy) return color;
+  const sourceEnergy = srgbLuma(color);
+  if (sourceEnergy > targetEnergy) {
+    return color.map((channel) => Math.min(255, Math.ceil(channel * targetEnergy / sourceEnergy)));
+  }
+  if (sourceEnergy === targetEnergy) return color;
   const maximumExposure = 255 / sourceValue;
   const fullyExposed = exposeSrgb(color, maximumExposure);
   if (srgbLuma(fullyExposed) >= targetEnergy) {
@@ -437,27 +460,30 @@ function buildFinalLitColorProfile(variants, enforce) {
       paletteVariantId: variant.paletteVariantId,
       medianLitValue: roundMetric(values[Math.floor((values.length - 1) / 2)]),
       darkFaceShare: roundMetric(darkFaceCount / values.length),
-      minimumCrossVariantEnergyRatio: roundMetric(energyRatios[0]),
-      medianCrossVariantEnergyRatio: roundMetric(
+      minimumTargetEnergyRatio: roundMetric(energyRatios[0]),
+      medianTargetEnergyRatio: roundMetric(
         energyRatios[Math.floor((energyRatios.length - 1) / 2)],
       ),
+      maximumTargetEnergyRatio: roundMetric(energyRatios[energyRatios.length - 1]),
     });
   });
   const invalidProfiles = profiles.filter((profile) =>
     profile.medianLitValue < PREPARED_MINIMUM_MEDIAN_LIT_VALUE ||
     profile.darkFaceShare > PREPARED_MAXIMUM_DARK_FACE_SHARE ||
-    profile.minimumCrossVariantEnergyRatio <
-      PREPARED_MINIMUM_CROSS_VARIANT_ENERGY_RATIO);
+    profile.minimumTargetEnergyRatio < PREPARED_MINIMUM_TARGET_ENERGY_RATIO ||
+    profile.maximumTargetEnergyRatio > PREPARED_MAXIMUM_TARGET_ENERGY_RATIO);
   if (enforce && invalidProfiles.length > 0) {
     throw new Error(`Prepared Cyclone final lit colors are too dark: ${JSON.stringify(invalidProfiles)}`);
   }
   return deepFreeze({
-    schema: "csscyclone-prepared-final-lit-color-profile@1",
+    schema: "csscyclone-prepared-final-lit-color-profile@2",
     darkFaceValueThreshold: PREPARED_DARK_FACE_VALUE,
     maximumDarkFaceShare: PREPARED_MAXIMUM_DARK_FACE_SHARE,
     minimumMedianLitValue: PREPARED_MINIMUM_MEDIAN_LIT_VALUE,
     srgbLumaWeights: SRGB_LUMA_WEIGHTS,
-    minimumCrossVariantEnergyRatio: PREPARED_MINIMUM_CROSS_VARIANT_ENERGY_RATIO,
+    targetSrgbEnergyRatio: PREPARED_TARGET_ENERGY_RATIO,
+    minimumTargetEnergyRatio: PREPARED_MINIMUM_TARGET_ENERGY_RATIO,
+    maximumTargetEnergyRatio: PREPARED_MAXIMUM_TARGET_ENERGY_RATIO,
     variants: profiles,
   });
 }

--- a/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
@@ -17,8 +17,6 @@ const PREPARED_TARGET_ENERGY_RATIO = Number(((
 ) / 2).toFixed(4));
 const PREPARED_MINIMUM_TARGET_ENERGY_RATIO = 1;
 const PREPARED_MAXIMUM_TARGET_ENERGY_RATIO = 1.03;
-const PREPARED_PRIMARY_HUE_SPREAD = 1 / 24;
-const PREPARED_COMPLEMENTARY_HUE_OFFSET = 5 / 12;
 const PREPARED_COMPLEMENTARY_ACCENT_SHARE = 0.2;
 const SOURCE_VERTEX_NORMALS = Object.freeze(
   CSSCYCLONE_PARTICLE_VERTICES.map((vertex) => Object.freeze(normalize(vertex))),
@@ -148,10 +146,13 @@ async function buildPreparedLightingColors({
   const paletteVariants = CSSCYCLONE_PRESENTATION.preparedPaletteVariants;
   if (!Array.isArray(paletteVariants) || paletteVariants.length !== 12 ||
       new Set(paletteVariants.map(({ id }) => id)).size !== paletteVariants.length ||
-      paletteVariants.some(({ id, hueRotation }, index) =>
+      paletteVariants.some(({ id, hueRotation, preparedHues }, index) =>
         id !== `rotate-${String(index * 30).padStart(3, "0")}` ||
-        hueRotation !== index / paletteVariants.length)) {
-    throw new Error("Cyclone prepared hue-rotation palette configuration drifted");
+        hueRotation !== index / paletteVariants.length ||
+        preparedHues?.length !== 3 ||
+        new Set(preparedHues).size !== preparedHues.length ||
+        preparedHues.some((hue) => typeof hue !== "number" || hue < 0 || hue >= 1))) {
+    throw new Error("Cyclone curated prepared palette configuration drifted");
   }
   const sourceLitVariants = paletteVariants.map((paletteVariant) => {
     const colors = [];
@@ -173,6 +174,7 @@ async function buildPreparedLightingColors({
     return Object.freeze({
       paletteVariantId: paletteVariant.id,
       hueRotation: paletteVariant.hueRotation,
+      preparedHues: paletteVariant.preparedHues,
       colors: Object.freeze(colors),
     });
   });
@@ -187,6 +189,7 @@ async function buildPreparedLightingColors({
     return Object.freeze({
       paletteVariantId: variant.paletteVariantId,
       hueRotation: variant.hueRotation,
+      preparedHues: variant.preparedHues,
       colors: Object.freeze(colors),
       energyRatios: Object.freeze(energyRatios),
     });
@@ -205,12 +208,13 @@ async function buildPreparedLightingColors({
   const variants = logicalVariants.map((variant) => Object.freeze({
     paletteVariantId: variant.paletteVariantId,
     hueRotation: variant.hueRotation,
+    preparedHues: variant.preparedHues,
     colors: Object.freeze(deduplication.uniqueSourceColorIndices.map((index) =>
       variant.colors[index])),
   }));
   const contract = deepFreeze({
-    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@16",
-    technique: "prepared-source-smooth-vertex-lighting-averaged-per-solid-face-with-three-color-split-complementary-session-palettes-mid-green-yellow-reference-srgb-energy-normalization-sparse-source-color-restarts-and-exact-cross-variant-deduplication",
+    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@17",
+    technique: "prepared-source-smooth-vertex-lighting-averaged-per-solid-face-with-curated-three-color-split-complementary-session-palettes-mid-green-yellow-reference-srgb-energy-normalization-sparse-source-color-restarts-and-exact-cross-variant-deduplication",
     source: "src/cyclone/cyclone.cpp#particle::update+initSaver",
     streamId,
     encoding: "CSS-sRGB-hex-plus-little-endian-color-slot-indices-base64",
@@ -353,18 +357,12 @@ export function prepareCyclonePaletteColor(baseColor, paletteVariantId) {
     else hue = (baseColor[0] - baseColor[1]) / chroma + 4;
     hue = (hue / 6 + 1) % 1;
   }
-  const primaryHue = (paletteVariant.hueRotation + 1 / 3) % 1;
-  const preparedHues = [
-    (primaryHue - PREPARED_PRIMARY_HUE_SPREAD + 1) % 1,
-    (primaryHue + PREPARED_PRIMARY_HUE_SPREAD) % 1,
-    (primaryHue + PREPARED_COMPLEMENTARY_HUE_OFFSET) % 1,
-  ];
   const primaryShare = (1 - PREPARED_COMPLEMENTARY_ACCENT_SHARE) / 2;
   const preparedHue = hue < primaryShare
-    ? preparedHues[0]
+    ? paletteVariant.preparedHues[0]
     : hue < primaryShare * 2
-      ? preparedHues[1]
-      : preparedHues[2];
+      ? paletteVariant.preparedHues[1]
+      : paletteVariant.preparedHues[2];
   return hsvToRgb(
     preparedHue,
     saturation,

--- a/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
@@ -213,7 +213,7 @@ async function buildPreparedLightingColors({
       variant.colors[index])),
   }));
   const contract = deepFreeze({
-    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@18",
+    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@19",
     technique: "prepared-source-smooth-vertex-lighting-averaged-per-solid-face-with-curated-three-color-analogous-session-palettes-mid-green-yellow-reference-srgb-energy-normalization-sparse-source-color-restarts-and-exact-cross-variant-deduplication",
     source: "src/cyclone/cyclone.cpp#particle::update+initSaver",
     streamId,

--- a/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/preparedLighting.mjs
@@ -17,7 +17,7 @@ const PREPARED_TARGET_ENERGY_RATIO = Number(((
 ) / 2).toFixed(4));
 const PREPARED_MINIMUM_TARGET_ENERGY_RATIO = 1;
 const PREPARED_MAXIMUM_TARGET_ENERGY_RATIO = 1.03;
-const PREPARED_COMPLEMENTARY_ACCENT_SHARE = 0.2;
+const PREPARED_THIRD_HUE_SHARE = 0.2;
 const SOURCE_VERTEX_NORMALS = Object.freeze(
   CSSCYCLONE_PARTICLE_VERTICES.map((vertex) => Object.freeze(normalize(vertex))),
 );
@@ -213,8 +213,8 @@ async function buildPreparedLightingColors({
       variant.colors[index])),
   }));
   const contract = deepFreeze({
-    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@17",
-    technique: "prepared-source-smooth-vertex-lighting-averaged-per-solid-face-with-curated-three-color-split-complementary-session-palettes-mid-green-yellow-reference-srgb-energy-normalization-sparse-source-color-restarts-and-exact-cross-variant-deduplication",
+    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@18",
+    technique: "prepared-source-smooth-vertex-lighting-averaged-per-solid-face-with-curated-three-color-analogous-session-palettes-mid-green-yellow-reference-srgb-energy-normalization-sparse-source-color-restarts-and-exact-cross-variant-deduplication",
     source: "src/cyclone/cyclone.cpp#particle::update+initSaver",
     streamId,
     encoding: "CSS-sRGB-hex-plus-little-endian-color-slot-indices-base64",
@@ -252,7 +252,7 @@ async function buildPreparedLightingColors({
     sampling: "three-source-smooth-vertex-light-samples-averaged-per-solid-face-state",
     interpolation: "browser-solid-face-average-of-stream-frame-zero-source-vertex-lighting",
     material: Object.freeze({
-      ambientAndDiffuse: "prepared-session-three-color-complementary-palette",
+      ambientAndDiffuse: "prepared-session-three-color-analogous-palette",
       specular: Object.freeze([0.7, 0.7, 0.7, 1]),
       shininess: 20,
     }),
@@ -357,7 +357,7 @@ export function prepareCyclonePaletteColor(baseColor, paletteVariantId) {
     else hue = (baseColor[0] - baseColor[1]) / chroma + 4;
     hue = (hue / 6 + 1) % 1;
   }
-  const primaryShare = (1 - PREPARED_COMPLEMENTARY_ACCENT_SHARE) / 2;
+  const primaryShare = (1 - PREPARED_THIRD_HUE_SHARE) / 2;
   const preparedHue = hue < primaryShare
     ? paletteVariant.preparedHues[0]
     : hue < primaryShare * 2

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -62,13 +62,29 @@ export const CSSCYCLONE_BANKS = Object.freeze({
 
 export const CSSCYCLONE_BANK = CSSCYCLONE_BANKS.desktop;
 
-const PREPARED_PALETTE_STARTUP_WEIGHTS = Object.freeze([3, 3, 3, 3, 2, 1, 1, 1, 1, 1, 2, 3]);
+const PREPARED_PALETTE_STARTUP_WEIGHTS = Object.freeze([3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1]);
+
+const PREPARED_PALETTE_HUES_DEGREES = Object.freeze([
+  Object.freeze([105, 135, 285]),
+  Object.freeze([120, 150, 300]),
+  Object.freeze([150, 180, 330]),
+  Object.freeze([180, 210, 0]),
+  Object.freeze([195, 225, 0]),
+  Object.freeze([210, 240, 15]),
+  Object.freeze([240, 270, 105]),
+  Object.freeze([255, 285, 120]),
+  Object.freeze([270, 300, 135]),
+  Object.freeze([285, 315, 150]),
+  Object.freeze([300, 330, 165]),
+  Object.freeze([315, 345, 180]),
+]);
 
 const PREPARED_PALETTE_VARIANTS = Object.freeze(Array.from({ length: 12 }, (_, index) => {
   const degrees = index * 30;
   return Object.freeze({
     id: `rotate-${String(degrees).padStart(3, "0")}`,
     hueRotation: index / 12,
+    preparedHues: Object.freeze(PREPARED_PALETTE_HUES_DEGREES[index].map((hue) => hue / 360)),
     startupWeight: PREPARED_PALETTE_STARTUP_WEIGHTS[index],
   });
 }));
@@ -79,7 +95,7 @@ export const CSSCYCLONE_PRESENTATION = Object.freeze({
   minimumSaturation: 0.55,
   hueSampling: "source-uniform-random-targets",
   particleColorAssignment: "source-hue-at-particle-restart",
-  preparedPaletteAssignment: "source-hue-ranked-session-three-color-split-complementary-palette",
+  preparedPaletteAssignment: "source-hue-ranked-curated-three-color-split-complementary-palette",
   preparedPaletteVariants: PREPARED_PALETTE_VARIANTS,
   maximumColorFamilyCount: 3,
   startupPaletteFamilies: Object.freeze(["blue", "yellow", "red", "magenta", "green"]),

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -62,11 +62,14 @@ export const CSSCYCLONE_BANKS = Object.freeze({
 
 export const CSSCYCLONE_BANK = CSSCYCLONE_BANKS.desktop;
 
+const PREPARED_PALETTE_STARTUP_WEIGHTS = Object.freeze([3, 3, 3, 3, 2, 1, 1, 1, 1, 1, 2, 3]);
+
 const PREPARED_PALETTE_VARIANTS = Object.freeze(Array.from({ length: 12 }, (_, index) => {
   const degrees = index * 30;
   return Object.freeze({
     id: `rotate-${String(degrees).padStart(3, "0")}`,
     hueRotation: index / 12,
+    startupWeight: PREPARED_PALETTE_STARTUP_WEIGHTS[index],
   });
 }));
 

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -65,18 +65,18 @@ export const CSSCYCLONE_BANK = CSSCYCLONE_BANKS.desktop;
 const PREPARED_PALETTE_STARTUP_WEIGHTS = Object.freeze([3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1]);
 
 const PREPARED_PALETTE_HUES_DEGREES = Object.freeze([
-  Object.freeze([105, 135, 285]),
-  Object.freeze([120, 150, 300]),
-  Object.freeze([150, 180, 330]),
-  Object.freeze([180, 210, 0]),
-  Object.freeze([195, 225, 0]),
-  Object.freeze([210, 240, 15]),
-  Object.freeze([240, 270, 105]),
-  Object.freeze([255, 285, 120]),
-  Object.freeze([270, 300, 135]),
-  Object.freeze([285, 315, 150]),
-  Object.freeze([300, 330, 165]),
-  Object.freeze([315, 345, 180]),
+  Object.freeze([105, 120, 135]),
+  Object.freeze([120, 135, 150]),
+  Object.freeze([150, 165, 180]),
+  Object.freeze([180, 195, 210]),
+  Object.freeze([195, 210, 225]),
+  Object.freeze([210, 225, 240]),
+  Object.freeze([240, 255, 270]),
+  Object.freeze([255, 270, 285]),
+  Object.freeze([270, 285, 300]),
+  Object.freeze([285, 300, 315]),
+  Object.freeze([300, 315, 330]),
+  Object.freeze([330, 345, 0]),
 ]);
 
 const PREPARED_PALETTE_VARIANTS = Object.freeze(Array.from({ length: 12 }, (_, index) => {
@@ -95,7 +95,7 @@ export const CSSCYCLONE_PRESENTATION = Object.freeze({
   minimumSaturation: 0.55,
   hueSampling: "source-uniform-random-targets",
   particleColorAssignment: "source-hue-at-particle-restart",
-  preparedPaletteAssignment: "source-hue-ranked-curated-three-color-split-complementary-palette",
+  preparedPaletteAssignment: "source-hue-ranked-curated-three-color-analogous-palette",
   preparedPaletteVariants: PREPARED_PALETTE_VARIANTS,
   maximumColorFamilyCount: 3,
   startupPaletteFamilies: Object.freeze(["blue", "yellow", "red", "magenta", "green"]),

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -79,7 +79,7 @@ export const CSSCYCLONE_PRESENTATION = Object.freeze({
   minimumSaturation: 0.55,
   hueSampling: "source-uniform-random-targets",
   particleColorAssignment: "source-hue-at-particle-restart",
-  preparedPaletteAssignment: "source-continuous-hue-plus-session-prepared-rotation",
+  preparedPaletteAssignment: "source-hue-ranked-session-three-color-split-complementary-palette",
   preparedPaletteVariants: PREPARED_PALETTE_VARIANTS,
   maximumColorFamilyCount: 3,
   startupPaletteFamilies: Object.freeze(["blue", "yellow", "red", "magenta", "green"]),

--- a/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
+++ b/src/adapters/cyclone/src/prepare/csscyclone/sourceModel.mjs
@@ -65,18 +65,18 @@ export const CSSCYCLONE_BANK = CSSCYCLONE_BANKS.desktop;
 const PREPARED_PALETTE_STARTUP_WEIGHTS = Object.freeze([3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1]);
 
 const PREPARED_PALETTE_HUES_DEGREES = Object.freeze([
-  Object.freeze([105, 120, 135]),
-  Object.freeze([120, 135, 150]),
-  Object.freeze([150, 165, 180]),
-  Object.freeze([180, 195, 210]),
-  Object.freeze([195, 210, 225]),
-  Object.freeze([210, 225, 240]),
-  Object.freeze([240, 255, 270]),
-  Object.freeze([255, 270, 285]),
-  Object.freeze([270, 285, 300]),
-  Object.freeze([285, 300, 315]),
-  Object.freeze([300, 315, 330]),
-  Object.freeze([330, 345, 0]),
+  Object.freeze([90, 120, 150]),
+  Object.freeze([105, 135, 165]),
+  Object.freeze([135, 165, 195]),
+  Object.freeze([165, 195, 225]),
+  Object.freeze([180, 210, 240]),
+  Object.freeze([210, 240, 270]),
+  Object.freeze([225, 255, 285]),
+  Object.freeze([240, 270, 300]),
+  Object.freeze([255, 285, 315]),
+  Object.freeze([270, 300, 330]),
+  Object.freeze([285, 315, 345]),
+  Object.freeze([300, 330, 0]),
 ]);
 
 const PREPARED_PALETTE_VARIANTS = Object.freeze(Array.from({ length: 12 }, (_, index) => {

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -56,7 +56,7 @@ function fixture({
     transforms: ["a", "b", "c", "d", "e", "f", "g", "h"],
   };
   const lighting = {
-    schema: "csscyclone-prepared-energy-balanced-continuous-hue-vertex-lighting-colors@15",
+    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@16",
     streamId: "stream",
     chunkCount: 1,
     chunkFrameCount: blockCount * 4,

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -56,7 +56,7 @@ function fixture({
     transforms: ["a", "b", "c", "d", "e", "f", "g", "h"],
   };
   const lighting = {
-    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@16",
+    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@17",
     streamId: "stream",
     chunkCount: 1,
     chunkFrameCount: blockCount * 4,

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -56,7 +56,7 @@ function fixture({
     transforms: ["a", "b", "c", "d", "e", "f", "g", "h"],
   };
   const lighting = {
-    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@18",
+    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@19",
     streamId: "stream",
     chunkCount: 1,
     chunkFrameCount: blockCount * 4,

--- a/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-prepared-playback.test.mjs
@@ -56,7 +56,7 @@ function fixture({
     transforms: ["a", "b", "c", "d", "e", "f", "g", "h"],
   };
   const lighting = {
-    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@17",
+    schema: "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@18",
     streamId: "stream",
     chunkCount: 1,
     chunkFrameCount: blockCount * 4,

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -75,7 +75,12 @@ test("pins the current Really Slick Cyclone source profile", () => {
   assert.deepEqual(CSSCYCLONE_PRESENTATION.preparedPaletteVariants[4], {
     id: "rotate-120",
     hueRotation: 1 / 3,
+    startupWeight: 2,
   });
+  assert.deepEqual(
+    CSSCYCLONE_PRESENTATION.preparedPaletteVariants.map(({ startupWeight }) => startupWeight),
+    [3, 3, 3, 3, 2, 1, 1, 1, 1, 1, 2, 3],
+  );
   assert.equal(CSSCYCLONE_PRESENTATION.maximumColorFamilyCount, 3);
   assert.deepEqual(
     CSSCYCLONE_PRESENTATION.startupPaletteFamilies,

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -69,7 +69,7 @@ test("pins the current Really Slick Cyclone source profile", () => {
   assert.equal(CSSCYCLONE_PRESENTATION.particleColorAssignment, "source-hue-at-particle-restart");
   assert.equal(
     CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
-    "source-continuous-hue-plus-session-prepared-rotation",
+    "source-hue-ranked-session-three-color-split-complementary-palette",
   );
   assert.equal(CSSCYCLONE_PRESENTATION.preparedPaletteVariants.length, 12);
   assert.deepEqual(CSSCYCLONE_PRESENTATION.preparedPaletteVariants[4], {
@@ -336,7 +336,7 @@ test("prepares source-vertex-averaged face lighting without a runtime lighting t
   const bank = { ...CSSCYCLONE_BANK, particleCount: 3, warmupFrames: 20, frameCount: 4 };
   const source = buildCycloneSourceSequence({ bank });
   const prepared = await buildCyclonePreparedLighting({ source });
-  assert.equal(prepared.contract.schema, "csscyclone-prepared-energy-balanced-continuous-hue-vertex-lighting-colors@15");
+  assert.equal(prepared.contract.schema, "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@16");
   assert.equal(prepared.contract.leafCount, 18);
   assert.equal(prepared.contract.colorStateCount, 3);
   assert.equal(prepared.contract.colorRestartCount, 0);
@@ -364,18 +364,20 @@ test("prepares source-vertex-averaged face lighting without a runtime lighting t
   );
   assert.equal(
     prepared.contract.finalLitColorProfile.schema,
-    "csscyclone-prepared-final-lit-color-profile@1",
+    "csscyclone-prepared-final-lit-color-profile@2",
   );
   assert.equal(prepared.contract.finalLitColorProfile.darkFaceValueThreshold, 0.4);
-  assert.equal(prepared.contract.finalLitColorProfile.maximumDarkFaceShare, 0.25);
+  assert.equal(prepared.contract.finalLitColorProfile.maximumDarkFaceShare, 0.2);
   assert.equal(prepared.contract.finalLitColorProfile.minimumMedianLitValue, 0.5);
   assert.deepEqual(
     prepared.contract.finalLitColorProfile.srgbLumaWeights,
     [0.2126, 0.7152, 0.0722],
   );
-  assert.equal(prepared.contract.finalLitColorProfile.minimumCrossVariantEnergyRatio, 1);
+  assert.equal(prepared.contract.finalLitColorProfile.targetSrgbEnergyRatio, 0.8215);
+  assert.equal(prepared.contract.finalLitColorProfile.minimumTargetEnergyRatio, 1);
+  assert.equal(prepared.contract.finalLitColorProfile.maximumTargetEnergyRatio, 1.03);
   assert.ok(prepared.contract.finalLitColorProfile.variants.every((variant) =>
-    variant.minimumCrossVariantEnergyRatio >= 1));
+    variant.minimumTargetEnergyRatio >= 1 && variant.maximumTargetEnergyRatio <= 1.03));
   assert.equal(prepared.contract.finalLitColorProfile.variants.length, 12);
   assert.equal(prepared.contract.variants.length, 12);
   assert.ok(prepared.contract.variants.every((variant, index) =>
@@ -395,6 +397,17 @@ test("prepares source-vertex-averaged face lighting without a runtime lighting t
   const liftedRedBlack = prepareCyclonePaletteColor([0, 0, 0], "rotate-000");
   assert.equal(Math.max(...liftedRedBlack), 0.75);
   assert.equal(Number((1 - Math.min(...liftedBlack) / Math.max(...liftedBlack)).toFixed(2)), 0.55);
+});
+
+test("maps source hues into two primary colors and one split-complementary accent", () => {
+  const preparedHues = Array.from({ length: 10 }, (_, index) => {
+    const source = hsvColor((index + 0.5) / 10, 0.8, 0.8);
+    return rgbHue(prepareCyclonePaletteColor(source, "rotate-000"));
+  });
+  const hueCounts = new Map();
+  for (const hue of preparedHues) hueCounts.set(hue, (hueCounts.get(hue) ?? 0) + 1);
+  assert.deepEqual([...hueCounts.values()], [4, 4, 2]);
+  assert.deepEqual([...hueCounts.keys()], [0.291667, 0.375, 0.75]);
 });
 
 test("publishes only exact source color restarts through sparse leaf colors", async () => {
@@ -468,3 +481,31 @@ test("preserves the source tangent orientation", () => {
     11.576768, -18.356715, 79.662214, 1,
   ]);
 });
+
+function hsvColor(hue, saturation, value) {
+  const sector = hue * 6;
+  const index = Math.floor(sector) % 6;
+  const fraction = sector - Math.floor(sector);
+  const minimum = value * (1 - saturation);
+  const descending = value * (1 - fraction * saturation);
+  const ascending = value * (1 - (1 - fraction) * saturation);
+  return [
+    [value, ascending, minimum],
+    [descending, value, minimum],
+    [minimum, value, ascending],
+    [minimum, descending, value],
+    [ascending, minimum, value],
+    [value, minimum, descending],
+  ][index];
+}
+
+function rgbHue(color) {
+  const maximum = Math.max(...color);
+  const minimum = Math.min(...color);
+  const chroma = maximum - minimum;
+  let hue = 0;
+  if (maximum === color[0]) hue = ((color[1] - color[2]) / chroma) % 6;
+  else if (maximum === color[1]) hue = (color[2] - color[0]) / chroma + 2;
+  else hue = (color[0] - color[1]) / chroma + 4;
+  return Number(((hue / 6 + 1) % 1).toFixed(6));
+}

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -69,13 +69,13 @@ test("pins the current Really Slick Cyclone source profile", () => {
   assert.equal(CSSCYCLONE_PRESENTATION.particleColorAssignment, "source-hue-at-particle-restart");
   assert.equal(
     CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
-    "source-hue-ranked-curated-three-color-split-complementary-palette",
+    "source-hue-ranked-curated-three-color-analogous-palette",
   );
   assert.equal(CSSCYCLONE_PRESENTATION.preparedPaletteVariants.length, 12);
   assert.deepEqual(CSSCYCLONE_PRESENTATION.preparedPaletteVariants[4], {
     id: "rotate-120",
     hueRotation: 1 / 3,
-    preparedHues: [195 / 360, 225 / 360, 0],
+    preparedHues: [195 / 360, 210 / 360, 225 / 360],
     startupWeight: 2,
   });
   assert.deepEqual(
@@ -337,7 +337,7 @@ test("prepares source-vertex-averaged face lighting without a runtime lighting t
   const bank = { ...CSSCYCLONE_BANK, particleCount: 3, warmupFrames: 20, frameCount: 4 };
   const source = buildCycloneSourceSequence({ bank });
   const prepared = await buildCyclonePreparedLighting({ source });
-  assert.equal(prepared.contract.schema, "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@17");
+  assert.equal(prepared.contract.schema, "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@18");
   assert.equal(prepared.contract.leafCount, 18);
   assert.equal(prepared.contract.colorStateCount, 3);
   assert.equal(prepared.contract.colorRestartCount, 0);
@@ -401,7 +401,7 @@ test("prepares source-vertex-averaged face lighting without a runtime lighting t
   assert.equal(Number((1 - Math.min(...liftedBlack) / Math.max(...liftedBlack)).toFixed(2)), 0.55);
 });
 
-test("maps source hues into two primary colors and one split-complementary accent", () => {
+test("maps source hues into three neighboring prepared colors", () => {
   const preparedHues = Array.from({ length: 10 }, (_, index) => {
     const source = hsvColor((index + 0.5) / 10, 0.8, 0.8);
     return rgbHue(prepareCyclonePaletteColor(source, "rotate-000"));
@@ -409,7 +409,7 @@ test("maps source hues into two primary colors and one split-complementary accen
   const hueCounts = new Map();
   for (const hue of preparedHues) hueCounts.set(hue, (hueCounts.get(hue) ?? 0) + 1);
   assert.deepEqual([...hueCounts.values()], [4, 4, 2]);
-  assert.deepEqual([...hueCounts.keys()], [0.291667, 0.375, 0.791667]);
+  assert.deepEqual([...hueCounts.keys()], [0.291667, 0.333333, 0.375]);
 });
 
 test("publishes only exact source color restarts through sparse leaf colors", async () => {

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -75,7 +75,7 @@ test("pins the current Really Slick Cyclone source profile", () => {
   assert.deepEqual(CSSCYCLONE_PRESENTATION.preparedPaletteVariants[4], {
     id: "rotate-120",
     hueRotation: 1 / 3,
-    preparedHues: [195 / 360, 210 / 360, 225 / 360],
+    preparedHues: [180 / 360, 210 / 360, 240 / 360],
     startupWeight: 2,
   });
   assert.deepEqual(
@@ -337,7 +337,7 @@ test("prepares source-vertex-averaged face lighting without a runtime lighting t
   const bank = { ...CSSCYCLONE_BANK, particleCount: 3, warmupFrames: 20, frameCount: 4 };
   const source = buildCycloneSourceSequence({ bank });
   const prepared = await buildCyclonePreparedLighting({ source });
-  assert.equal(prepared.contract.schema, "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@18");
+  assert.equal(prepared.contract.schema, "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@19");
   assert.equal(prepared.contract.leafCount, 18);
   assert.equal(prepared.contract.colorStateCount, 3);
   assert.equal(prepared.contract.colorRestartCount, 0);
@@ -409,7 +409,7 @@ test("maps source hues into three neighboring prepared colors", () => {
   const hueCounts = new Map();
   for (const hue of preparedHues) hueCounts.set(hue, (hueCounts.get(hue) ?? 0) + 1);
   assert.deepEqual([...hueCounts.values()], [4, 4, 2]);
-  assert.deepEqual([...hueCounts.keys()], [0.291667, 0.333333, 0.375]);
+  assert.deepEqual([...hueCounts.keys()], [0.25, 0.333333, 0.416667]);
 });
 
 test("publishes only exact source color restarts through sparse leaf colors", async () => {

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -69,17 +69,18 @@ test("pins the current Really Slick Cyclone source profile", () => {
   assert.equal(CSSCYCLONE_PRESENTATION.particleColorAssignment, "source-hue-at-particle-restart");
   assert.equal(
     CSSCYCLONE_PRESENTATION.preparedPaletteAssignment,
-    "source-hue-ranked-session-three-color-split-complementary-palette",
+    "source-hue-ranked-curated-three-color-split-complementary-palette",
   );
   assert.equal(CSSCYCLONE_PRESENTATION.preparedPaletteVariants.length, 12);
   assert.deepEqual(CSSCYCLONE_PRESENTATION.preparedPaletteVariants[4], {
     id: "rotate-120",
     hueRotation: 1 / 3,
+    preparedHues: [195 / 360, 225 / 360, 0],
     startupWeight: 2,
   });
   assert.deepEqual(
     CSSCYCLONE_PRESENTATION.preparedPaletteVariants.map(({ startupWeight }) => startupWeight),
-    [3, 3, 3, 3, 2, 1, 1, 1, 1, 1, 2, 3],
+    [3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1],
   );
   assert.equal(CSSCYCLONE_PRESENTATION.maximumColorFamilyCount, 3);
   assert.deepEqual(
@@ -336,7 +337,7 @@ test("prepares source-vertex-averaged face lighting without a runtime lighting t
   const bank = { ...CSSCYCLONE_BANK, particleCount: 3, warmupFrames: 20, frameCount: 4 };
   const source = buildCycloneSourceSequence({ bank });
   const prepared = await buildCyclonePreparedLighting({ source });
-  assert.equal(prepared.contract.schema, "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@16");
+  assert.equal(prepared.contract.schema, "csscyclone-prepared-energy-balanced-three-color-vertex-lighting-colors@17");
   assert.equal(prepared.contract.leafCount, 18);
   assert.equal(prepared.contract.colorStateCount, 3);
   assert.equal(prepared.contract.colorRestartCount, 0);
@@ -382,7 +383,8 @@ test("prepares source-vertex-averaged face lighting without a runtime lighting t
   assert.equal(prepared.contract.variants.length, 12);
   assert.ok(prepared.contract.variants.every((variant, index) =>
     variant.paletteVariantId === prepared.contract.paletteVariantIds[index] &&
-    variant.hueRotation === index / 12));
+    variant.hueRotation === index / 12 &&
+    variant.preparedHues.length === 3));
   assert.equal(prepared.contract.sourceStreamFrameCount, 4);
   assert.equal(prepared.contract.chunkCount, 1);
   assert.equal(prepared.chunk.frameParticleColorStateIndices.length, 4);
@@ -407,7 +409,7 @@ test("maps source hues into two primary colors and one split-complementary accen
   const hueCounts = new Map();
   for (const hue of preparedHues) hueCounts.set(hue, (hueCounts.get(hue) ?? 0) + 1);
   assert.deepEqual([...hueCounts.values()], [4, 4, 2]);
-  assert.deepEqual([...hueCounts.keys()], [0.291667, 0.375, 0.75]);
+  assert.deepEqual([...hueCounts.keys()], [0.291667, 0.375, 0.791667]);
 });
 
 test("publishes only exact source color restarts through sparse leaf colors", async () => {

--- a/src/adapters/cyclone/test/csscyclone-startup-palette-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-startup-palette-selection.test.mjs
@@ -4,26 +4,43 @@ import { selectCycloneStartupPaletteVariant } from "../src/csscyclone/startupPal
 
 const variantIds = Object.freeze(Array.from({ length: 12 }, (_, index) =>
   `rotate-${String(index * 30).padStart(3, "0")}`));
+const weights = Object.freeze([3, 3, 3, 3, 2, 1, 1, 1, 1, 1, 2, 3]);
 
-test("visits every prepared hue rotation once before repeating across reloads", () => {
+test("biases reloads toward cool rotations without adjacent repeats", () => {
   const storage = fixtureStorage();
   let randomValue = 0;
-  const options = { storage, randomUint32: () => randomValue++ };
-  const firstCycle = Array.from({ length: variantIds.length }, () =>
+  const options = { storage, weights, randomUint32: () => randomValue++ };
+  const cycleLength = weights.reduce((sum, weight) => sum + weight, 0);
+  const firstCycle = Array.from({ length: cycleLength }, () =>
     selectCycloneStartupPaletteVariant(variantIds, options).paletteVariantId);
-  const secondCycle = Array.from({ length: variantIds.length }, () =>
+  const secondCycle = Array.from({ length: cycleLength }, () =>
     selectCycloneStartupPaletteVariant(variantIds, options).paletteVariantId);
-  assert.equal(new Set(firstCycle).size, variantIds.length);
-  assert.equal(new Set(secondCycle).size, variantIds.length);
-  assert.notEqual(secondCycle[0], firstCycle.at(-1));
+  for (const cycle of [firstCycle, secondCycle]) {
+    assert.deepEqual(
+      variantIds.map((variantId) => cycle.filter((entry) => entry === variantId).length),
+      weights,
+    );
+  }
+  const combined = [...firstCycle, ...secondCycle];
+  assert.ok(combined.every((variantId, index) =>
+    index === 0 || variantId !== combined[index - 1]));
+  assert.equal(firstCycle.filter((variantId) =>
+    ["rotate-000", "rotate-030", "rotate-060", "rotate-090", "rotate-120", "rotate-300", "rotate-330"]
+      .includes(variantId)).length, 19);
+  assert.equal(firstCycle.filter((variantId) => variantId === "rotate-240").length, 1);
 });
 
 test("rejects a broken palette bank or random source", () => {
   assert.throws(() => selectCycloneStartupPaletteVariant(["red", "red"]), /distinct prepared variants/u);
   assert.throws(() => selectCycloneStartupPaletteVariant(variantIds, {
     storage: fixtureStorage(),
+    weights,
     randomUint32: () => -1,
   }), /must be uint32/u);
+  assert.throws(() => selectCycloneStartupPaletteVariant(variantIds, {
+    storage: fixtureStorage(),
+    weights: weights.slice(1),
+  }), /positive prepared weights/u);
 });
 
 function fixtureStorage() {

--- a/src/adapters/cyclone/test/csscyclone-startup-palette-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-startup-palette-selection.test.mjs
@@ -4,7 +4,7 @@ import { selectCycloneStartupPaletteVariant } from "../src/csscyclone/startupPal
 
 const variantIds = Object.freeze(Array.from({ length: 12 }, (_, index) =>
   `rotate-${String(index * 30).padStart(3, "0")}`));
-const weights = Object.freeze([3, 3, 3, 3, 2, 1, 1, 1, 1, 1, 2, 3]);
+const weights = Object.freeze([3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1]);
 
 test("biases reloads toward cool rotations without adjacent repeats", () => {
   const storage = fixtureStorage();
@@ -25,9 +25,10 @@ test("biases reloads toward cool rotations without adjacent repeats", () => {
   assert.ok(combined.every((variantId, index) =>
     index === 0 || variantId !== combined[index - 1]));
   assert.equal(firstCycle.filter((variantId) =>
-    ["rotate-000", "rotate-030", "rotate-060", "rotate-090", "rotate-120", "rotate-300", "rotate-330"]
-      .includes(variantId)).length, 19);
-  assert.equal(firstCycle.filter((variantId) => variantId === "rotate-240").length, 1);
+    ["rotate-000", "rotate-030", "rotate-060", "rotate-090", "rotate-120", "rotate-150"]
+      .includes(variantId)).length, 16);
+  assert.equal(firstCycle.filter((variantId) =>
+    ["rotate-240", "rotate-270", "rotate-300", "rotate-330"].includes(variantId)).length, 4);
 });
 
 test("rejects a broken palette bank or random source", () => {

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -10,7 +10,7 @@ const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", 
 const startupPaletteFamilies = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
 const startupPaletteVariantIds = Object.freeze(Array.from({ length: 12 }, (_, index) =>
   `rotate-${String(index * 30).padStart(3, "0")}`));
-const startupPaletteVariantWeights = Object.freeze([3, 3, 3, 3, 2, 1, 1, 1, 1, 1, 2, 3]);
+const startupPaletteVariantWeights = Object.freeze([3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1]);
 const startupSelections = Object.freeze([
   Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 17, startFrameIndex: 249, frameCount: 48 }),
   Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 23, startFrameIndex: 492, frameCount: 48 }),

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -10,6 +10,7 @@ const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", 
 const startupPaletteFamilies = Object.freeze(["blue", "yellow", "red", "magenta", "green"]);
 const startupPaletteVariantIds = Object.freeze(Array.from({ length: 12 }, (_, index) =>
   `rotate-${String(index * 30).padStart(3, "0")}`));
+const startupPaletteVariantWeights = Object.freeze([3, 3, 3, 3, 2, 1, 1, 1, 1, 1, 2, 3]);
 const startupSelections = Object.freeze([
   Object.freeze({ id: "blue-a", paletteFamily: "blue", chunkIndex: 17, startFrameIndex: 249, frameCount: 48 }),
   Object.freeze({ id: "blue-b", paletteFamily: "blue", chunkIndex: 23, startFrameIndex: 492, frameCount: 48 }),
@@ -49,11 +50,12 @@ const catalog = Object.freeze({
   streamDurationMilliseconds: 216_000,
   startupPaletteFamilies,
   startupPaletteVariantIds,
+  startupPaletteVariantWeights,
   startupSelections,
   startupSilhouetteSampling: "browser-reviewed-expressive-source-windows",
   startupSilhouetteSampleFrameOffsets: Object.freeze([0, 12, 24, 36, 47]),
   maximumColorFamilyCount: 3,
-  selection: "session-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat",
+  selection: "session-weighted-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat",
   startupColorProfile: Object.freeze({
     schema: "csscyclone-prepared-startup-color-profile@2",
     metric: "prepared-source-particle-rgb-hsv-dominant-family-per-curated-window",
@@ -149,7 +151,7 @@ test("uses the session-shuffled hue rotation with an independent curated source 
     sourcePaletteFamily: "magenta",
     chunkIndex: 12,
     frameIndex: 451,
-    mode: "session-shuffled-hue-rotation-crypto-random-source-window",
+    mode: "session-weighted-shuffled-hue-rotation-crypto-random-source-window",
   });
 });
 

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -370,6 +370,7 @@ async function writePreparedLightingVariantAssets(lighting, profile) {
       streamId: lighting.streamId,
       paletteVariantId: variant.paletteVariantId,
       hueRotation: variant.hueRotation,
+      preparedHues: variant.preparedHues,
       uniqueColorCount: lighting.uniqueColorCount,
       colors: variant.colors,
     })}\n`);
@@ -379,6 +380,7 @@ async function writePreparedLightingVariantAssets(lighting, profile) {
     variants.push(Object.freeze({
       paletteVariantId: variant.paletteVariantId,
       hueRotation: variant.hueRotation,
+      preparedHues: variant.preparedHues,
       assetUrl,
       byteLength: bytes.byteLength,
       sha256: digest,

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -41,6 +41,9 @@ const startupPaletteFamilies = CSSCYCLONE_PRESENTATION.startupPaletteFamilies;
 const startupPaletteVariantIds = Object.freeze(
   CSSCYCLONE_PRESENTATION.preparedPaletteVariants.map(({ id }) => id),
 );
+const startupPaletteVariantWeights = Object.freeze(
+  CSSCYCLONE_PRESENTATION.preparedPaletteVariants.map(({ startupWeight }) => startupWeight),
+);
 const startupSilhouetteSampleFrameOffsets = CSSCYCLONE_PRESENTATION.startupSilhouetteSampleFrameOffsets;
 const hueSectorNames = Object.freeze(["red", "yellow", "green", "cyan", "blue", "magenta"]);
 const profileConfigs = Object.freeze([
@@ -235,12 +238,13 @@ async function prepareProfile(profile) {
     streamDurationMilliseconds: bank.chunkCount * bank.frameCount / bank.framesPerSecond * 1_000,
     startupPaletteFamilies,
     startupPaletteVariantIds,
+    startupPaletteVariantWeights,
     startupSelections,
     startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
     startupSilhouetteSampleFrameOffsets,
     maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
     startupColorProfile,
-    selection: "session-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat",
+    selection: "session-weighted-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat",
     playbackOrder: "source-continuous-ascending-chunks-with-one-terminal-stream-wrap",
     runtimeLookaheadBlockCount,
     runtimeMaterializedLookaheadBlockCount,
@@ -289,12 +293,13 @@ async function prepareProfile(profile) {
         streamDurationMilliseconds: bank.chunkCount * bank.frameCount / bank.framesPerSecond * 1_000,
         startupPaletteFamilies,
         startupPaletteVariantIds,
+        startupPaletteVariantWeights,
         startupSelections,
         startupSilhouetteSampling: CSSCYCLONE_PRESENTATION.startupSilhouetteSampling,
         startupSilhouetteSampleFrameOffsets,
         maximumColorFamilyCount: CSSCYCLONE_PRESENTATION.maximumColorFamilyCount,
         startupColorProfile,
-        startupSelection: "session-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat",
+        startupSelection: "session-weighted-shuffled-hue-rotation-plus-crypto-source-window-no-immediate-repeat",
         handoff: "source-continuous-twelve-block-decoded-window",
       }),
       productParticleCount: bank.particleCount,


### PR DESCRIPTION
## Summary
- replace independently sampled cyclone colors with prepared three-color analogous palettes
- widen neighboring hue steps while keeping each palette coordinated and avoiding orange/brown combinations
- preserve cool-biased randomized reloads and midpoint luminance normalization
- keep the retained DOM, prepared lighting, desktop/mobile leaf counts, and runtime behavior unchanged

## Verification
- `pnpm test:cyclone` (34/34)
- `pnpm prepare:cyclone`
- `pnpm build:cyclone`
- `pnpm typecheck`
- `pnpm verify:source-only`
- browser retained-DOM smoke: 1,920 desktop leaves, stable identity, no runtime DOM growth, zero runtime lighting calculations