### PR TITLE
fix(cyclone): improve startup and stream framing

### DIFF
--- a/src/adapters/cyclone/src/csscyclone/client.mjs
+++ b/src/adapters/cyclone/src/csscyclone/client.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-import { createPolyPerspectiveCamera } from "@layoutit/polycss";
-import { loadPolyMorphPackage, mountPolyMorphModel } from "@layoutit/polycss-morph";
+import { loadPolyMorphPackage } from "@layoutit/polycss-morph";
+import { prepareCycloneDom } from "./preparedDom.mjs";
 import { loadCyclonePreparedLightingColors } from "./preparedLightingColors.mjs";
 import { createCyclonePreparedPlayer } from "./preparedPlayback.mjs";
 import {
@@ -89,11 +89,8 @@ export async function mountCycloneClient(host) {
       blockLoader.prime(residentBlockIndices),
     ]);
     lightingColors = loadedLightingColors;
-    const mounted = mountPolyMorphModel(host, loaded.model, {
-      resources: loaded.resources,
-      camera: createPolyPerspectiveCamera({ perspective: 800, target: [0, 0, 0], rotX: 0, rotY: 0, zoom: 50 }),
-    });
-    const modelTransform = cleanPreparedDom(mounted);
+    const preparedDom = prepareCycloneDom(host, loaded);
+    const { mounted, modelTransform } = preparedDom;
     const player = createCyclonePreparedPlayer({
       mounted,
       modelTransform,
@@ -113,6 +110,7 @@ export async function mountCycloneClient(host) {
       },
     });
     player.resize();
+    preparedDom.attach();
     addEventListener("resize", player.resize, { passive: true });
     state.metadata = metadata;
     state.profile = profile;
@@ -146,45 +144,6 @@ export async function mountCycloneClient(host) {
 
 function waitForCycloneScenePaint() {
   return new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)));
