### PR TITLE
fix(luminet): halve prepared background opacity

### DIFF
--- a/src/adapters/blackhole/src/cssblackhole/preparedStream.mjs
+++ b/src/adapters/blackhole/src/cssblackhole/preparedStream.mjs
@@ -734,11 +734,13 @@ function validSpaceContext(context) {
         JSON.stringify(["0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8"]) ||
       context.opacityDecimalPlaces !== 1 ||
       context.maximumBaseOpacity !== 0.8 ||
+      context.layerOpacity !== 0.5 ||
+      context.maximumEffectiveOpacity !== 0.4 ||
       context.opacitySamplingBucketCount !== 9 ||
       context.opacityMode !==
         "prepared-original-dot-opacity-palette" ||
       context.opacityComposition !==
-        "prepared-srgb-over-opaque-black" ||
+        "prepared-srgb-base-opacity-times-layer-opacity-over-opaque-black" ||
       context.pointPrimitive?.shape !== "axis-aligned-square" ||
       context.pointPrimitive.foregroundReference !== ".polycss-scene > b" ||
       context.pointPrimitive.cssPixelsAt1dppx !== 2 ||

--- a/src/adapters/blackhole/test/cssblackhole-assets.test.mjs
+++ b/src/adapters/blackhole/test/cssblackhole-assets.test.mjs
@@ -93,6 +93,8 @@ test("Luminet adapter owns a standalone prepared cssblackhole contract", async (
   assert.deepEqual(catalog.spaceContext.opacityPalette,
     ["0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8"]);
   assert.equal(catalog.spaceContext.maximumBaseOpacity, 0.8);
+  assert.equal(catalog.spaceContext.layerOpacity, 0.5);
+  assert.equal(catalog.spaceContext.maximumEffectiveOpacity, 0.4);
   assert.equal(catalog.spaceContext.opacitySamplingBucketCount, 9);
   assert.equal(catalog.spaceContext.opacityMode,
     "prepared-original-dot-opacity-palette");
@@ -244,7 +246,8 @@ test("Luminet adapter owns a standalone prepared cssblackhole contract", async (
   const allowedPixels = new Set(["0,0,0"]);
   for (const color of palette) {
     for (const opacity of catalog.spaceContext.opacityPalette) {
-      allowedPixels.add(compositeOverBlack(color, Number(opacity)).join(","));
+      allowedPixels.add(compositeOverBlack(
+        color, Number(opacity) * catalog.spaceContext.layerOpacity).join(","));
     }
   }
   for (const plate of catalog.spaceContext.plates) {

--- a/src/adapters/blackhole/tools/prepare-space-context.mjs
+++ b/src/adapters/blackhole/tools/prepare-space-context.mjs
@@ -13,6 +13,7 @@ const SPACE_CONTEXT_BAND_POINT_COUNT = 400;
 const SPACE_CONTEXT_OPACITY_PALETTE = Object.freeze([
   "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8",
 ]);
+const SPACE_CONTEXT_LAYER_OPACITY = 0.5;
 const SPACE_CONTEXT_OPACITY_SAMPLING_BUCKET_COUNT = 9;
 const SPACE_CONTEXT_PLATES = Object.freeze([
   Object.freeze({ id: "landscape", width: 2560, height: 1440, seedOffset: 0 }),
@@ -65,9 +66,11 @@ export async function prepareBlackHoleSpaceContext(outputRoot) {
     opacityPalette: SPACE_CONTEXT_OPACITY_PALETTE,
     opacityDecimalPlaces: 1,
     maximumBaseOpacity: 0.8,
+    layerOpacity: SPACE_CONTEXT_LAYER_OPACITY,
+    maximumEffectiveOpacity: 0.4,
     opacitySamplingBucketCount: SPACE_CONTEXT_OPACITY_SAMPLING_BUCKET_COUNT,
     opacityMode: "prepared-original-dot-opacity-palette",
-    opacityComposition: "prepared-srgb-over-opaque-black",
+    opacityComposition: "prepared-srgb-base-opacity-times-layer-opacity-over-opaque-black",
     pointPrimitive: Object.freeze({
       shape: "axis-aligned-square",
       foregroundReference: ".polycss-scene > b",
@@ -128,7 +131,7 @@ function preparePlatePoints({ width, height, seedOffset }) {
     points.push(Object.freeze({
       x,
       y,
-      rgb: compositeOverBlack(color, Number(opacity)),
+      rgb: compositeOverBlack(color, Number(opacity) * SPACE_CONTEXT_LAYER_OPACITY),
     }));
     for (let offsetY = -1; offsetY <= 1; offsetY += 1) {
       for (let offsetX = -1; offsetX <= 1; offsetX += 1) {


### PR DESCRIPTION
## What changed

- apply an explicit `0.5` layer opacity while preparing the static Luminet space-context plates
- record `layerOpacity: 0.5` and `maximumEffectiveOpacity: 0.4` in the prepared catalog
- keep the 1,979 animated foreground dots unchanged
- keep background rendering fully prepared: no pseudo-element, runtime DOM, style writes, or rasterization

## Evidence

- `pnpm prepare:luminet`
- `pnpm test:luminet`: 7/7
- `pnpm test:luminet:browser`: desktop, 27-inch, mobile, and DPR2 passed
- `pnpm typecheck`
- generated pixels are validated against base opacity multiplied by the 0.5 layer opacity

All browser work for this change is headless-only.
