### PR TITLE
feat: add Google Analytics

### DIFF
--- a/site/layouts/ExamplesLayout.astro
+++ b/site/layouts/ExamplesLayout.astro
@@ -37,6 +37,13 @@ const backgroundClass = project.id === "cloth"
     <link rel="canonical" href={canonicalUrl} />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="stylesheet" href="/site.css" />
+    <script async is:inline src="https://www.googletagmanager.com/gtag/js?id=G-XV72TXWTM5"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag("js", new Date());
+      gtag("config", "G-XV72TXWTM5");
+    </script>
     {projectStyles && <style is:global set:html={projectStyles} />}
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="css.graphics" />

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -154,6 +154,9 @@ test("landing uses the compact examples shell and mounts the latest scene direct
   assert.match(shellRenderer, /href="https:\/\/github\.com\/layoutit\/cssGraphics"/u);
   assert.match(shellRenderer, /id="example-search"/u);
   assert.match(layout, /<link rel="stylesheet" href="\/site\.css"/u);
+  assert.match(layout, /https:\/\/www\.googletagmanager\.com\/gtag\/js\?id=G-XV72TXWTM5/u);
+  assert.match(layout, /gtag\("config", "G-XV72TXWTM5"\);/u);
+  assert.equal(layout.match(/G-XV72TXWTM5/gu)?.length, 2);
   assert.doesNotMatch(shellRenderer, /class="examples-list-heading"/u);
   assert.doesNotMatch(shellRenderer, /cssgraphics-project-count/u);
   assert.match(layout, /class="example-stage"/u);


### PR DESCRIPTION
## Summary
- add the shared GA4 tag used by cssQuake and PolyCSS to the single examples layout
- cover every css.graphics scene route with measurement ID G-XV72TXWTM5
- pin the integration in the shell test

## Verification
- pnpm test:site
- pnpm build:site