### PR TITLE
fix: standardize loading indicators

### DIFF
--- a/site/site.css
+++ b/site/site.css
@@ -337,7 +337,18 @@ html.example-background-solitaire {
 html body.loading::after,
 html body:not(.ready):not(.error)::after {
   inset: 0 0 0 var(--examples-sidebar-width);
+  width: 30px;
+  height: 30px;
   margin: auto;
+  border-width: 2px;
+  border-color: rgb(240 240 240 / 35%);
+  border-top-color: rgb(240 240 240);
+}
+
+html.example-background-cloth body.loading::after,
+html.example-background-cloth body:not(.ready):not(.error)::after {
+  border-color: rgb(32 54 78 / 35%);
+  border-top-color: rgb(32 54 78);
 }
 
 @media (max-width: 760px) {

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -159,6 +159,8 @@ test("landing uses the compact examples shell and mounts the latest scene direct
   assert.match(shellRenderer, /id="asset-list"/u);
   assert.doesNotMatch(`${layout}\n${shellRenderer}`, /code-panel|controls-panel|asset-stage|landing-mark/u);
   assert.doesNotMatch(siteCss, /\.project-thumbnail::after/u);
+  assert.doesNotMatch(siteCss, /examples-loading-copy|Reticulating splines/u);
+  assert.match(siteCss, /html body\.loading::after,[\s\S]*?width: 30px;[\s\S]*?height: 30px;[\s\S]*?border-width: 2px;[\s\S]*?border-color: rgb\(240 240 240 \/ 35%\);[\s\S]*?border-top-color: rgb\(240 240 240\);/u);
   assert.match(siteCss, /\.project-thumbnail img \{[\s\S]*?height: auto;[\s\S]*?object-fit: cover;/u);
   assert.match(siteCss, /\[hidden\] \{[\s\S]*?display: none !important;/u);
   assert.match(siteCss, /\.project-thumbnail\[aria-current="page"\]/u);

--- a/src/adapters/gears/src/cssgears/styles.css
+++ b/src/adapters/gears/src/cssgears/styles.css
@@ -31,6 +31,19 @@ body:not(.ready):not(.error)::after {
   border: 1px solid rgb(240 240 240 / 18%);
   border-top-color: rgb(240 240 240 / 70%);
   border-radius: 50%;
+  animation: cssgears-loading 0.8s linear infinite;
+}
+
+@keyframes cssgears-loading {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body:not(.ready):not(.error)::after {
+    animation: none;
+  }
 }
 
 #scene {

--- a/src/adapters/gears/test/cssgears-shell.test.mjs
+++ b/src/adapters/gears/test/cssgears-shell.test.mjs
@@ -24,5 +24,7 @@ test("css.graphics/gears uses the shared examples shell", () => {
     ).length,
     2,
   );
-  assert.doesNotMatch(css, /@keyframes|will-change/u);
+  assert.match(css, /animation: cssgears-loading 0\.8s linear infinite;/u);
+  assert.match(css, /@keyframes cssgears-loading/u);
+  assert.doesNotMatch(css, /will-change/u);
 });

--- a/src/adapters/maze/src/cssmaze/styles.css
+++ b/src/adapters/maze/src/cssmaze/styles.css
@@ -31,6 +31,19 @@ body.loading::after {
   border: 1px solid rgb(240 240 240 / 18%);
   border-top-color: rgb(240 240 240 / 70%);
   border-radius: 50%;
+  animation: cssmaze-loading 0.8s linear infinite;
+}
+
+@keyframes cssmaze-loading {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.loading::after {
+    animation: none;
+  }
 }
 
 #scene {

--- a/src/adapters/maze/test/cssmaze-shell.test.mjs
+++ b/src/adapters/maze/test/cssmaze-shell.test.mjs
@@ -21,5 +21,7 @@ test("css.graphics/maze uses the shipped cssGraphics product shell", () => {
     2,
   );
   assert.doesNotMatch(css, /#scene \{[^}]*(?:position|inset):/u);
-  assert.doesNotMatch(css, /@keyframes|will-change/u);
+  assert.match(css, /animation: cssmaze-loading 0\.8s linear infinite;/u);
+  assert.match(css, /@keyframes cssmaze-loading/u);
+  assert.doesNotMatch(css, /will-change/u);
 });

--- a/src/adapters/menger/src/cssmenger/styles.css
+++ b/src/adapters/menger/src/cssmenger/styles.css
@@ -32,6 +32,19 @@ body:not(.ready):not(.error)::after {
   border: 1px solid rgb(240 240 240 / 18%);
   border-top-color: rgb(240 240 240 / 70%);
   border-radius: 50%;
+  animation: cssmenger-loading 0.8s linear infinite;
+}
+
+@keyframes cssmenger-loading {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body:not(.ready):not(.error)::after {
+    animation: none;
+  }
 }
 
 body:not(.ready):not(.error)::before {

--- a/src/adapters/menger/test/cssmenger-assets.test.mjs
+++ b/src/adapters/menger/test/cssmenger-assets.test.mjs
@@ -330,6 +330,8 @@ test("product runtime CSS stays on the fast browser path", async () => {
   const shellGradient = "linear-gradient(180deg, #0b1119 0%, #000 100%)";
   assert.equal(css.split(shellGradient).length - 1, 2);
   assert.doesNotMatch(css, /!important/iu);
+  assert.match(css, /animation: cssmenger-loading 0\.8s linear infinite;/u);
+  assert.match(css, /@keyframes cssmenger-loading/u);
   assert.match(css, /\.example-stage > \.polycss-camera > \.polycss-scene\s*\{[^}]*animation:\s*cssmenger-prepared-rotation var\(--cssmenger-rotation-duration\) linear infinite normal both paused;/su);
   assert.match(css, /\.example-stage > \.polycss-camera > \.polycss-scene\s*\{[^}]*will-change:\s*transform;/su);
   assert.match(css, /\.example-stage > \.polycss-camera > \.polycss-scene > b\s*\{/u);

--- a/src/adapters/solitaire/src/csssolitaire/styles.css
+++ b/src/adapters/solitaire/src/csssolitaire/styles.css
@@ -33,6 +33,19 @@ body.loading::after {
   border: 1px solid rgb(240 240 240 / 18%);
   border-top-color: rgb(240 240 240 / 70%);
   border-radius: 50%;
+  animation: csssolitaire-loading 0.8s linear infinite;
+}
+
+@keyframes csssolitaire-loading {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.loading::after {
+    animation: none;
+  }
 }
 
 .example-stage > .polycss-camera {

--- a/src/adapters/solitaire/test/csssolitaire-shell.test.mjs
+++ b/src/adapters/solitaire/test/csssolitaire-shell.test.mjs
@@ -26,6 +26,8 @@ test("product shell is the standard css.graphics route without demo controls", a
     (css.match(/background: linear-gradient\(180deg, #008000 0%, #003d00 100%\);/gu) ?? []).length,
     2,
   );
+  assert.match(css, /animation: csssolitaire-loading 0\.8s linear infinite;/u);
+  assert.match(css, /@keyframes csssolitaire-loading/u);
   assert.match(css,
     /\.example-stage > \.polycss-camera \{[^}]*position: absolute;[^}]*inset: 0;[^}]*contain: layout paint size style;/u);
   assert.doesNotMatch(css, /clip-path|mask(?:-image)?|filter|box-shadow|text-shadow|mix-blend-mode/iu);


### PR DESCRIPTION
## Summary
- animate the previously static Gears, Maze, Menger, and Solitaire loaders
- standardize the shared shell spinner at 30px with a 2px brighter stroke
- keep the light Cloth variant legible

## Verification
- pnpm test:site
- pnpm test:gears
- pnpm test:maze
- pnpm test:menger:assets
- pnpm test:solitaire
- pnpm build:site