### PR TITLE
fix: refine scene header attribution

### DIFF
--- a/site/examples-shell-plugin.mjs
+++ b/site/examples-shell-plugin.mjs
@@ -109,7 +109,7 @@ export function renderExamplesInfo(activeProjectId) {
   if (!project) {
     throw new Error(`Unknown css.graphics project: ${activeProjectId}`);
   }
-  return `<div class="example-info example-info-${project.numberTone}">${escapeText(project.name)} - <a href="https://github.com/layoutit/polycss" target="_blank" rel="noopener">PolyCSS ${polycssVersion}</a><br>${renderCredits(project.credits)}</div>`;
+  return `<div class="example-info example-info-${project.numberTone}">${escapeText(project.name)} · <a href="https://github.com/layoutit/polycss" target="_blank" rel="noopener">PolyCSS ${polycssVersion}</a> · ${renderCredits(project.credits)}</div>`;
 }
 
 function renderCredits(credits) {

--- a/site/public/projects.json
+++ b/site/public/projects.json
@@ -8,11 +8,11 @@
       "route": "/cyclone/",
       "preview": "/landing/cyclone.webp",
       "numberTone": "light",
-      "source": "Really Slick Screensavers",
+      "source": "Really Slick",
       "credits": [
         {
           "relation": "Adapted from",
-          "name": "Really Slick Screensavers",
+          "name": "Really Slick",
           "url": "https://github.com/reallyslickscreensavers/reallyslickscreensavers/blob/5f0a788bf0cc47f66a233ed528919295cd1e7500/src/cyclone/cyclone.cpp"
         }
       ],
@@ -26,11 +26,11 @@
       "route": "/cloth/",
       "preview": "/landing/cloth.webp",
       "numberTone": "dark",
-      "source": "Three.js",
+      "source": "three.js",
       "credits": [
         {
           "relation": "Adapted from",
-          "name": "three.js examples",
+          "name": "three.js",
           "url": "https://github.com/mrdoob/three.js/blob/e62b253081438c030d6af1ee3c3346a89124f277/examples/webgl_animation_cloth.html"
         }
       ],
@@ -62,20 +62,21 @@
       "route": "/electropaint/",
       "preview": "/landing/electropaint.webp",
       "numberTone": "light",
-      "source": "David Tristram",
+      "source": "David A. Tristram",
       "credits": [
         {
           "relation": "Original by",
-          "name": "David Tristram"
+          "name": "David A. Tristram",
+          "url": "https://github.com/sgi-demos/sgi-demos"
         }
       ],
-      "description": "ElectroPaint, originally written by David Tristram, rendered entirely with HTML and CSS using PolyCSS.",
+      "description": "ElectroPaint, originally written by David A. Tristram, rendered entirely with HTML and CSS using PolyCSS.",
       "date": "2026-08-10"
     },
     {
       "number": 4,
       "id": "menger",
-      "name": "Menger",
+      "name": "Menger Sponge",
       "route": "/menger/",
       "preview": "/landing/menger.webp",
       "numberTone": "light",
@@ -87,7 +88,7 @@
           "url": "https://github.com/Zygo/xscreensaver/blob/906693799e4fb7581436590cf84ecb2d3c9186ba/hacks/glx/menger.c"
         }
       ],
-      "description": "Menger rendered entirely with HTML and CSS using PolyCSS.",
+      "description": "Menger Sponge rendered entirely with HTML and CSS using PolyCSS.",
       "date": "2026-08-13"
     },
     {
@@ -139,10 +140,6 @@
           "relation": "Inspired by",
           "name": "XScreenSaver",
           "url": "https://github.com/Zygo/xscreensaver/blob/906693799e4fb7581436590cf84ecb2d3c9186ba/hacks/glx/pipes.c"
-        },
-        {
-          "relation": "and",
-          "name": "Windows 3D Pipes"
         }
       ],
       "description": "CSS Pipes rendered entirely with HTML and CSS using PolyCSS.",

