### PR TITLE
fix(cyclone): preserve depth guards in prepared blocks

### DIFF
--- a/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
+++ b/src/adapters/cyclone/src/csscyclone/preparedStream.mjs
@@ -772,6 +772,8 @@ function validateBlock(block, descriptor, catalog) {
       !(lighting.frameParticleColorStateIndices instanceof Uint16Array) ||
       lighting.frameParticleColorStateIndices.length !== descriptor.frameCount * playback.particleCount ||
       block.preparedMatrixExpansionCount !== playback.transforms.length ||
+      !Number.isSafeInteger(block.preparedCenterZOverrideCount) ||
+      block.preparedCenterZOverrideCount < 0 ||
       !Number.isSafeInteger(block.preparedCssStringByteLength) ||
       block.preparedCssStringByteLength < playback.transforms.length) {
     throw new Error(`Prepared Cyclone block ${descriptor.index} drifted`);

--- a/src/adapters/cyclone/src/shared/csscyclone/particleTransform.mjs
+++ b/src/adapters/cyclone/src/shared/csscyclone/particleTransform.mjs
@@ -9,13 +9,15 @@ export function advanceCycloneParticleTransform({
   complexity,
   particleSize,
   radialOrbitScale = 1,
+  centerZOverride,
 }) {
   if (!validState(state) || !validPoints(points) || !validWidths(widths) ||
       !Number.isFinite(deltaSeconds) || deltaSeconds <= 0 ||
       !Number.isFinite(speed) || speed <= 0 ||
       !Number.isSafeInteger(complexity) || complexity < 1 || complexity + 2 >= widths.length ||
       !Number.isFinite(particleSize) || particleSize <= 0 ||
-      !Number.isFinite(radialOrbitScale) || radialOrbitScale <= 0) {
+      !Number.isFinite(radialOrbitScale) || radialOrbitScale <= 0 ||
+      (centerZOverride !== undefined && !Number.isFinite(centerZOverride))) {
     throw new TypeError("Complete prepared Cyclone particle transform inputs are required");
   }
   const { width } = state;
@@ -52,8 +54,10 @@ export function advanceCycloneParticleTransform({
       ),
     ),
   );
+  const cssMatrix = flattenCss(matrix);
+  if (centerZOverride !== undefined) cssMatrix[14] = centerZOverride;
   return Object.freeze({
-    matrix: Object.freeze(flattenCss(matrix)),
+    matrix: Object.freeze(cssMatrix),
     state: nextState,
   });
 }

--- a/src/adapters/cyclone/src/shared/csscyclone/preparedBlockTransport.mjs
+++ b/src/adapters/cyclone/src/shared/csscyclone/preparedBlockTransport.mjs
@@ -1,17 +1,18 @@
 import { formatMatrix3dValues } from "@layoutit/polycss";
 import { advanceCycloneParticleTransform } from "./particleTransform.mjs";
 
-export const CSSCYCLONE_BLOCK_ENCODING = "gzip-cyclone-source-state-float64-uint16@1";
+export const CSSCYCLONE_BLOCK_ENCODING = "gzip-cyclone-source-state-float64-uint16-float64@2";
 export const CSSCYCLONE_PLAYBACK_SCHEMA = "csscyclone-prepared-dom-playback@5";
 export const CSSCYCLONE_LIGHTING_BLOCK_SCHEMA = "csscyclone-prepared-lighting-block@2";
 
 const MAGIC = "CCST";
-const VERSION = 1;
+const VERSION = 2;
 const CONTROL_POINT_COUNT = 6;
 const PARTICLE_STATE_FIELD_COUNT = 3;
 const CYCLONE_FRAME_VALUE_COUNT = CONTROL_POINT_COUNT * 3 + CONTROL_POINT_COUNT;
 const HEADER_BYTES = 24;
 const RESET_EVENT_BYTES = 20;