-}
-
-function cleanPreparedDom(mounted) {
-  mounted.cameraElement.className = "polycss-camera";
-  mounted.cameraElement.removeAttribute("data-polycss-camera-projection");
-  mounted.cameraElement.removeAttribute("data-polycss-camera-perspective");
-  mounted.cameraElement.style.removeProperty("perspective");
-  mounted.sceneElement.className = "polycss-scene";
-  mounted.sceneElement.removeAttribute("aria-hidden");
-  mounted.sceneElement.style.removeProperty("transform");
-  mounted.modelElement.removeAttribute("class");
-  mounted.modelElement.removeAttribute("data-poly-morph-model");
-  for (const element of mounted.shapeElements.values()) {
-    element.removeAttribute("class");
-    element.removeAttribute("data-poly-morph-shape");
-  }
-  for (const { element } of mounted.leafHandles.values()) {
-    element.removeAttribute("class");
-    element.removeAttribute("data-poly-morph-leaf");
-    element.removeAttribute("data-poly-morph-strategy");
-    element.removeAttribute("data-poly-morph-resolved-strategy");
-    element.style.removeProperty("backface-visibility");
-    element.style.removeProperty("color");
-    element.style.removeProperty("opacity");
-    element.style.removeProperty("transform-origin");
-    element.style.removeProperty("visibility");
-  }
-  if (mounted.modelElement.parentElement !== mounted.sceneElement ||
-      [...mounted.shapeElements.values()].some((element) =>
-        element.parentElement !== mounted.modelElement)) {
-    throw new Error("Cyclone prepared model wrapper binding drifted");
-  }
-  const modelTransform = mounted.modelElement.style.transform;
-  for (const element of mounted.shapeElements.values()) mounted.sceneElement.append(element);
-  if (mounted.modelElement.childElementCount !== 0) {
-    throw new Error("Cyclone prepared model wrapper contains unexpected retained nodes");
-  }
-  mounted.modelElement.remove();
-  return modelTransform;
 }
 
 function installDebugApi(state) {

--- a/src/adapters/cyclone/src/csscyclone/preparedDom.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedDom.mjs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import {
+  createPolyPerspectiveCamera,
+  formatMatrix3dValues,
+  injectPolyBaseStyles,
+} from "@layoutit/polycss";
+import { mountPolyMorphModel } from "@layoutit/polycss-morph";
+
+export function prepareCycloneDom(host, loaded) {
+  const doc = host.ownerDocument;
+  const model = loaded.model;
+  let mounted;
+  let modelTransform;
+
+  if (supportsPreparedTriangles(doc, model)) {
+    injectPolyBaseStyles(doc);
+    ({ mounted, modelTransform } = mountPreparedTriangles(doc, model));
+  } else {
+    const stagingHost = doc.createElement("div");
+    mounted = mountPolyMorphModel(stagingHost, model, {
+      resources: loaded.resources,
+      camera: createPolyPerspectiveCamera({
+        perspective: 800,
+        target: [0, 0, 0],
+        rotX: 0,
+        rotY: 0,
+        zoom: 50,
+      }),
+    });
+    modelTransform = cleanPreparedDom(mounted);
+  }
+
+  return {
+    mounted,
+    modelTransform,
+    attach() {
+      host.append(mounted.cameraElement);
+    },
+  };
+}
+
+function supportsPreparedTriangles(doc, model) {
+  const css = doc.defaultView?.CSS ?? globalThis.CSS;
+  return !!css?.supports?.("corner-top-left-shape", "bevel") &&
+    !!css.supports("corner-top-right-shape", "bevel") &&
+    model.render.leaves.every((leaf) => leaf.strategy === "solid-triangle");
+}
+
+function mountPreparedTriangles(doc, model) {
+  const cameraElement = doc.createElement("div");
+  cameraElement.className = "polycss-camera";
+  const sceneElement = doc.createElement("div");
+  sceneElement.className = "polycss-scene";
+  cameraElement.append(sceneElement);
+
+  sceneElement.style.transform = matrixText(model.render.modelMatrix);
+  const modelTransform = sceneElement.style.transform;
+  sceneElement.style.removeProperty("transform");
+
+  const shapeElements = new Map();
+  for (const shape of model.render.shapes) {
+    const element = doc.createElement("div");
+    sceneElement.append(element);
+    shapeElements.set(shape.id, element);
+  }
+
+  const leafHandles = new Map();
+  for (const leaf of model.render.leaves) {
+    const element = doc.createElement("u");
+    element.style.transform = matrixText(leaf.matrix);
+    shapeElements.get(leaf.shapeId).append(element);
+    leafHandles.set(leaf.id, { id: leaf.id, plan: leaf, element });
+  }
+
+  let destroyed = false;
+  const mounted = {
+    model,
+    cameraElement,
+    sceneElement,
+    shapeElements,
+    leafHandles,
+    get destroyed() { return destroyed; },
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      cameraElement.remove();
+      shapeElements.clear();
+      leafHandles.clear();
+    },
+  };
+  return { mounted, modelTransform };
+}
+
+function matrixText(matrix) {
+  return `matrix3d(${formatMatrix3dValues(matrix)})`;
+}
+
+function cleanPreparedDom(mounted) {
+  mounted.cameraElement.className = "polycss-camera";
+  mounted.cameraElement.removeAttribute("data-polycss-camera-projection");
+  mounted.cameraElement.removeAttribute("data-polycss-camera-perspective");
+  mounted.cameraElement.style.removeProperty("perspective");
+  mounted.sceneElement.className = "polycss-scene";
+  mounted.sceneElement.removeAttribute("aria-hidden");
+  mounted.sceneElement.style.removeProperty("transform");
+  mounted.modelElement.removeAttribute("class");
+  mounted.modelElement.removeAttribute("data-poly-morph-model");
+  for (const element of mounted.shapeElements.values()) {
+    element.removeAttribute("class");
+    element.removeAttribute("data-poly-morph-shape");
+  }
+  for (const { element } of mounted.leafHandles.values()) {
+    element.removeAttribute("class");
+    element.removeAttribute("data-poly-morph-leaf");
+    element.removeAttribute("data-poly-morph-strategy");
+    element.removeAttribute("data-poly-morph-resolved-strategy");
+    element.style.removeProperty("backface-visibility");
+    element.style.removeProperty("color");
+    element.style.removeProperty("opacity");
+    element.style.removeProperty("transform-origin");
+    element.style.removeProperty("visibility");
+  }
+  if (mounted.modelElement.parentElement !== mounted.sceneElement ||
+      [...mounted.shapeElements.values()].some((element) =>
+        element.parentElement !== mounted.modelElement)) {
+    throw new Error("Cyclone prepared model wrapper binding drifted");
+  }
+  const modelTransform = mounted.modelElement.style.transform;
+  for (const element of mounted.shapeElements.values()) mounted.sceneElement.append(element);
+  if (mounted.modelElement.childElementCount !== 0) {
+    throw new Error("Cyclone prepared model wrapper contains unexpected retained nodes");
+  }
+  mounted.modelElement.remove();
+  return modelTransform;
+}

