### PR TITLE
fix: pause hidden scenes and harden the shared shell

### DIFF
--- a/site/components/ProjectPage.astro
+++ b/site/components/ProjectPage.astro
@@ -4,13 +4,14 @@ import { ROUTE_PROJECTS } from "../projects";
 
 interface Props {
   projectId: string;
+  projectStyles?: string;
   home?: boolean;
 }
 
-const { projectId, home = false } = Astro.props;
+const { projectId, projectStyles, home = false } = Astro.props;
 const project = ROUTE_PROJECTS.find(({ id }) => id === projectId);
 if (!project) throw new Error(`Unknown css.graphics project: ${projectId}`);
 const stageId = projectId === "maze" || projectId === "gears" ? "scene" : undefined;
 ---
 
-<ExamplesLayout project={project} home={home} stageId={stageId} />
+<ExamplesLayout project={project} projectStyles={projectStyles} home={home} stageId={stageId} />

--- a/site/layouts/ExamplesLayout.astro
+++ b/site/layouts/ExamplesLayout.astro
@@ -8,11 +8,12 @@ import { PROJECTS } from "../projects";
 
 interface Props {
   project: LandingProject;
+  projectStyles?: string;
   home?: boolean;
   stageId?: string;
 }
 
-const { project, home = false, stageId } = Astro.props;
+const { project, projectStyles, home = false, stageId } = Astro.props;
 const canonicalPath = home ? "/" : project.route;
 const canonicalUrl = new URL(canonicalPath, "https://css.graphics/").href;
 const title = home
@@ -36,6 +37,7 @@ const backgroundClass = project.id === "cloth"
     <link rel="canonical" href={canonicalUrl} />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="stylesheet" href="/site.css" />
