### PR TITLE
fix(menger): bind prepared atlas inside shell

### DIFF
--- a/src/adapters/menger/src/cssmenger/polycssScene.mjs
+++ b/src/adapters/menger/src/cssmenger/polycssScene.mjs
@@ -1,4 +1,6 @@
 let mountedStyles = [];
+const preparedBodySceneSelector = "body>.polycss-camera>.polycss-scene";
+const preparedShellSceneSelector = ":is(body,.example-stage)>.polycss-camera>.polycss-scene";
 
 export function mountPreparedPolycssSnapshot({
   host,
@@ -50,6 +52,10 @@ export function mountPreparedPolycssSnapshot({
   removePreparedSnapshotStyles();
   for (const style of styles) {
     const imported = document.importNode(style, true);
+    imported.textContent = imported.textContent.replaceAll(
+      preparedBodySceneSelector,
+      preparedShellSceneSelector,
+    );
     document.head.append(imported);
     mountedStyles.push(imported);
   }


### PR DESCRIPTION
## Fix
- scope the shipped prepared Menger atlas rules to the shared `.example-stage` mount
- preserve the existing prepared bank, geometry, lighting, and playback

## Verification
- `pnpm test:menger`
- `pnpm test:menger:assets`
- `pnpm build:menger`
- `pnpm test:site`
- `pnpm build:site`
- local shared-shell route reaches `body.ready` with 84 leaves and the verified atlas URL