--- a/site/site.css
+++ b/site/site.css
@@ -287,7 +287,11 @@ html.example-background-solitaire {
   top: 0;
   right: 0;
   left: var(--examples-sidebar-width);
-  padding: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--examples-header-height);
+  padding: 0 10px;
   margin: 0;
   font-family: monospace;
   font-size: 14px;

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -7,11 +7,11 @@ import { fileURLToPath } from "node:url";
 const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = resolve(siteRoot, "..");
 const expectedProjects = [
-  ["cyclone", 8, "Really Slick Screensavers", "2026-08-22", "Really Slick Cyclone rendered"],
-  ["cloth", 7, "Three.js", "2026-08-20", "The Three.js cloth simulation"],
+  ["cyclone", 8, "Really Slick", "2026-08-22", "Really Slick Cyclone rendered"],
+  ["cloth", 7, "three.js", "2026-08-20", "The Three.js cloth simulation"],
   ["solitaire", 6, "Classic Solitaire", "2026-08-17", "The classic Solitaire victory cascade"],
-  ["electropaint", 5, "David Tristram", "2026-08-10", "ElectroPaint, originally written by David Tristram"],
-  ["menger", 4, "XScreenSaver", "2026-08-13", "Menger rendered"],
+  ["electropaint", 5, "David A. Tristram", "2026-08-10", "ElectroPaint, originally written by David A. Tristram"],
+  ["menger", 4, "XScreenSaver", "2026-08-13", "Menger Sponge rendered"],
   ["maze", 3, "XScreenSaver", "2026-08-09", "Maze3D rendered"],
   ["gears", 2, "XScreenSaver", "2026-08-07", "Gears rendered"],
   ["pipes", 1, "Original", "2026-08-06", "CSS Pipes"],
@@ -54,6 +54,11 @@ test("landing presents the current deployed collection", async () => {
   ]);
   const projectManifest = JSON.parse(projectManifestText);
   assert.equal(projectManifest.schema, "cssgraphics.projects@2");
+  assert.doesNotMatch(projectManifestText, /Windows 3D Pipes/u);
+  assert.equal(projectManifest.projects.find(({ id }) => id === "cyclone").credits[0].name, "Really Slick");
+  assert.doesNotMatch(projectManifestText, /David Tristram/u);
+  assert.doesNotMatch(projectManifestText, /three\.js examples/u);
+  assert.match(projectManifestText, /David A\. Tristram/u);
   assert.deepEqual(
     projectManifest.projects.map(({ id, number, source, date }) => [id, number, source, date]),
     expectedProjects.map(([id, number, source, date]) => [id, number, source, date]),
@@ -157,6 +162,9 @@ test("landing uses the compact examples shell and mounts the latest scene direct
   assert.match(layout, /property="og:image"/u);
   assert.match(layout, /name="twitter:card" content="summary_large_image"/u);
   assert.match(shellRenderer, /id="asset-list"/u);
+  assert.match(shellRenderer, /\$\{escapeText\(project\.name\)\} · <a[^>]+>PolyCSS \$\{polycssVersion\}<\/a> · \$\{renderCredits\(project\.credits\)\}/u);
+  assert.doesNotMatch(shellRenderer, /<br>/u);
+  assert.doesNotMatch(shellRenderer, /Source:/u);
   assert.doesNotMatch(`${layout}\n${shellRenderer}`, /code-panel|controls-panel|asset-stage|landing-mark/u);
   assert.doesNotMatch(siteCss, /\.project-thumbnail::after/u);
   assert.doesNotMatch(siteCss, /examples-loading-copy|Reticulating splines/u);
@@ -189,7 +197,7 @@ test("landing uses the compact examples shell and mounts the latest scene direct
   assert.match(siteCss, /\.example-info-dark a:hover \{[\s\S]*?color: #282828;/u);
   assert.match(siteCss, /\.example-info-light \{[\s\S]*?color: rgb\(223 223 223 \/ 80%\);/u);
   assert.match(siteCss, /\.example-info-light a:hover \{[\s\S]*?color: var\(--examples-shell-text\);/u);
-  assert.match(siteCss, /\.example-info \{[\s\S]*?padding: 10px;[\s\S]*?font-size: 14px;[\s\S]*?line-height: 24px;/u);
+  assert.match(siteCss, /\.example-info \{[\s\S]*?display: flex;[\s\S]*?align-items: center;[\s\S]*?height: var\(--examples-header-height\);[\s\S]*?padding: 0 10px;[\s\S]*?font-size: 14px;[\s\S]*?line-height: 24px;/u);
   assert.match(siteCss, /\.example-info a \{[\s\S]*?color: inherit;[\s\S]*?text-decoration: underline;/u);
   assert.doesNotMatch(siteCss, /color: #f00/u);
   assert.doesNotMatch(`${siteCss}\n${shellClient}`, /examples-performance|stats\.js|stats\.update/u);

--- a/src/adapters/menger/index.html
+++ b/src/adapters/menger/index.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="/site.css" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="css.graphics" />
-    <meta property="og:title" content="Menger - Powered by PolyCSS" />
+    <meta property="og:title" content="Menger Sponge - Powered by PolyCSS" />
     <meta property="og:description" content="XScreenSaver Menger rendered entirely with HTML and CSS using PolyCSS." />
     <meta property="og:url" content="https://css.graphics/menger/" />
     <meta property="og:image" content="https://css.graphics/landing/menger.webp" />
@@ -23,11 +23,11 @@
     <meta property="og:image:height" content="540" />
     <meta property="og:image:alt" content="A rotating green Menger sponge rendered with HTML and CSS" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Menger - Powered by PolyCSS" />
+    <meta name="twitter:title" content="Menger Sponge - Powered by PolyCSS" />
     <meta name="twitter:description" content="XScreenSaver Menger rendered entirely with HTML and CSS using PolyCSS." />
     <meta name="twitter:image" content="https://css.graphics/landing/menger.webp" />
     <meta name="twitter:image:alt" content="A rotating green Menger sponge rendered with HTML and CSS" />
-    <title>Menger - Powered by PolyCSS</title>
+    <title>Menger Sponge - Powered by PolyCSS</title>
   </head>
   <body>
     <!-- cssgraphics-examples-sidebar -->

--- a/src/adapters/menger/test/cssmenger-assets.test.mjs
+++ b/src/adapters/menger/test/cssmenger-assets.test.mjs
@@ -343,7 +343,7 @@ test("product runtime CSS stays on the fast browser path", async () => {
 
 test("product index uses the css.graphics shell", async () => {
   const html = await readFile(join(root, "index.html"), "utf8");
-  assert.match(html, /<title>Menger - Powered by PolyCSS<\/title>/u);
+  assert.match(html, /<title>Menger Sponge - Powered by PolyCSS<\/title>/u);
   assert.match(html, /cssgraphics-examples-sidebar/u);
   assert.match(html, /<main class="example-stage"><\/main>/u);
   assert.doesNotMatch(html, /iframe|site-header/u);


### PR DESCRIPTION
## Summary
- place scene title, PolyCSS version, and attribution on one middot-separated row
- align the title row with the shell header and refine requested source names
- rename the Menger page title to Menger Sponge

## Verification
- pnpm test:site
- pnpm test:menger:assets
- pnpm build:site