+const CENTER_Z_OVERRIDE_BYTES = 12;
 
 export function encodeCyclonePreparedBlock({ frames, lightingRows, particleCount }) {
   if (!Array.isArray(frames) || frames.length < 1 || frames.length > 0xffff ||
@@ -23,6 +24,18 @@ export function encodeCyclonePreparedBlock({ frames, lightingRows, particleCount
     throw new TypeError("Complete prepared Cyclone source-state block inputs are required");
   }
   const resetEvents = [];
+  const centerZOverrides = [];
+  for (let frameIndex = 0; frameIndex < frames.length; frameIndex += 1) {
+    for (let particleIndex = 0; particleIndex < particleCount; particleIndex += 1) {
+      const centerZ = frames[frameIndex].particles?.[particleIndex]?.preparedCenterZOverride;
+      if (centerZ !== undefined) {
+        if (!Number.isFinite(centerZ)) {
+          throw new TypeError("Prepared Cyclone center-Z overrides must be finite");
+        }
+        centerZOverrides.push({ frameIndex, particleIndex, centerZ });
+      }
+    }
+  }
   for (let frameIndex = 1; frameIndex < frames.length; frameIndex += 1) {
     for (let particleIndex = 0; particleIndex < particleCount; particleIndex += 1) {
       const state = frames[frameIndex].transformState.particles[particleIndex];
@@ -32,9 +45,12 @@ export function encodeCyclonePreparedBlock({ frames, lightingRows, particleCount
   const cycloneBytes = frames.length * CYCLONE_FRAME_VALUE_COUNT * Float64Array.BYTES_PER_ELEMENT;
   const initialStateBytes = particleCount * PARTICLE_STATE_FIELD_COUNT * Float64Array.BYTES_PER_ELEMENT;
   const resetBytes = resetEvents.length * RESET_EVENT_BYTES;
+  const centerZOverrideBytes = centerZOverrides.length * CENTER_Z_OVERRIDE_BYTES;
   const lightingValueCount = frames.length * particleCount;
   const lightingBytes = lightingValueCount * Uint16Array.BYTES_PER_ELEMENT;
-  const bytes = new Uint8Array(HEADER_BYTES + cycloneBytes + initialStateBytes + resetBytes + lightingBytes);
+  const bytes = new Uint8Array(
+    HEADER_BYTES + cycloneBytes + initialStateBytes + resetBytes + centerZOverrideBytes + lightingBytes,
+  );
   const view = new DataView(bytes.buffer);
   for (let index = 0; index < MAGIC.length; index += 1) bytes[index] = MAGIC.charCodeAt(index);
   bytes[4] = VERSION;
@@ -45,7 +61,7 @@ export function encodeCyclonePreparedBlock({ frames, lightingRows, particleCount
   view.setUint16(10, frames.length, true);
   view.setUint32(12, resetEvents.length, true);
   view.setUint32(16, lightingValueCount, true);
-  view.setUint32(20, 0, true);
+  view.setUint32(20, centerZOverrides.length, true);
   let offset = HEADER_BYTES;
   for (const frame of frames) {
     for (const point of frame.transformState.points) {
@@ -71,6 +87,12 @@ export function encodeCyclonePreparedBlock({ frames, lightingRows, particleCount
     view.setFloat64(offset + 4, event.width, true);
     view.setFloat64(offset + 12, event.spinAngle, true);
     offset += RESET_EVENT_BYTES;
+  }
+  for (const event of centerZOverrides) {
+    view.setUint16(offset, event.frameIndex, true);
+    view.setUint16(offset + 2, event.particleIndex, true);
+    view.setFloat64(offset + 4, event.centerZ, true);
+    offset += CENTER_Z_OVERRIDE_BYTES;
   }
   for (const row of lightingRows) {
     for (const value of row) {
@@ -149,7 +171,8 @@ function* decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog) {
   const frameCount = view.getUint16(10, true);
   const resetEventCount = view.getUint32(12, true);
   const lightingValueCount = view.getUint32(16, true);
-  if (view.getUint32(20, true) !== 0 || particleCount !== catalog.particleCount ||
+  const centerZOverrideCount = view.getUint32(20, true);
+  if (particleCount !== catalog.particleCount ||
       frameCount !== descriptor.frameCount || lightingValueCount !== particleCount * frameCount ||
       !validSourceProfile(catalog.sourceTransformProfile)) {
     throw new Error(`Prepared Cyclone block ${descriptor.index} source-state counts drifted`);
@@ -157,14 +180,17 @@ function* decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog) {
   const cycloneBytes = frameCount * CYCLONE_FRAME_VALUE_COUNT * Float64Array.BYTES_PER_ELEMENT;
   const initialStateBytes = particleCount * PARTICLE_STATE_FIELD_COUNT * Float64Array.BYTES_PER_ELEMENT;
   const resetBytes = resetEventCount * RESET_EVENT_BYTES;
+  const centerZOverrideBytes = centerZOverrideCount * CENTER_Z_OVERRIDE_BYTES;
   const lightingBytes = lightingValueCount * Uint16Array.BYTES_PER_ELEMENT;
-  if (HEADER_BYTES + cycloneBytes + initialStateBytes + resetBytes + lightingBytes !== bytes.byteLength) {
+  if (HEADER_BYTES + cycloneBytes + initialStateBytes + resetBytes + centerZOverrideBytes + lightingBytes !==
+      bytes.byteLength) {
     throw new Error(`Prepared Cyclone block ${descriptor.index} binary byte length drifted`);
   }
   const cycloneOffset = HEADER_BYTES;
   const initialStateOffset = cycloneOffset + cycloneBytes;
   const resetOffset = initialStateOffset + initialStateBytes;
-  const lightingOffset = resetOffset + resetBytes;
+  const centerZOverrideOffset = resetOffset + resetBytes;
+  const lightingOffset = centerZOverrideOffset + centerZOverrideBytes;
   const states = Array.from({ length: particleCount }, (_, particleIndex) => {
     const offset = initialStateOffset + particleIndex * PARTICLE_STATE_FIELD_COUNT * Float64Array.BYTES_PER_ELEMENT;
     return {
@@ -197,8 +223,28 @@ function* decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog) {
     previousParticleIndex = event.particleIndex;
     resetEvents.push(event);
   }
+  const centerZOverrides = [];
+  previousFrameIndex = 0;
+  previousParticleIndex = -1;
+  for (let eventIndex = 0; eventIndex < centerZOverrideCount; eventIndex += 1) {
+    const offset = centerZOverrideOffset + eventIndex * CENTER_Z_OVERRIDE_BYTES;
+    const event = {
+      frameIndex: view.getUint16(offset, true),
+      particleIndex: view.getUint16(offset + 2, true),
+      centerZ: view.getFloat64(offset + 4, true),
+    };
+    if (event.frameIndex >= frameCount || event.particleIndex >= particleCount ||
+        !Number.isFinite(event.centerZ) || event.frameIndex < previousFrameIndex ||
+        (event.frameIndex === previousFrameIndex && event.particleIndex <= previousParticleIndex)) {
+      throw new Error(`Prepared Cyclone block ${descriptor.index} center-Z override drifted`);
+    }
+    previousFrameIndex = event.frameIndex;
+    previousParticleIndex = event.particleIndex;
+    centerZOverrides.push(event);
+  }
   const transforms = new Array(frameCount * particleCount);
   let resetCursor = 0;
+  let centerZOverrideCursor = 0;
   let operationsSinceYield = 0;
   for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
     const frameOffset = cycloneOffset + frameIndex * CYCLONE_FRAME_VALUE_COUNT * Float64Array.BYTES_PER_ELEMENT;
@@ -214,6 +260,9 @@ function* decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog) {
         states[particleIndex] = { width: reset.width, step: 0, spinAngle: reset.spinAngle };
         resetCursor += 1;
       }
+      const centerZOverride = centerZOverrides[centerZOverrideCursor];
+      const hasCenterZOverride = centerZOverride?.frameIndex === frameIndex &&
+        centerZOverride.particleIndex === particleIndex;
       const advanced = advanceCycloneParticleTransform({
         state: states[particleIndex],
         points,
@@ -223,7 +272,9 @@ function* decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog) {
         complexity: catalog.sourceTransformProfile.complexity,
         particleSize: catalog.sourceTransformProfile.particleSize,
         radialOrbitScale: catalog.sourceTransformProfile.radialOrbitScale,
+        centerZOverride: hasCenterZOverride ? centerZOverride.centerZ : undefined,
       });
+      if (hasCenterZOverride) centerZOverrideCursor += 1;
       transforms[frameIndex * particleCount + particleIndex] =
         `matrix3d(${formatMatrix3dValues(advanced.matrix, 6)})`;
       states[particleIndex] = advanced.state;
@@ -237,6 +288,9 @@ function* decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog) {
   if (operationsSinceYield > 0) yield operationsSinceYield;
   if (resetCursor !== resetEvents.length) {
     throw new Error(`Prepared Cyclone block ${descriptor.index} reset events were not consumed`);
+  }
+  if (centerZOverrideCursor !== centerZOverrides.length) {
+    throw new Error(`Prepared Cyclone block ${descriptor.index} center-Z overrides were not consumed`);
   }
   const lightingValues = new Uint16Array(lightingValueCount);
   for (let index = 0; index < lightingValues.length; index += 1) {
@@ -286,6 +340,7 @@ function* decodeCyclonePreparedBlockOperations(bytes, descriptor, catalog) {
       frameParticleColorStateIndices: lightingValues,
     }),
     preparedMatrixExpansionCount: transforms.length,
+    preparedCenterZOverrideCount: centerZOverrides.length,
     preparedCssStringByteLength,
   });
 }

--- a/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-source-profile.test.mjs
@@ -310,6 +310,7 @@ test("round-trips exact prepared matrices through compact source-state blocks", 
   });
   const decoded = decodeCyclonePreparedBlock(bytes, descriptor, catalog);
   assert.deepEqual(decoded.playback.transforms, expected.transforms);
+  assert.equal(decoded.preparedCenterZOverrideCount, 0);
   assert.deepEqual(
     [...decoded.lighting.frameParticleColorStateIndices],
     lightingRows.flat(),
@@ -348,6 +349,30 @@ test("round-trips exact prepared matrices through compact source-state blocks", 
     () => decodeCyclonePreparedBlock(bytes.slice(0, -1), descriptor, catalog),
     /binary byte length drifted/u,
   );
+
+  const guardedFrames = source.frames.map((frame, frameIndex) => {
+    if (frameIndex !== 2 && frameIndex !== 17) return frame;
+    const particleIndex = frameIndex === 2 ? 3 : 8;
+    const particles = [...frame.particles];
+    const matrix = [...particles[particleIndex].matrix];
+    matrix[14] = frameIndex === 2 ? 351.125 : 357.875;
+    particles[particleIndex] = Object.freeze({
+      ...particles[particleIndex],
+      matrix: Object.freeze(matrix),
+      preparedCenterZOverride: matrix[14],
+    });
+    return Object.freeze({ ...frame, particles: Object.freeze(particles) });
+  });
+  const guardedSource = Object.freeze({ ...source, frames: Object.freeze(guardedFrames) });
+  const guardedExpected = buildCyclonePreparedPlayback({ source: guardedSource }).playback;
+  const guardedBytes = encodeCyclonePreparedBlock({
+    frames: guardedFrames,
+    lightingRows,
+    particleCount: bank.particleCount,
+  });
+  const guardedDecoded = decodeCyclonePreparedBlock(guardedBytes, descriptor, catalog);
+  assert.deepEqual(guardedDecoded.playback.transforms, guardedExpected.transforms);
+  assert.equal(guardedDecoded.preparedCenterZOverrideCount, 2);
 });
 
 test("prepares source-vertex-averaged face lighting without a runtime lighting timeline", async () => {

--- a/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
+++ b/src/adapters/cyclone/test/csscyclone-stream-selection.test.mjs
@@ -87,7 +87,7 @@ const catalog = Object.freeze({
     startFrameIndex: index * 60,
     frameCount: 60,
     sourceContinuousFromPrevious: index > 0,
-    encoding: "gzip-cyclone-source-state-float64-uint16@1",
+    encoding: "gzip-cyclone-source-state-float64-uint16-float64@2",
     assetUrl: `/block-${index}.bin`,
     byteLength: 1,
     sha256: hash,

--- a/src/adapters/cyclone/tools/prepare-csscyclone.mjs
+++ b/src/adapters/cyclone/tools/prepare-csscyclone.mjs
@@ -10,12 +10,14 @@ import {
   CSSCYCLONE_FACE_INDICES,
   CSSCYCLONE_MODEL_IDS,
   buildCyclonePreparedModel,
+  buildCyclonePreparedPlayback,
 } from "../src/prepare/csscyclone/modelBuilder.mjs";
 import { createCyclonePreparedLightingStream } from "../src/prepare/csscyclone/preparedLighting.mjs";
 import {
   CSSCYCLONE_BLOCK_ENCODING,
   CSSCYCLONE_LIGHTING_BLOCK_SCHEMA,
   CSSCYCLONE_PLAYBACK_SCHEMA,
+  decodeCyclonePreparedBlock,
   encodeCyclonePreparedBlock,
 } from "../src/shared/csscyclone/preparedBlockTransport.mjs";
 import {
@@ -142,6 +144,26 @@ async function prepareProfile(profile) {
   if (!Number.isSafeInteger(blocksPerChunk)) {
     throw new Error(`Cyclone ${profile.id} prepared chunk must divide into exact transport blocks`);
   }
+  const transportCatalog = Object.freeze({
+    streamId: bank.id,
+    modelId: profile.modelId,
+    particleCount: bank.particleCount,
+    leafCount: bank.particleCount * CSSCYCLONE_FACE_INDICES.length,
+    frameMilliseconds: bank.frameMilliseconds,
+    framesPerSecond: bank.framesPerSecond,
+    chunkCount: bank.chunkCount,
+    blockCount,
+    blocksPerChunk,
+    playbackSchema: CSSCYCLONE_PLAYBACK_SCHEMA,
+    lightingBlockSchema: CSSCYCLONE_LIGHTING_BLOCK_SCHEMA,
+    sourceTransformProfile: Object.freeze({
+      controlPointCount: 6,
+      speed: CSSCYCLONE_SOURCE.speed,
+      complexity: CSSCYCLONE_SOURCE.complexity,
+      particleSize: CSSCYCLONE_SOURCE.particleSize,
+      radialOrbitScale: CSSCYCLONE_PRESENTATION.radialOrbitScale,
+    }),
+  });
   const lightingStream = createCyclonePreparedLightingStream();
   const blockEntries = [];
   const startupSelectionColorProfiles = new Map();
@@ -165,18 +187,8 @@ async function prepareProfile(profile) {
       maximumRawParticleCenterZ,
       guarded.metrics.maximumRawParticleCenterZ,
     );
-    maximumObservedParticleCenterZ = Math.max(
-      maximumObservedParticleCenterZ,
-      guarded.metrics.maximumGuardedParticleCenterZ,
-    );
     guardedParticleFrameCount += guarded.metrics.guardedParticleFrameCount;
     rawUnsafeParticleFrameCount += guarded.metrics.rawUnsafeParticleFrameCount;
-    unsafeParticleFrameCount += guarded.metrics.unsafeParticleFrameCount;
-    for (const frameIndex of guarded.metrics.unsafeFrameIndices) {
-      unsafeBlockIndices.add(Math.floor(
-        (source.bank.startFrameIndex + frameIndex) / blockFrameCount,
-      ));
-    }
     if (preparedModel === null) {
       const result = buildCyclonePreparedModel({ source, modelId: profile.modelId });
       preparedModel = Object.freeze({ model: result.model, metrics: result.metrics });
@@ -190,17 +202,51 @@ async function prepareProfile(profile) {
       const streamBlockIndex = source.bank.chunkIndex * blocksPerChunk + blockIndex;
       const localStartFrameIndex = blockIndex * blockFrameCount;
       const startFrameIndex = source.bank.startFrameIndex + localStartFrameIndex;
-      const decoded = Buffer.from(encodeCyclonePreparedBlock({
-        frames: source.frames.slice(localStartFrameIndex, localStartFrameIndex + blockFrameCount),
+      const blockFrames = source.frames.slice(localStartFrameIndex, localStartFrameIndex + blockFrameCount);
+      const decodedBytes = Buffer.from(encodeCyclonePreparedBlock({
+        frames: blockFrames,
         lightingRows: lighting.frameParticleColorStateIndices.slice(
           localStartFrameIndex,
           localStartFrameIndex + blockFrameCount,
         ),
         particleCount: source.bank.particleCount,
       }));
-      const encoded = gzipSync(decoded, { level: 9 });
+      const descriptor = Object.freeze({
+        index: streamBlockIndex,
+        chunkIndex: source.bank.chunkIndex,
+        blockIndex,
+        startFrameIndex,
+        frameCount: blockFrameCount,
+        encoding: CSSCYCLONE_BLOCK_ENCODING,
+      });
+      const decodedBlock = decodeCyclonePreparedBlock(decodedBytes, descriptor, transportCatalog);
+      const expectedTransforms = buildCyclonePreparedPlayback({
+        source: Object.freeze({ ...source, frames: Object.freeze(blockFrames) }),
+        modelId: profile.modelId,
+      }).playback.transforms;
+      if (decodedBlock.playback.transforms.length !== expectedTransforms.length ||
+          decodedBlock.playback.transforms.some((transform, index) => transform !== expectedTransforms[index])) {
+        throw new Error(`Cyclone ${profile.id} block ${streamBlockIndex} transport changed prepared geometry`);
+      }
+      const expectedOverrideCount = blockFrames.reduce((total, frame) => total +
+        frame.particles.filter((particle) => particle.preparedCenterZOverride !== undefined).length, 0);
+      if (decodedBlock.preparedCenterZOverrideCount !== expectedOverrideCount) {
+        throw new Error(`Cyclone ${profile.id} block ${streamBlockIndex} transport dropped camera-depth guards`);
+      }
+      for (const frame of blockFrames) {
+        for (const particle of frame.particles) {
+          const centerZ = particle.matrix[14];
+          maximumObservedParticleCenterZ = Math.max(maximumObservedParticleCenterZ, centerZ);
+          if (centerZ > CSSCYCLONE_SOURCE.viewDistance -
+              CSSCYCLONE_SOURCE_SAFETY.minimumParticleCenterDepth) {
+            unsafeParticleFrameCount += 1;
+            unsafeBlockIndices.add(streamBlockIndex);
+          }
+        }
+      }
+      const encoded = gzipSync(decodedBytes, { level: 9 });
       const encodedSha256 = sha256(encoded);
-      const decodedSha256 = sha256(decoded);
+      const decodedSha256 = sha256(decodedBytes);
       const assetUrl = `${profile.blockRoot}/block-${String(streamBlockIndex).padStart(3, "0")}-${encodedSha256}.bin`;
       await writeBytes(join(stagingRoot, assetUrl.replace(/^\/csscyclone\//u, "")), encoded);
       blockEntries.push(Object.freeze({
@@ -214,11 +260,11 @@ async function prepareProfile(profile) {
         encoding: CSSCYCLONE_BLOCK_ENCODING,
         byteLength: encoded.byteLength,
         sha256: encodedSha256,
-        decodedByteLength: decoded.byteLength,
+        decodedByteLength: decodedBytes.byteLength,
         decodedSha256,
       }));
       preparedBlockEncodedBytes += encoded.byteLength;
-      preparedBlockDecodedBytes += decoded.byteLength;
+      preparedBlockDecodedBytes += decodedBytes.byteLength;
     }
     preparedFrameCount += source.frames.length;
     uniquePreparedTransformCount += source.frames.length * source.bank.particleCount;
@@ -453,6 +499,7 @@ function applyCycloneCameraDepthGuard(source) {
       guardedParticles[particleIndex] = Object.freeze({
         ...particle,
         matrix: Object.freeze(matrix),
+        preparedCenterZOverride: matrix[14],
       });
     }
     return guardedParticles === null ? frame : Object.freeze({


### PR DESCRIPTION
## Summary
- serialize precomputed camera-depth guards in Cyclone prepared blocks
- verify every generated transform survives encode/decode unchanged
- keep publication and retained-DOM runtime unchanged

## Verification
- pnpm test:cyclone (36/36)
- pnpm prepare:cyclone
- pnpm build:cyclone
- poisoned blocks 166-176 decode below the 360 center-Z safety limit
- local trace p95 cadence: 16.36 ms