### PR TITLE
fix: preserve scene header spacing

### DIFF
--- a/site/site.css
+++ b/site/site.css
@@ -287,11 +287,8 @@ html.example-background-solitaire {
   top: 0;
   right: 0;
   left: var(--examples-sidebar-width);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   height: var(--examples-header-height);
-  padding: 0 10px;
+  padding: calc((var(--examples-header-height) - 24px) / 2) 10px;
   margin: 0;
   font-family: monospace;
   font-size: 14px;

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -197,7 +197,7 @@ test("landing uses the compact examples shell and mounts the latest scene direct
   assert.match(siteCss, /\.example-info-dark a:hover \{[\s\S]*?color: #282828;/u);
   assert.match(siteCss, /\.example-info-light \{[\s\S]*?color: rgb\(223 223 223 \/ 80%\);/u);
   assert.match(siteCss, /\.example-info-light a:hover \{[\s\S]*?color: var\(--examples-shell-text\);/u);
-  assert.match(siteCss, /\.example-info \{[\s\S]*?display: flex;[\s\S]*?align-items: center;[\s\S]*?height: var\(--examples-header-height\);[\s\S]*?padding: 0 10px;[\s\S]*?font-size: 14px;[\s\S]*?line-height: 24px;/u);
+  assert.match(siteCss, /\.example-info \{[\s\S]*?height: var\(--examples-header-height\);[\s\S]*?padding: calc\(\(var\(--examples-header-height\) - 24px\) \/ 2\) 10px;[\s\S]*?font-size: 14px;[\s\S]*?line-height: 24px;/u);
   assert.match(siteCss, /\.example-info a \{[\s\S]*?color: inherit;[\s\S]*?text-decoration: underline;/u);
   assert.doesNotMatch(siteCss, /color: #f00/u);
   assert.doesNotMatch(`${siteCss}\n${shellClient}`, /examples-performance|stats\.js|stats\.update/u);


### PR DESCRIPTION
## Summary
- keep scene header content in normal inline formatting so spaces remain around middots and attribution links
- center the 24px title line within the shared header height without flex formatting

## Verification
- pnpm test:site
- pnpm build:site
- browser geometry: title and Contact/GitHub rows share the same 27.5px center