### PR TITLE
fix(cyclone): use solid black background

### DIFF
--- a/src/adapters/cyclone/index.html
+++ b/src/adapters/cyclone/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Really Slick Cyclone rendered entirely with retained HTML and CSS using PolyCSS." />
     <meta name="robots" content="index, follow" />
-    <meta name="theme-color" content="#0b1119" />
+    <meta name="theme-color" content="#000000" />
     <link rel="canonical" href="https://css.graphics/cyclone/" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="stylesheet" href="/site.css" />

--- a/src/adapters/cyclone/src/csscyclone/styles.css
+++ b/src/adapters/cyclone/src/csscyclone/styles.css
@@ -1,6 +1,6 @@
 :root {
   color-scheme: dark;
-  background: linear-gradient(180deg, #0b1119 0%, #000 100%);
+  background: #000;
   color: #eef2f4;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
@@ -17,7 +17,7 @@ body {
 body {
   position: relative;
   overflow: hidden;
-  background: linear-gradient(180deg, #0b1119 0%, #000 100%);
+  background: #000;
 }
 
 body.loading::before,
@@ -62,7 +62,7 @@ body.priming::after {
 }
 
 .example-stage {
-  background: linear-gradient(180deg, #0b1119 0%, #000 100%);
+  background: #000;
 }
 
 .example-stage > .polycss-camera {

--- a/src/adapters/cyclone/test/csscyclone-shell.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-shell.test.mjs
@@ -24,7 +24,8 @@ test("uses the shared css.graphics examples shell without alternate renderers", 
   assert.match(preparedDom, /model\.render\.leaves\.every\(\(leaf\) => leaf\.strategy === "solid-triangle"\)/u);
   assert.match(preparedDom, /host\.append\(mounted\.cameraElement\)/u);
   assert.match(playback, /createPolyMorphPreparedDomTarget/u);
-  assert.match(styles, /\.example-stage\s*\{[^}]*background:\s*linear-gradient\(180deg, #0b1119 0%, #000 100%\);/su);
+  assert.match(styles, /\.example-stage\s*\{[^}]*background:\s*#000;/su);
+  assert.doesNotMatch(styles, /linear-gradient/u);
   assert.match(styles, /\.example-stage > \.polycss-camera\s*\{[^}]*background:\s*transparent;/su);
   assert.match(styles, /\.example-stage > \.polycss-camera\s*\{[^}]*pointer-events:\s*none;/su);
   assert.match(styles, /\.example-stage > \.polycss-camera\s*\{[^}]*perspective:\s*var\(--cyclone-perspective\);/su);


### PR DESCRIPTION
## Summary
- replace Cyclone's stage gradient with solid black
- keep the document, body, and stage backgrounds consistent
- update the browser theme color

## Verification
- pnpm test:cyclone
- pnpm test:site
- CSSCYCLONE_DEPLOY_BUILD=1 pnpm build:cyclone