--- a/src/adapters/cyclone/src/csscyclone/styles.css
+++ b/src/adapters/cyclone/src/csscyclone/styles.css
@@ -161,8 +161,14 @@ body > .polycss-camera > .polycss-scene > div {
 }
 
 body > .polycss-camera > .polycss-scene {
+  left: 60%;
+  top: 60%;
   transform: translateZ(var(--cyclone-perspective))
     matrix3d(1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, -400, 1);
+}
+
+@media (max-width: 599px) {
+  body > .polycss-camera > .polycss-scene { left: 62%; }
 }
 
 body > .polycss-camera :is(u, b) {

--- a/src/adapters/cyclone/test/csscyclone-shell.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-shell.test.mjs
@@ -5,9 +5,10 @@ import test from "node:test";
 const adapter = new URL("../", import.meta.url);
 
 test("uses the cssGraphics shell without product UI or alternate renderers", async () => {
-  const [html, client, playback, stream, worker, styles] = await Promise.all([
+  const [html, client, preparedDom, playback, stream, worker, styles] = await Promise.all([
     readFile(new URL("index.html", adapter), "utf8"),
     readFile(new URL("src/csscyclone/client.mjs", adapter), "utf8"),
+    readFile(new URL("src/csscyclone/preparedDom.mjs", adapter), "utf8"),
     readFile(new URL("src/csscyclone/preparedPlayback.mjs", adapter), "utf8"),
     readFile(new URL("src/csscyclone/preparedStream.mjs", adapter), "utf8"),
     readFile(new URL("src/csscyclone/preparedBlockWorker.mjs", adapter), "utf8"),
@@ -17,7 +18,9 @@ test("uses the cssGraphics shell without product UI or alternate renderers", asy
   assert.match(html, /<nav class="site-actions" aria-label="Scene actions">/u);
   assert.doesNotMatch(html, /<main\b/u);
   assert.doesNotMatch(html, /<canvas\b|<svg\b[^>]*class="scene|controls|button/u);
-  assert.match(client, /mountPolyMorphModel/u);
+  assert.match(preparedDom, /mountPolyMorphModel/u);
+  assert.match(preparedDom, /model\.render\.leaves\.every\(\(leaf\) => leaf\.strategy === "solid-triangle"\)/u);
+  assert.match(preparedDom, /host\.append\(mounted\.cameraElement\)/u);
   assert.match(playback, /createPolyMorphPreparedDomTarget/u);
   assert.match(styles, /\.site-wordmark-svg\s*\{[^}]*width:\s*190px;/su);
   assert.match(styles, /\.site-actions\s*\{/u);
@@ -37,8 +40,8 @@ test("uses the cssGraphics shell without product UI or alternate renderers", asy
   assert.match(styles, /body > \.polycss-camera u\s*\{[^}]*corner-top-left-shape:\s*bevel;/su);
   assert.doesNotMatch(styles, /body > \.polycss-camera :is\(u, b\)\s*\{[^}]*corner-top-left-shape:/su);
   assert.doesNotMatch(styles, /color-mix|--cyclone-tone/u);
-  assert.match(client, /cameraElement\.style\.removeProperty\("perspective"\)/u);
-  assert.match(client, /sceneElement\.style\.removeProperty\("transform"\)/u);
+  assert.match(preparedDom, /cameraElement\.style\.removeProperty\("perspective"\)/u);
+  assert.match(preparedDom, /sceneElement\.style\.removeProperty\("transform"\)/u);
   assert.match(playback, /style\.setProperty\("--cyclone-perspective"/u);
   assert.doesNotMatch(playback, /sceneElement\.style\.transform|cameraElement\.style\.perspective/u);
   assert.match(playback, /deadline-setTimeout-requestAnimationFrame-prepared-publication/u);

--- a/src/adapters/cyclone/test/csscyclone-shell.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-shell.test.mjs
@@ -32,8 +32,9 @@ test("uses the cssGraphics shell without product UI or alternate renderers", asy
   assert.match(styles, /body > \.polycss-camera\s*\{[^}]*perspective:\s*var\(--cyclone-perspective\);/su);
   assert.match(
     styles,
-    /body > \.polycss-camera > \.polycss-scene\s*\{[^}]*transform:\s*translateZ\(var\(--cyclone-perspective\)\)\s*matrix3d\(1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, -400, 1\);/su,
+    /body > \.polycss-camera > \.polycss-scene\s*\{[^}]*left:\s*60%;[^}]*top:\s*60%;[^}]*transform:\s*translateZ\(var\(--cyclone-perspective\)\)\s*matrix3d\(1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, -400, 1\);/su,
   );
+  assert.match(styles, /@media \(max-width: 599px\)\s*\{[^}]*body > \.polycss-camera > \.polycss-scene\s*\{\s*left:\s*62%;/su);
   assert.doesNotMatch(styles, /background-image/u);
   assert.match(styles, /background-color:\s*transparent/u);
   assert.match(styles, /body > \.polycss-camera :is\(u, b\)/u);


### PR DESCRIPTION
## Summary
- avoid duplicate prepared-model validation during Cyclone mount
- center the prepared stream so fewer particles remain fully outside the viewport
- keep the existing particle count, retained DOM, playback, and visual treatment

## Verification
- `pnpm test:cyclone`
- `pnpm build:cyclone`
- deterministic desktop and mobile full-stream visibility audit
- two matched Chrome traces before and after the framing adjustment
- no long tasks or presentation gaps above 33.3 ms