### PR TITLE
fix(site): follow the latest project automatically

### DIFF
--- a/site/layouts/ExamplesLayout.astro
+++ b/site/layouts/ExamplesLayout.astro
@@ -60,7 +60,12 @@ const backgroundClass = project.id === "cloth"
       <Fragment set:html={renderExamplesSidebar(project.id)} />
     </div>
     <Fragment set:html={renderExamplesInfo(project.id)} />
-    <main id={stageId} class="example-stage" aria-busy={stageId === "scene" ? "true" : undefined}></main>
+    <main
+      id={stageId}
+      class="example-stage"
+      data-project-id={project.id}
+      aria-busy={stageId === "scene" ? "true" : undefined}
+    ></main>
     <script>
       import "../examples-shell-client.mjs";
       import "../scene-router.mjs";

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -1,6 +1,25 @@
 ---
-import "../../src/adapters/cloth/src/csscloth/styles.css";
 import ProjectPage from "../components/ProjectPage.astro";
+import { PROJECT_ADAPTER_DIRECTORIES } from "../project-adapters";
+import { PROJECTS } from "../projects";
+
+const latestProject = PROJECTS[0];
+const adapterDirectory = PROJECT_ADAPTER_DIRECTORIES[latestProject.id];
+if (!adapterDirectory) {
+  throw new Error(`Missing adapter for latest css.graphics project: ${latestProject.id}`);
+}
+const adapterStyles = import.meta.glob<string>(
+  "../../src/adapters/*/src/*/styles.css",
+  { eager: true, import: "default", query: "?inline" },
+);
+const stylesheetPrefix = `../../src/adapters/${adapterDirectory}/`;
+const matchingStylesheets = Object.entries(adapterStyles)
+  .filter(([path]) => path.startsWith(stylesheetPrefix));
+if (matchingStylesheets.length !== 1) {
+  throw new Error(`Expected one stylesheet for latest css.graphics project: ${latestProject.id}`);
+}
+const latestProjectStyles = matchingStylesheets[0][1];
 ---
 
-<ProjectPage projectId="cloth" home />
+<style is:global set:html={latestProjectStyles} />
+<ProjectPage projectId={latestProject.id} home />

--- a/site/project-adapters.ts
+++ b/site/project-adapters.ts
@@ -1,0 +1,11 @@
+export const PROJECT_ADAPTER_DIRECTORIES: Readonly<Record<string, string>> = Object.freeze({
+  cloth: "cloth",
+  cyclone: "cyclone",
+  electropaint: "electropaint",
+  flocks: "flocks",
+  gears: "gears",
+  maze: "maze",
+  menger: "menger",
+  pipes: "3dpipes",
+  solitaire: "solitaire",
+});

--- a/site/scene-router.mjs
+++ b/site/scene-router.mjs
@@ -86,5 +86,8 @@ function syncActiveThumbnail() {
 }
 
 function projectIdFromPath(pathname) {
-  return pathname === "/" ? "cloth" : pathname.split("/").filter(Boolean)[0];
+  if (pathname !== "/") return pathname.split("/").filter(Boolean)[0];
+  const projectId = document.querySelector(".example-stage")?.dataset.projectId;
+  if (!projectId) throw new Error("Missing css.graphics home project.");
+  return projectId;
 }

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -83,7 +83,10 @@ test("landing presents the current deployed collection", async () => {
     `${homePage}\n${layout}\n${sceneRouter}\n${projectSource}\n${rendererSource}\n${projectManifestText}`,
     /animated-morph-sphere|webgl-morphtargets|morph-stress-test/u,
   );
-  assert.match(homePage, /<ProjectPage projectId="cloth" home \/>/u);
+  assert.match(homePage, /const latestProject = PROJECTS\[0\];/u);
+  assert.match(homePage, /PROJECT_ADAPTER_DIRECTORIES\[latestProject\.id\]/u);
+  assert.match(homePage, /<ProjectPage projectId=\{latestProject\.id\} home \/>/u);
+  assert.doesNotMatch(homePage, /projectId="cloth"|adapters\/cloth/u);
   assert.match(sceneRouter, /mountClothClient\(host\)/u);
   assert.match(sceneRouter, /mountFlocksClient\(host\)/u);
   assert.match(sceneRouter, /mountCycloneClient\(host\)/u);
@@ -101,6 +104,9 @@ test("landing presents the current deployed collection", async () => {
   assert.match(rendererSource, /"@type": "ItemList"/u);
   assert.match(layout, /renderExamplesSidebar\(project\.id\)/u);
   assert.match(layout, /renderExamplesInfo\(project\.id\)/u);
+  assert.match(layout, /data-project-id=\{project\.id\}/u);
+  assert.match(sceneRouter, /querySelector\("\.example-stage"\)\?\.dataset\.projectId/u);
+  assert.doesNotMatch(sceneRouter, /pathname === "\/" \? "cloth"/u);
   assert.match(layout, /transition:persist="examples-sidebar"/u);
   assert.match(layout, /transition:animate="none"/u);
   assert.match(astroConfig, /devToolbar: \{ enabled: false \}/u);

--- a/src/adapters/cyclone/src/csscyclone/styles.css
+++ b/src/adapters/cyclone/src/csscyclone/styles.css
@@ -72,6 +72,7 @@ body.priming::after {
   height: 100%;
   overflow: hidden;
   background: transparent;
+  pointer-events: none;
   perspective: var(--cyclone-perspective);
   perspective-origin: 50% 50%;
 }

--- a/src/adapters/cyclone/test/csscyclone-shell.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-shell.test.mjs
@@ -26,6 +26,7 @@ test("uses the shared css.graphics examples shell without alternate renderers", 
   assert.match(playback, /createPolyMorphPreparedDomTarget/u);
   assert.match(styles, /\.example-stage\s*\{[^}]*background:\s*linear-gradient\(180deg, #0b1119 0%, #000 100%\);/su);
   assert.match(styles, /\.example-stage > \.polycss-camera\s*\{[^}]*background:\s*transparent;/su);
+  assert.match(styles, /\.example-stage > \.polycss-camera\s*\{[^}]*pointer-events:\s*none;/su);
   assert.match(styles, /\.example-stage > \.polycss-camera\s*\{[^}]*perspective:\s*var\(--cyclone-perspective\);/su);
   assert.match(
     styles,


### PR DESCRIPTION
## Summary
- derive the root scene and stylesheet from the first published project
- remove the hard-coded Cloth home route
- disable pointer hit-testing on Cyclone scene leaves

## Verification
- pnpm test:site
- pnpm test:cyclone
- pnpm build:site
- pnpm build:cyclone
- headless root and pointer-hit contract