### PR TITLE
fix: stabilize shared shell layers

### DIFF
--- a/site/site.css
+++ b/site/site.css
@@ -282,7 +282,7 @@ html.example-background-solitaire {
 }
 
 .example-info {
-  position: fixed;
+  position: absolute;
   z-index: 90;
   top: 0;
   right: 0;
@@ -320,7 +320,7 @@ html.example-background-solitaire {
 }
 
 .example-stage {
-  position: fixed;
+  position: absolute;
   inset: 0 0 0 var(--examples-sidebar-width);
   min-width: 0;
   min-height: 0;


### PR DESCRIPTION
## Summary
- position the shared scene stage relative to the viewport-sized body instead of creating a fixed compositor layer
- keep the shared info banner absolutely positioned with unchanged geometry

## Verification
- `pnpm test:site`
- `pnpm test:cyclone`
- `CSSCYCLONE_DEPLOY_BUILD=1 pnpm build:cyclone`
- `CSSGRAPHICS_DEPLOY_BUILD=1 pnpm build:site`
- 65-second FrameSleuth trace: no presentation gap above 33 ms
- layer count: 1,931 → 1,930 desktop; 1,007 → 1,006 mobile