+    {projectStyles && <style is:global set:html={projectStyles} />}
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="css.graphics" />
     <meta property="og:title" content={title} />

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -21,5 +21,4 @@ if (matchingStylesheets.length !== 1) {
 const latestProjectStyles = matchingStylesheets[0][1];
 ---
 
-<style is:global set:html={latestProjectStyles} />
-<ProjectPage projectId={latestProject.id} home />
+<ProjectPage projectId={latestProject.id} projectStyles={latestProjectStyles} home />

--- a/site/scene-router.mjs
+++ b/site/scene-router.mjs
@@ -2,6 +2,9 @@ import { requireExamplesStage } from "./examples-shell-client.mjs";
 
 let activeMount = null;
 let navigationId = 0;
+let pausedForVisibility = false;
+
+document.addEventListener("visibilitychange", syncSceneVisibility);
 
 document.addEventListener("astro:before-swap", () => {
   navigationId += 1;
@@ -16,12 +19,25 @@ document.addEventListener("astro:page-load", () => {
 async function mountActiveScene(id) {
   const projectId = projectIdFromPath(location.pathname);
   const host = requireExamplesStage();
-  const mount = await mountForProject(projectId, host);
+  const mount = requireSceneLifecycle(await mountForProject(projectId, host));
   if (id !== navigationId) {
     mount?.destroy?.();
     return;
   }
   activeMount = mount;
+  if (document.hidden) {
+    activeMount?.pause?.();
+    pausedForVisibility = true;
+  }
+}
+
+function requireSceneLifecycle(mount) {
+  if (mount === null) return null;
+  if (!mount || typeof mount.pause !== "function" || typeof mount.resume !== "function" ||
+      typeof mount.destroy !== "function") {
+    throw new Error("css.graphics scene mount does not implement pause, resume, and destroy");
+  }
+  return mount;
 }
 
 async function mountForProject(projectId, host) {
@@ -71,6 +87,19 @@ async function mountForProject(projectId, host) {
 function destroyActiveScene() {
   activeMount?.destroy?.();
   activeMount = null;
+  pausedForVisibility = false;
+}
+
+function syncSceneVisibility() {
+  if (document.hidden) {
+    if (!activeMount) return;
+    activeMount.pause();
+    pausedForVisibility = true;
+    return;
+  }
+  if (!pausedForVisibility) return;
+  pausedForVisibility = false;
+  activeMount?.resume();
 }
 
 function syncActiveThumbnail() {

--- a/site/site.css
+++ b/site/site.css
@@ -327,6 +327,7 @@ html.example-background-solitaire {
   margin: 0;
   overflow: hidden;
   background: var(--examples-stage-background);
+  pointer-events: none;
 }
 
 .example-stage > [class$="-error-message"] {

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -90,6 +90,11 @@ test("landing presents the current deployed collection", async () => {
   assert.match(sceneRouter, /mountClothClient\(host\)/u);
   assert.match(sceneRouter, /mountFlocksClient\(host\)/u);
   assert.match(sceneRouter, /mountCycloneClient\(host\)/u);
+  assert.match(sceneRouter, /addEventListener\("visibilitychange", syncSceneVisibility\)/u);
+  assert.match(sceneRouter, /activeMount\.pause\(\)/u);
+  assert.match(sceneRouter, /activeMount\?\.resume\(\)/u);
+  assert.match(sceneRouter, /if \(document\.hidden\)/u);
+  assert.match(sceneRouter, /scene mount does not implement pause, resume, and destroy/u);
   assert.doesNotMatch(sceneRouter, /createElement|appendChild|innerHTML/u);
   assert.match(shellRenderer, /<a class="project-thumbnail" href=/u);
   assert.match(shellRenderer, /href="\$\{escapeAttribute\(project\.route\)\}"/u);

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -85,7 +85,11 @@ test("landing presents the current deployed collection", async () => {
   );
   assert.match(homePage, /const latestProject = PROJECTS\[0\];/u);
   assert.match(homePage, /PROJECT_ADAPTER_DIRECTORIES\[latestProject\.id\]/u);
-  assert.match(homePage, /<ProjectPage projectId=\{latestProject\.id\} home \/>/u);
+  assert.match(
+    homePage,
+    /<ProjectPage projectId=\{latestProject\.id\} projectStyles=\{latestProjectStyles\} home \/>/u,
+  );
+  assert.match(layout, /<link rel="stylesheet" href="\/site\.css" \/>[\s\S]*projectStyles/u);
   assert.doesNotMatch(homePage, /projectId="cloth"|adapters\/cloth/u);
   assert.match(sceneRouter, /mountClothClient\(host\)/u);
   assert.match(sceneRouter, /mountFlocksClient\(host\)/u);
@@ -175,6 +179,7 @@ test("landing uses the compact examples shell and mounts the latest scene direct
   assert.match(siteCss, /--examples-sidebar-width: 354px;/u);
   assert.equal(siteCss.match(/354px/gu)?.length, 1);
   assert.match(siteCss, /\.example-stage \{[\s\S]*?inset: 0 0 0 var\(--examples-sidebar-width\);/u);
+  assert.match(siteCss, /\.example-stage \{[\s\S]*?pointer-events: none;/u);
   assert.match(siteCss, /\.example-info \{[\s\S]*?left: var\(--examples-sidebar-width\);/u);
   assert.doesNotMatch(siteCss, /\.example-info \{[\s\S]*?text-shadow:/u);
   assert.doesNotMatch(siteCss, /mix-blend-mode/u);

--- a/src/adapters/3dpipes/src/csspipes/client.mjs
+++ b/src/adapters/3dpipes/src/csspipes/client.mjs
@@ -11,6 +11,7 @@ const PREPARE_FAILURE = "cssPipes prepared clip scene unavailable. Run pnpm prep
 export async function startCssPipesClient(host, route) {
   let presentation = null;
   let player = null;
+  let shouldPlay = true;
   try {
     const manifest = await loadCssPipesManifest(route.manifestUrl);
     const descriptor = selectDefaultScene(manifest);
@@ -38,13 +39,24 @@ export async function startCssPipesClient(host, route) {
       ...snapshot,
       presentation,
       player,
+      pause() {
+        shouldPlay = false;
+        return player.pause();
+      },
+      resume() {
+        shouldPlay = true;
+        return player.resume();
+      },
       destroy() {
+        shouldPlay = false;
         presentation.destroy();
         player.destroy();
       },
     });
     host.classList.add("csspipes-ready");
-    globalThis.requestAnimationFrame(() => player.resume());
+    globalThis.requestAnimationFrame(() => {
+      if (shouldPlay) player.resume();
+    });
     return mounted;
   } catch (error) {
     player?.destroy();

--- a/src/adapters/cloth/src/csscloth/client.mjs
+++ b/src/adapters/cloth/src/csscloth/client.mjs
@@ -36,14 +36,24 @@ const CLOTH_PACKAGE_RESOURCE_PATHS = Object.freeze([
 export function mountClothClient(host) {
   const state = { ready: false, errors: [], mounted: null, player: null, metadata: null };
   let disposed = false;
+  let shouldPlay = true;
   const onError = (event) => recordError(event.message || String(event.error || "error"));
   const onUnhandledRejection = (event) =>
     recordError(String(event.reason?.stack || event.reason || "unhandled rejection"));
   const onResize = () => state.player?.resize();
   const controller = Object.freeze({
+    pause() {
+      shouldPlay = false;
+      state.player?.pause();
+    },
+    resume() {
+      shouldPlay = true;
+      state.player?.resume();
+    },
     destroy() {
       if (disposed) return;
       disposed = true;
+      shouldPlay = false;
       state.player?.destroy();
       window.removeEventListener("error", onError);
       window.removeEventListener("unhandledrejection", onUnhandledRejection);
@@ -135,7 +145,7 @@ export function mountClothClient(host) {
     state.ready = true;
     setStatus("ready");
     playbackStream.resumeInitial();
-    player.resume();
+    if (shouldPlay) player.resume();
   }
 
   function recordError(message) {

--- a/src/adapters/cyclone/src/csscyclone/client.mjs
+++ b/src/adapters/cyclone/src/csscyclone/client.mjs
@@ -17,6 +17,7 @@ import { selectCycloneStartupPaletteVariant } from "./startupPaletteSelection.mj
 const LAST_START_SELECTION_STORAGE_KEY = "csscyclone:last-start-selection";
 
 export async function mountCycloneClient(host) {
+  let shouldPlay = true;
   const state = {
     ready: false,
     errors: [],
@@ -119,7 +120,16 @@ export async function mountCycloneClient(host) {
     state.blockLoader = blockLoader;
     state.mounted = mounted;
     state.player = player;
+    state.pause = () => {
+      shouldPlay = false;
+      return player.pause();
+    };
+    state.resume = () => {
+      shouldPlay = true;
+      return player.resume();
+    };
     state.destroy = () => {
+      shouldPlay = false;
       player.destroy();
       blockLoader.destroy();
     };
@@ -134,7 +144,7 @@ export async function mountCycloneClient(host) {
     await waitForCycloneScenePaint();
     state.ready = true;
     document.body.classList.replace("priming", "ready");
-    player.resume();
+    if (shouldPlay) player.resume();
     return state;
   } catch (error) {
     lightingColors?.destroy();

--- a/src/adapters/electropaint/src/cssselectropaint/client.mjs
+++ b/src/adapters/electropaint/src/cssselectropaint/client.mjs
@@ -10,6 +10,7 @@ const PRESENTATION_RULE_MARKER = "--cssselectropaint-presentation-rule";
 export async function mountElectropaintClient(host) {
   if (!(host instanceof HTMLElement)) throw new Error("Missing ElectroPaint host");
   const debug = { status: "loading" };
+  let shouldPlay = true;
   globalThis.__cssElectropaint = debug;
   const presentation = mountPresentation(host);
   try {
@@ -25,8 +26,14 @@ export async function mountElectropaintClient(host) {
       manifest: prepared.manifest,
       selectedVariant: prepared.selectedVariant,
       scene: prepared.sceneData,
-      pause: () => player.pause(),
-      resume: () => player.resume(),
+      pause() {
+        shouldPlay = false;
+        return player.pause();
+      },
+      resume() {
+        shouldPlay = true;
+        return player.resume();
+      },
       step: (count) => player.step(count),
       setState: (stateIndex) => player.setState(stateIndex),
       assertStableDomIdentity: () => mounted.assertStableDomIdentity() && player.assertStableDomIdentity(),
@@ -36,6 +43,7 @@ export async function mountElectropaintClient(host) {
         presentation: presentation.stats(),
       }),
       destroy() {
+        shouldPlay = false;
         presentation.destroy();
         player.destroy();
         mounted.destroy();
@@ -43,7 +51,7 @@ export async function mountElectropaintClient(host) {
       },
     });
     document.body.classList.remove("loading");
-    player.resume();
+    if (shouldPlay) player.resume();
     return debug;
   } catch (error) {
     presentation.destroy();

--- a/src/adapters/flocks/src/cssflocks/client.mjs
+++ b/src/adapters/flocks/src/cssflocks/client.mjs
@@ -15,6 +15,7 @@ import { resolveFlocksRoute } from "./routeState.mjs";
 import { selectFlocksStartupWindow } from "../shared/cssflocks/startupWindows.mjs";
 
 export async function mountFlocksClient(host) {
+  let shouldPlay = true;
   const state = {
     ready: false,
     errors: [],
@@ -116,7 +117,16 @@ export async function mountFlocksClient(host) {
     state.player = player;
     state.startupWindow = startupWindow;
     state.paletteSelection = paletteSelection;
+    state.pause = () => {
+      shouldPlay = false;
+      return player.pause();
+    };
+    state.resume = () => {
+      shouldPlay = true;
+      return player.resume();
+    };
     state.destroy = () => {
+      shouldPlay = false;
       removeEventListener("resize", resize);
       player.destroy();
       mounted.cameraElement.remove();
@@ -127,7 +137,7 @@ export async function mountFlocksClient(host) {
     await waitForPaint();
     state.ready = true;
     document.body.classList.replace("priming", "ready");
-    player.resume();
+    if (shouldPlay) player.resume();
     return state;
   } catch (error) {
     state.errors.push(String(error?.stack || error));

--- a/src/adapters/gears/src/cssgears/client.mjs
+++ b/src/adapters/gears/src/cssgears/client.mjs
@@ -21,6 +21,7 @@ export function mountCssgearsClient() {
     errors: [],
   };
   let disposed = false;
+  let shouldPlay = true;
   const onError = (event) => {
     recordError(state, event.message || String(event.error || "error"));
   };
@@ -28,9 +29,18 @@ export function mountCssgearsClient() {
     recordError(state, String(event.reason?.message || event.reason || "unhandled rejection"));
   };
   const controller = Object.freeze({
+    pause() {
+      shouldPlay = false;
+      return state.mount?.player?.pause?.() ?? null;
+    },
+    resume() {
+      shouldPlay = true;
+      return state.mount?.player?.resume?.() ?? null;
+    },
     destroy() {
       if (disposed) return;
       disposed = true;
+      shouldPlay = false;
       state.mount?.destroy();
       window.removeEventListener("error", onError);
       window.removeEventListener("unhandledrejection", onUnhandledRejection);
@@ -160,7 +170,7 @@ export function mountCssgearsClient() {
       },
     });
     setBodyState("ready");
-    player.resume();
+    if (shouldPlay) player.resume();
     const unloadedIndices = entries.map((_, index) => index)
       .filter((index) => index !== selection.bankIndex);
     if (unloadedIndices.length === 0) {

--- a/src/adapters/maze/src/cssmaze/client.mjs
+++ b/src/adapters/maze/src/cssmaze/client.mjs
@@ -25,6 +25,7 @@ export function mountCssmazeClient() {
   let preparedScenePrefetchCount = 0;
   let preparedTransitionFrameCallbackCount = 0;
   let destroyed = false;
+  let shouldPlay = true;
   const onError = (event) => {
     recordError(state, event.message || String(event.error || "error"), host);
   };
@@ -32,9 +33,18 @@ export function mountCssmazeClient() {
     recordError(state, String(event.reason?.message || event.reason || "unhandled rejection"), host);
   };
   const controller = Object.freeze({
+    pause() {
+      shouldPlay = false;
+      return state.player?.pause() ?? null;
+    },
+    resume() {
+      shouldPlay = true;
+      return state.player?.resume() ?? null;
+    },
     destroy() {
       if (destroyed) return;
       destroyed = true;
+      shouldPlay = false;
       state.mount?.destroy();
       window.removeEventListener("error", onError);
       window.removeEventListener("unhandledrejection", onUnhandledRejection);
@@ -110,7 +120,9 @@ export function mountCssmazeClient() {
     });
     state.ready = true;
     setBodyState(host, "ready");
-    requestAnimationFrame(() => state.player.resume());
+    requestAnimationFrame(() => {
+      if (!destroyed && shouldPlay) state.player.resume();
+    });
     queueNextPreparedScene();
   }
 
@@ -167,7 +179,7 @@ export function mountCssmazeClient() {
       restoreCameraTransition();
     }
     if (destroyed) return;
-    state.player.resume();
+    if (shouldPlay) state.player.resume();
     queueNextPreparedScene();
   }
 

--- a/src/adapters/menger/src/cssmenger/client.mjs
+++ b/src/adapters/menger/src/cssmenger/client.mjs
@@ -9,14 +9,24 @@ import { canonicalizeCssmengerRoute, createRouteState, MOBILE_SCENE_ID } from ".
 export function mountCssmengerClient(host) {
   const state = { ready: false, route: null, manifest: null, sceneData: null, mount: null, errors: [] };
   let disposed = false;
+  let shouldPlay = true;
   const onError = (event) =>
     recordError(state, event.message || String(event.error || "error"), host);
   const onUnhandledRejection = (event) =>
     recordError(state, String(event.reason?.message || event.reason || "unhandled rejection"), host);
   const controller = Object.freeze({
+    pause() {
+      shouldPlay = false;
+      return state.mount?.player?.pause?.() ?? null;
+    },
+    resume() {
+      shouldPlay = true;
+      return state.mount?.player?.resume?.() ?? null;
+    },
     destroy() {
       if (disposed) return;
       disposed = true;
+      shouldPlay = false;
       state.mount?.destroy();
       window.removeEventListener("error", onError);
       window.removeEventListener("unhandledrejection", onUnhandledRejection);
@@ -109,7 +119,9 @@ export function mountCssmengerClient(host) {
     if (disposed) return;
     state.ready = true;
     setStatus("ready");
-    requestAnimationFrame(() => player.resume());
+    requestAnimationFrame(() => {
+      if (!disposed && shouldPlay) player.resume();
+    });
   }
 }
 

--- a/src/adapters/solitaire/src/csssolitaire/client.mjs
+++ b/src/adapters/solitaire/src/csssolitaire/client.mjs
@@ -13,13 +13,23 @@ export function mountCsssolitaireClient(host) {
     errors: [],
   };
   let disposed = false;
+  let shouldPlay = true;
   const onError = (event) => recordError(event.message || String(event.error || "error"));
   const onUnhandledRejection = (event) =>
     recordError(String(event.reason?.message || event.reason || "unhandled rejection"));
   const controller = Object.freeze({
+    pause() {
+      shouldPlay = false;
+      state.player?.pause();
+    },
+    resume() {
+      shouldPlay = true;
+      state.player?.resume();
+    },
     destroy() {
       if (disposed) return;
       disposed = true;
+      shouldPlay = false;
       state.resizeObserver?.disconnect();
       window.removeEventListener("resize", syncPresentation);
       window.removeEventListener("error", onError);
@@ -58,7 +68,7 @@ export function mountCsssolitaireClient(host) {
     });
     state.ready = true;
     setBodyState("ready");
-    state.player.resume();
+    if (shouldPlay) state.player.resume();
     state.resizeObserver = typeof ResizeObserver === "function"
       ? new ResizeObserver(syncPresentation)
       : null;


### PR DESCRIPTION
## Summary
- pause every mounted scene while the document is hidden and resume it in place
- load the latest adapter CSS after the shared shell on the root route
- remove scene-stage pointer hit testing while keeping shell controls interactive

## Verification
- `pnpm test:site`
- `pnpm test:cyclone`
- `pnpm build`
- verified `/` mounts Cyclone on solid `#000` with 1,920 retained leaves
- verified the stage and Cyclone leaves compute to `pointer-events: none`