### PR TITLE
fix(luminet): bound prepared playback payload

### DIFF
--- a/src/adapters/blackhole/src/cssblackhole/preparedStream.mjs
+++ b/src/adapters/blackhole/src/cssblackhole/preparedStream.mjs
@@ -63,11 +63,6 @@ export function createBlackHolePreparedStreamLoader(catalog) {
   const requests = new Map();
   const retainedBanks = new Uint8Array(catalog.bankCount);
   const retainedBlocks = new Uint8Array(catalog.blockCount);
-  const responseChunkQueue = [];
-  const requestIdle = globalThis.requestIdleCallback?.bind(globalThis) ??
-    ((callback) => setTimeout(() => callback({ didTimeout: true, timeRemaining: () => 0 }), 0));
-  const cancelIdle = globalThis.cancelIdleCallback?.bind(globalThis) ?? clearTimeout;
-  let responseIdleRequest = null;
   let requestId = 0;
   let destroyed = false;
   let transportBankFetchCount = 0;
@@ -99,25 +94,6 @@ export function createBlackHolePreparedStreamLoader(catalog) {
     requests.clear();
     registerPending.clear();
     materializePending.clear();
-    responseChunkQueue.length = 0;
-    if (responseIdleRequest !== null) cancelIdle(responseIdleRequest);
-    responseIdleRequest = null;
-  }
-
-  function scheduleResponseChunk() {
-    if (responseIdleRequest !== null || responseChunkQueue.length === 0) return;
-    responseIdleRequest = requestIdle(processResponseChunk, { timeout: 500 });
-  }
-
-  function processResponseChunk() {
-    responseIdleRequest = null;
-    const queued = responseChunkQueue.shift();
-    if (!queued) return;
-    const { data, request, response } = queued;
-    if (requests.get(data.requestId) === request && request.response === response) {
-      acceptTransformChunk(data, request, response, true);
-    }
-    scheduleResponseChunk();
   }
 
   function acceptTransformChunk(data, request, response, idleSlice) {
@@ -136,9 +112,16 @@ export function createBlackHolePreparedStreamLoader(catalog) {
   }
 
   function completeMaterializedResponse(data, request, response) {
+    const scheduleByteLength = response.frameOffsets.byteLength +
+      response.assignmentLeafIndices.byteLength + response.opacityFrameOffsets.byteLength +
+      response.opacityLeafIndices.byteLength + response.opacityIndices.byteLength;
     if (response.receivedChunkCount !== response.chunkCount ||
         response.receivedTransformCount !== response.assignmentCount ||
-        data.transformCharacterCount !== response.receivedTransformCharacterCount) {
+        data.transformCharacterCount !== response.receivedTransformCharacterCount ||
+        data.transformCharacterCount > catalog.materialization.maximumTransformCharacters ||
+        data.transformCharacterCount > catalog.materialization.transformCharacterLimit ||
+        scheduleByteLength > catalog.materialization.maximumScheduleBytes ||
+        scheduleByteLength > catalog.materialization.scheduleByteLimit) {
       rejectAll(new Error("BlackHole worker prepared transform completion drifted"));
       return;
     }
@@ -156,9 +139,7 @@ export function createBlackHolePreparedStreamLoader(catalog) {
       opacityFrameOffsets: response.opacityFrameOffsets,
       opacityLeafIndices: response.opacityLeafIndices,
       opacityIndices: response.opacityIndices,
-      scheduleByteLength: response.frameOffsets.byteLength + response.assignmentLeafIndices.byteLength +
-        response.opacityFrameOffsets.byteLength + response.opacityLeafIndices.byteLength +
-        response.opacityIndices.byteLength,
+      scheduleByteLength,
       workerDurationMilliseconds: data.workerDurationMilliseconds,
       workerMaximumSliceMilliseconds: data.workerMaximumSliceMilliseconds,
       workerSliceCount: data.workerSliceCount,
@@ -224,6 +205,7 @@ export function createBlackHolePreparedStreamLoader(catalog) {
           data.descriptor?.index !== request.index ||
           data.descriptor.frameCount !== catalog.blockFrameCount ||
           !Number.isSafeInteger(data.assignmentCount) || data.assignmentCount < catalog.starCount ||
+          data.assignmentCount > catalog.materialization.maximumTransformAssignmentCount ||
           data.assignmentCount > catalog.blockFrameCount * catalog.starCount ||
           !Number.isSafeInteger(data.chunkCount) || data.chunkCount < 1 ||
           !(data.frameOffsets instanceof Uint32Array) ||
@@ -234,6 +216,7 @@ export function createBlackHolePreparedStreamLoader(catalog) {
           data.assignmentLeafIndices.length !== data.assignmentCount ||
           !Number.isSafeInteger(data.opacityAssignmentCount) ||
           data.opacityAssignmentCount < catalog.starCount ||
+          data.opacityAssignmentCount > catalog.materialization.maximumOpacityAssignmentCount ||
           data.opacityAssignmentCount > catalog.blockFrameCount * catalog.starCount ||
           !(data.opacityFrameOffsets instanceof Uint32Array) ||
           data.opacityFrameOffsets.length !== catalog.blockFrameCount + 1 ||
@@ -282,11 +265,7 @@ export function createBlackHolePreparedStreamLoader(catalog) {
         return;
       }
       response.queuedChunkCount += 1;
-      if (request.eager) acceptTransformChunk(data, request, response, false);
-      else {
-        responseChunkQueue.push({ data, request, response });
-        scheduleResponseChunk();
-      }
+      acceptTransformChunk(data, request, response, false);
       return;
     }
     if (data.type !== "materialized-end" || !response ||
@@ -451,6 +430,12 @@ export function createBlackHolePreparedStreamLoader(catalog) {
         retainedMaterializedPackedCoordinateBytes: 0,
         retainedMaterializedTransformBytes: retainedTransformCharacters,
         retainedDecodedDictionaryBytes: 0,
+        materializedBlockTransformCharacterLimit:
+          catalog.materialization.transformCharacterLimit,
+        materializedBlockScheduleByteLimit: catalog.materialization.scheduleByteLimit,
+        maximumPreparedBlockTransformCharacters:
+          catalog.materialization.maximumTransformCharacters,
+        maximumPreparedBlockScheduleBytes: catalog.materialization.maximumScheduleBytes,
         pendingTransportBankCount: bankPending.size,
         pendingRegisteredBankCount: registerPending.size,
         pendingMaterializedBlockCount: materializePending.size,
@@ -524,11 +509,12 @@ function validateCatalog(catalog) {
         "fixed-zero-to-global-maximum-over-all-moving-source-configurations" ||
       !validSpaceContext(catalog.spaceContext) ||
       !validPreparedOpacityPalette(catalog.preparedOpacityPalette) ||
+      !validMaterialization(catalog.materialization) ||
       catalog.sourceFramesPerSecond !== 60 || catalog.framesPerSecond !== 60 ||
       Math.abs(catalog.frameMilliseconds - 1000 / 60) > 1e-9 ||
-      catalog.blockFrameCount !== 300 || catalog.blocksPerBank !== 1 ||
+      catalog.blockFrameCount !== 60 || catalog.blocksPerBank !== 5 ||
       catalog.bankFrameCount !== 300 || catalog.bankSeconds !== 5 ||
-      catalog.bankCount !== 36 || catalog.blockCount !== 36 ||
+      catalog.bankCount !== 36 || catalog.blockCount !== 180 ||
       catalog.streamFrameCount !== 10800 || catalog.streamDurationMilliseconds !== 180000 ||
       catalog.publication?.schema !== "cssblackhole-prepared-useful-publication@1" ||
       catalog.publication.mode !== "complete-1979-point-state-at-sixty-hertz" ||
@@ -544,7 +530,7 @@ function validateCatalog(catalog) {
       catalog.transport.maximumCoordinateQuantizationErrorPixels !==
         CSSBLACKHOLE_MAXIMUM_COORDINATE_QUANTIZATION_ERROR_PIXELS ||
       catalog.transport.predictor !==
-        "independent-five-second-coordinate-second-difference-plus-prepared-sparse-opacity-ranges" ||
+        "independent-five-second-bank-one-second-block-coordinate-second-difference-plus-prepared-sparse-opacity-ranges" ||
       catalog.configurationLoop?.schema !==
         "cssblackhole-luminet-moving-configuration-loop@4" ||
       catalog.configurationLoop.mode !==
@@ -707,6 +693,29 @@ function validateTransport(catalog) {
 function validPreparedOpacityPalette(palette) {
   return Array.isArray(palette) &&
     JSON.stringify(palette) === JSON.stringify(CSSBLACKHOLE_OPACITY_PALETTE);
+}
+
+function validMaterialization(materialization) {
+  return materialization?.schema === "cssblackhole-bounded-materialized-block@1" &&
+    materialization.policy === "galaxy-style-multiple-playback-blocks-per-transport-bank" &&
+    materialization.maximumRetainedBlockCount === 2 &&
+    materialization.transformCharacterLimit === 3_200_000 &&
+    materialization.scheduleByteLimit === 260_000 &&
+    Number.isSafeInteger(materialization.maximumTransformAssignmentCount) &&
+    materialization.maximumTransformAssignmentCount >= 1979 &&
+    materialization.maximumTransformAssignmentCount <= 60 * 1979 &&
+    Number.isSafeInteger(materialization.maximumOpacityAssignmentCount) &&
+    materialization.maximumOpacityAssignmentCount >= 1979 &&
+    materialization.maximumOpacityAssignmentCount <= 60 * 1979 &&
+    Number.isSafeInteger(materialization.maximumTransformCharacters) &&
+    materialization.maximumTransformCharacters > 0 &&
+    materialization.maximumTransformCharacters <= materialization.transformCharacterLimit &&
+    Number.isSafeInteger(materialization.maximumScheduleBytes) &&
+    materialization.maximumScheduleBytes > 0 &&
+    materialization.maximumScheduleBytes <= materialization.scheduleByteLimit &&
+    Number.isSafeInteger(materialization.maximumTransformCharacterBlockIndex) &&
+    materialization.maximumTransformCharacterBlockIndex >= 0 &&
+    materialization.maximumTransformCharacterBlockIndex < 180;
 }
 
 function validSpaceContext(context) {

--- a/src/adapters/blackhole/test/cssblackhole-assets.test.mjs
+++ b/src/adapters/blackhole/test/cssblackhole-assets.test.mjs
@@ -51,14 +51,26 @@ test("Luminet adapter owns a standalone prepared cssblackhole contract", async (
   assert.equal(catalog.transportSeed, 6477);
   assert.equal(catalog.sourceFramesPerSecond, 60);
   assert.equal(catalog.framesPerSecond, 60);
-  assert.equal(catalog.blockFrameCount, 300);
-  assert.equal(catalog.blocksPerBank, 1);
+  assert.equal(catalog.blockFrameCount, 60);
+  assert.equal(catalog.blocksPerBank, 5);
   assert.equal(catalog.bankFrameCount, 300);
   assert.equal(catalog.bankCount, 36);
-  assert.equal(catalog.blockCount, 36);
+  assert.equal(catalog.blockCount, 180);
+  assert.deepEqual(catalog.materialization, {
+    schema: "cssblackhole-bounded-materialized-block@1",
+    policy: "galaxy-style-multiple-playback-blocks-per-transport-bank",
+    maximumRetainedBlockCount: 2,
+    transformCharacterLimit: 3_200_000,
+    scheduleByteLimit: 260_000,
+    maximumTransformAssignmentCount: 118_740,
+    maximumOpacityAssignmentCount: 5_252,
+    maximumTransformCharacters: 3_159_406,
+    maximumScheduleBytes: 253_720,
+    maximumTransformCharacterBlockIndex: 176,
+  });
   assert.equal(catalog.streamFrameCount, 10800);
   assert.equal(catalog.streamDurationMilliseconds, 180_000);
-  assert.equal(prepared.cadence.blockSeconds, 5);
+  assert.equal(prepared.cadence.blockSeconds, 1);
   assert.equal(prepared.cadence.bankSeconds, 5);
   assert.equal(prepared.cadence.streamSeconds, 180);
   assert.equal(prepared.renderer.kind, "retained-dom-polycss-prepared-playback");

--- a/src/adapters/blackhole/test/cssblackhole-shell.test.mjs
+++ b/src/adapters/blackhole/test/cssblackhole-shell.test.mjs
@@ -21,11 +21,12 @@ test("Luminet owns the shared css.graphics shell at its canonical route", async 
 });
 
 test("Luminet keeps one retained point topology and no alternate renderer", async () => {
-  const [css, scene, client, presentation] = await Promise.all([
+  const [css, scene, client, presentation, stream] = await Promise.all([
     readFile(new URL("src/cssblackhole/styles.css", adapterRoot), "utf8"),
     readFile(new URL("src/cssblackhole/polycssScene.mjs", adapterRoot), "utf8"),
     readFile(new URL("src/cssblackhole/client.mjs", adapterRoot), "utf8"),
     readFile(new URL("src/cssblackhole/stagePresentation.mjs", adapterRoot), "utf8"),
+    readFile(new URL("src/cssblackhole/preparedStream.mjs", adapterRoot), "utf8"),
   ]);
   assert.match(css, /\.polycss-scene > b/u);
   assert.doesNotMatch(css, /\.example-stage\s*\{/u);
@@ -61,4 +62,5 @@ test("Luminet keeps one retained point topology and no alternate renderer", asyn
   assert.match(client, /pause\(\)/u);
   assert.match(client, /resume\(\)/u);
   assert.match(client, /destroy\(\)/u);
+  assert.doesNotMatch(stream, /requestIdleCallback|processResponseChunk|responseChunkQueue/u);
 });

--- a/src/adapters/blackhole/tools/prepare-cssblackhole.mjs
+++ b/src/adapters/blackhole/tools/prepare-cssblackhole.mjs
@@ -56,13 +56,15 @@ const sourceFramesPerSecond = 60;
 const framesPerSecond = 60;
 const sourceFrameStep = sourceFramesPerSecond / framesPerSecond;
 const frameMilliseconds = 1000 / framesPerSecond;
-const blockFrameCount = 300 / sourceFrameStep;
-const blocksPerBank = 1;
+const blockFrameCount = 60 / sourceFrameStep;
+const blocksPerBank = 5;
 const bankFrameCount = blockFrameCount * blocksPerBank;
 const bankCount = 36;
 const blockCount = bankCount * blocksPerBank;
 const streamFrameCount = bankCount * bankFrameCount;
 const preparedOpacityPalette = CSSBLACKHOLE_OPACITY_PALETTE;
+const materializedBlockTransformCharacterLimit = 3_200_000;
+const materializedBlockScheduleByteLimit = 260_000;
 
 if (endianness() !== "LE") throw new Error("Luminet preparation requires little endian");
 await ensurePinnedSource();
@@ -99,6 +101,17 @@ const selectedGhostOrbitCounts = selectedSourcePointIndices.slice(directPointCou
 const selectedCoordinates = pointSelectionResult.selectedCoordinates;
 const selectedLuminances = selectSourcePoints(
   luminances, sourceState.frameCount, sourcePointCount, 1, selectedSourcePointIndices);
+const materialization = measureMaterializedBlockPayload({
+  coordinates: selectedCoordinates,
+  luminances: selectedLuminances,
+  starCount,
+  blockFrameCount,
+  blockCount,
+});
+if (materialization.maximumTransformCharacters > materializedBlockTransformCharacterLimit ||
+    materialization.maximumScheduleBytes > materializedBlockScheduleByteLimit) {
+  throw new Error("Luminet materialized block exceeds the bounded payload contract");
+}
 
 await rm(stagingRoot, { recursive: true, force: true });
 await mkdir(banksRoot, { recursive: true });
@@ -290,6 +303,14 @@ const catalog = Object.freeze({
   runtimeLookaheadBankCount: 1,
   runtimeMaterializedLookaheadBlockCount: 1,
   startupMaterializedLookaheadBlockCount: 0,
+  materialization: Object.freeze({
+    schema: "cssblackhole-bounded-materialized-block@1",
+    policy: "galaxy-style-multiple-playback-blocks-per-transport-bank",
+    maximumRetainedBlockCount: 2,
+    transformCharacterLimit: materializedBlockTransformCharacterLimit,
+    scheduleByteLimit: materializedBlockScheduleByteLimit,
+    ...materialization,
+  }),
   publication: Object.freeze({
     schema: "cssblackhole-prepared-useful-publication@1",
     mode: "complete-1979-point-state-at-sixty-hertz",
@@ -327,7 +348,7 @@ const catalog = Object.freeze({
     maximumCoordinateQuantizationErrorPixels:
       CSSBLACKHOLE_MAXIMUM_COORDINATE_QUANTIZATION_ERROR_PIXELS,
     predictor:
-      "independent-five-second-coordinate-second-difference-plus-prepared-sparse-opacity-ranges",
+      "independent-five-second-bank-one-second-block-coordinate-second-difference-plus-prepared-sparse-opacity-ranges",
   }),
   configurationLoop,
   luminetPreparedState: sourceState,
@@ -519,6 +540,65 @@ function maximumFrequency(values) {
     maximum = Math.max(maximum, frequency);
   }
   return maximum;
+}
+
+function measureMaterializedBlockPayload({
+  coordinates, luminances, starCount, blockFrameCount, blockCount,
+}) {
+  if (!(coordinates instanceof Int32Array) || !(luminances instanceof Uint8Array) ||
+      coordinates.length !== blockCount * blockFrameCount * starCount * 2 ||
+      luminances.length !== blockCount * blockFrameCount * starCount) {
+    throw new Error("Luminet materialized payload source cardinality drifted");
+  }
+  let maximumTransformAssignmentCount = 0;
+  let maximumOpacityAssignmentCount = 0;
+  let maximumTransformCharacters = 0;
+  let maximumScheduleBytes = 0;
+  let maximumTransformCharacterBlockIndex = -1;
+  for (let blockIndex = 0; blockIndex < blockCount; blockIndex += 1) {
+    const blockStartFrame = blockIndex * blockFrameCount;
+    let transformAssignmentCount = 0;
+    let opacityAssignmentCount = 0;
+    let transformCharacters = 0;
+    for (let localFrameIndex = 0; localFrameIndex < blockFrameCount; localFrameIndex += 1) {
+      const frameIndex = blockStartFrame + localFrameIndex;
+      for (let leafIndex = 0; leafIndex < starCount; leafIndex += 1) {
+        const sampleIndex = frameIndex * starCount + leafIndex;
+        const coordinateOffset = sampleIndex * 2;
+        const x = coordinates[coordinateOffset];
+        const y = coordinates[coordinateOffset + 1];
+        const previousCoordinateOffset = coordinateOffset - starCount * 2;
+        if (localFrameIndex === 0 || x !== coordinates[previousCoordinateOffset] ||
+            y !== coordinates[previousCoordinateOffset + 1]) {
+          transformAssignmentCount += 1;
+          transformCharacters += formatBlackHolePreparedTransform(x, y).length;
+        }
+        if (localFrameIndex === 0 ||
+            quantizeBlackHolePreparedOpacityIndex(luminances[sampleIndex]) !==
+              quantizeBlackHolePreparedOpacityIndex(luminances[sampleIndex - starCount])) {
+          opacityAssignmentCount += 1;
+        }
+      }
+    }
+    const scheduleBytes = (blockFrameCount + 1) * Uint32Array.BYTES_PER_ELEMENT * 2 +
+      transformAssignmentCount * Uint16Array.BYTES_PER_ELEMENT +
+      opacityAssignmentCount * (Uint16Array.BYTES_PER_ELEMENT + Uint8Array.BYTES_PER_ELEMENT);
+    maximumTransformAssignmentCount = Math.max(
+      maximumTransformAssignmentCount, transformAssignmentCount);
+    maximumOpacityAssignmentCount = Math.max(maximumOpacityAssignmentCount, opacityAssignmentCount);
+    maximumScheduleBytes = Math.max(maximumScheduleBytes, scheduleBytes);
+    if (transformCharacters > maximumTransformCharacters) {
+      maximumTransformCharacters = transformCharacters;
+      maximumTransformCharacterBlockIndex = blockIndex;
+    }
+  }
+  return Object.freeze({
+    maximumTransformAssignmentCount,
+    maximumOpacityAssignmentCount,
+    maximumTransformCharacters,
+    maximumScheduleBytes,
+    maximumTransformCharacterBlockIndex,
+  });
 }
 
 async function ensurePinnedSource() {

--- a/src/adapters/blackhole/tools/smoke-browser.mjs
+++ b/src/adapters/blackhole/tools/smoke-browser.mjs
@@ -255,6 +255,14 @@ function assertSmoke(report) {
       report.initial.stats?.runtimePhysicsCount !== 0 ||
       report.initial.stats?.runtimeRasterizationCount !== 0 ||
       report.initial.stats?.runtimeDomReconstructionCount !== 0 ||
+      report.initial.stats?.materializedBlockTransformCharacterLimit !== 3_200_000 ||
+      report.initial.stats?.materializedBlockScheduleByteLimit !== 260_000 ||
+      report.initial.stats?.maximumPreparedBlockTransformCharacters !== 3_159_406 ||
+      report.initial.stats?.maximumPreparedBlockScheduleBytes !== 253_720 ||
+      report.initial.stats?.retainedMaterializedBlockCount !== 1 ||
+      report.initial.stats?.retainedMaterializedTransformBytes > 3_200_000 ||
+      report.initial.stats?.retainedMaterializedScheduleBytes > 260_000 ||
+      report.initial.stats?.workerMaterializationMaximumResponseChunkCharacters > 112_000 ||
       report.initial.stats?.spaceContextSourceStarCountPerPlate !== 1000 ||
       report.initial.stats?.spaceContextPointPrimitive !== "axis-aligned-square" ||
       report.initial.stats?.spaceContextRuntimeDomNodeCount !== 0 ||
@@ -289,6 +297,13 @@ function assertSmoke(report) {
       report.final.leafCount !== 1979 || !report.final.stableIdentity ||
       report.final.changedTransformCount < 100 ||
       report.final.stats?.preparedConfigurationSwitchCount < 1 ||
+      report.final.stats?.retainedMaterializedBlockCount < 1 ||
+      report.final.stats?.retainedMaterializedBlockCount > 2 ||
+      report.final.stats?.retainedMaterializedTransformBytes > 6_400_000 ||
+      report.final.stats?.retainedMaterializedScheduleBytes > 520_000 ||
+      report.final.stats?.preparedBlockWaitCount !== 0 ||
+      report.final.stats?.preparedBankWaitCount !== 0 ||
+      report.final.stats?.sourceFrameDropCount !== 0 ||
       report.final.stats?.schedulerNoopCallbackCount !== 0 ||
       report.final.stats?.runtimeDomGrowth !== false ||
       report.final.pausedFrame !== report.final.pausedFrameAfterWait ||


### PR DESCRIPTION
## What changed

- split each five-second Luminet transport bank into five one-second playback blocks, matching Galaxy's bank/block boundary
- retain at most the active block plus one materialized lookahead block
- adopt paced worker chunks directly instead of double-throttling them through requestIdleCallback
- measure the complete prepared loop at preparation time and fail closed above 3,200,000 transform characters or 260,000 schedule bytes per block
- enforce the same payload, residency, wait, and dropped-frame limits in browser smoke

## Why

The previously merged Luminet runtime could materialize about 15.75 million transform characters plus a 1.24 MB schedule for a single five-second block. That payload was not safe for production startup and the deployment was rolled back.

The bounded contract produces an initial block of 3,150,761 transform characters plus 253,407 schedule bytes. Runtime residency is limited to one or two blocks.

## Local evidence

- pnpm test:luminet: 7/7
- pnpm test:luminet:browser: desktop, 27-inch, mobile, and DPR2 profiles passed
- pnpm test:luminet:deploy: all four production-build profiles passed
- zero prepared-block waits, bank waits, and dropped source frames
- pnpm typecheck
- pnpm test:site: 6/6
- production-shaped cold trace: ready 826 ms, FCP 939 ms, LCP 947 ms, no renderer-main long task at or above 50 ms

This PR is intentionally draft until its exact Netlify deploy preview is built and cold-start validated.
