### PR TITLE
fix(luminet): thin central background stars

### DIFF
--- a/src/adapters/blackhole/src/cssblackhole/preparedStream.mjs
+++ b/src/adapters/blackhole/src/cssblackhole/preparedStream.mjs
@@ -752,8 +752,12 @@ function validSpaceContext(context) {
       context.distribution?.uniformPointCount !== 600 ||
       context.distribution.broadGalacticBandPointCount !== 400 ||
       context.distribution.centerDensityMode !==
-        "uniform-sparse-no-static-center-hole" ||
-      context.distribution.minimumCenterDensity !== 1 ||
+        "prepared-smooth-radial-sparsity-no-hard-cutout" ||
+      context.distribution.centerDensityCurve !== "smoothstep" ||
+      context.distribution.minimumCenterDensity !== 0.1 ||
+      context.distribution.fullDensityRadiusLogicalPixels !== 360 ||
+      context.distribution.centerProbeRadiusLogicalPixels !== 160 ||
+      context.distribution.coreRadiusLogicalPixels !== 96 ||
       context.lensing?.classification !==
         "thin-lens-compositional-context-not-luminet-source-parity" ||
       context.lensing.einsteinRadiusLogicalPixels !== 96 ||
@@ -768,7 +772,10 @@ function validSpaceContext(context) {
     const expected = expectedPlates[plateIndex];
     return plate?.id === expected.id && plate.logicalWidth === expected.logicalWidth &&
       plate.logicalHeight === expected.logicalHeight && plate.sourceStarCount === 1000 &&
-      plate.centerDensityFalloff === undefined &&
+      plate.centralPointCountWithinCoreRadius === 0 &&
+      Number.isSafeInteger(plate.centralPointCountWithinProbeRadius) &&
+      plate.centralPointCountWithinProbeRadius >= 1 &&
+      plate.centralPointCountWithinProbeRadius <= 16 &&
       Array.isArray(plate.variants) && plate.variants.length === 2 &&
       plate.variants.every((variant, variantIndex) => {
         const deviceScaleFactor = variantIndex + 1;

--- a/src/adapters/blackhole/test/cssblackhole-assets.test.mjs
+++ b/src/adapters/blackhole/test/cssblackhole-assets.test.mjs
@@ -87,8 +87,12 @@ test("Luminet adapter owns a standalone prepared cssblackhole contract", async (
   assert.equal(catalog.spaceContext.distribution.uniformPointCount, 600);
   assert.equal(catalog.spaceContext.distribution.broadGalacticBandPointCount, 400);
   assert.equal(catalog.spaceContext.distribution.centerDensityMode,
-    "uniform-sparse-no-static-center-hole");
-  assert.equal(catalog.spaceContext.distribution.minimumCenterDensity, 1);
+    "prepared-smooth-radial-sparsity-no-hard-cutout");
+  assert.equal(catalog.spaceContext.distribution.centerDensityCurve, "smoothstep");
+  assert.equal(catalog.spaceContext.distribution.minimumCenterDensity, 0.1);
+  assert.equal(catalog.spaceContext.distribution.fullDensityRadiusLogicalPixels, 360);
+  assert.equal(catalog.spaceContext.distribution.centerProbeRadiusLogicalPixels, 160);
+  assert.equal(catalog.spaceContext.distribution.coreRadiusLogicalPixels, 96);
   assert.deepEqual(catalog.spaceContext.palette, palette);
   assert.deepEqual(catalog.spaceContext.opacityPalette,
     ["0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8"]);
@@ -252,7 +256,9 @@ test("Luminet adapter owns a standalone prepared cssblackhole contract", async (
   }
   for (const plate of catalog.spaceContext.plates) {
     assert.equal(plate.sourceStarCount, 1_000);
-    assert.equal(plate.centerDensityFalloff, undefined);
+    assert.equal(plate.centralPointCountWithinCoreRadius, 0);
+    assert.ok(plate.centralPointCountWithinProbeRadius >= 1);
+    assert.ok(plate.centralPointCountWithinProbeRadius <= 16);
     for (const variant of plate.variants) {
       const path = resolve(generatedRoot, variant.assetUrl.split("/").at(-1));
       const bytes = await readFile(path);

--- a/src/adapters/blackhole/tools/prepare-space-context.mjs
+++ b/src/adapters/blackhole/tools/prepare-space-context.mjs
@@ -15,6 +15,10 @@ const SPACE_CONTEXT_OPACITY_PALETTE = Object.freeze([
 ]);
 const SPACE_CONTEXT_LAYER_OPACITY = 0.5;
 const SPACE_CONTEXT_OPACITY_SAMPLING_BUCKET_COUNT = 9;
+const SPACE_CONTEXT_MINIMUM_CENTER_DENSITY = 0.1;
+const SPACE_CONTEXT_FULL_DENSITY_RADIUS = 360;
+const SPACE_CONTEXT_CENTER_PROBE_RADIUS = 160;
+const SPACE_CONTEXT_CORE_RADIUS = 96;
 const SPACE_CONTEXT_PLATES = Object.freeze([
   Object.freeze({ id: "landscape", width: 2560, height: 1440, seedOffset: 0 }),
   Object.freeze({ id: "portrait", width: 1440, height: 2560, seedOffset: 0x51f15e }),
@@ -52,6 +56,10 @@ export async function prepareBlackHoleSpaceContext(outputRoot) {
       logicalWidth: specification.width,
       logicalHeight: specification.height,
       sourceStarCount: points.length,
+      centralPointCountWithinCoreRadius: countPointsWithinRadius(
+        points, specification, SPACE_CONTEXT_CORE_RADIUS),
+      centralPointCountWithinProbeRadius: countPointsWithinRadius(
+        points, specification, SPACE_CONTEXT_CENTER_PROBE_RADIUS),
       variants: Object.freeze(variants),
     }));
   }
@@ -85,8 +93,12 @@ export async function prepareBlackHoleSpaceContext(outputRoot) {
       uniformPointCount: SPACE_CONTEXT_UNIFORM_POINT_COUNT,
       broadGalacticBandPointCount: SPACE_CONTEXT_BAND_POINT_COUNT,
       bandClassification: "decorative-broad-density-context",
-      centerDensityMode: "uniform-sparse-no-static-center-hole",
-      minimumCenterDensity: 1,
+      centerDensityMode: "prepared-smooth-radial-sparsity-no-hard-cutout",
+      centerDensityCurve: "smoothstep",
+      minimumCenterDensity: SPACE_CONTEXT_MINIMUM_CENTER_DENSITY,
+      fullDensityRadiusLogicalPixels: SPACE_CONTEXT_FULL_DENSITY_RADIUS,
+      centerProbeRadiusLogicalPixels: SPACE_CONTEXT_CENTER_PROBE_RADIUS,
+      coreRadiusLogicalPixels: SPACE_CONTEXT_CORE_RADIUS,
     }),
     lensing: Object.freeze({
       classification: "thin-lens-compositional-context-not-luminet-source-parity",
@@ -118,6 +130,7 @@ function preparePlatePoints({ width, height, seedOffset }) {
     if (sourceY < 0 || sourceY >= height) continue;
     const lensed = lensPoint(sourceX, sourceY, width, height);
     if (lensed === null) continue;
+    if (random() > centerDensity(lensed.x, lensed.y, width, height)) continue;
     const x = Math.round(lensed.x);
     const y = Math.round(lensed.y);
     if (x < 0 || x >= width - 1 || y < 0 || y >= height - 1 ||
@@ -140,6 +153,21 @@ function preparePlatePoints({ width, height, seedOffset }) {
     }
   }
   return Object.freeze(points);
+}
+
+function centerDensity(x, y, width, height) {
+  const radius = Math.hypot(x - width / 2, y - height / 2);
+  const normalized = Math.min(1, radius / SPACE_CONTEXT_FULL_DENSITY_RADIUS);
+  const smoothstep = normalized * normalized * (3 - 2 * normalized);
+  return SPACE_CONTEXT_MINIMUM_CENTER_DENSITY +
+    (1 - SPACE_CONTEXT_MINIMUM_CENTER_DENSITY) * smoothstep;
+}
+
+function countPointsWithinRadius(points, { width, height }, radius) {
+  const centerX = width / 2;
+  const centerY = height / 2;
+  return points.filter((point) =>
+    Math.hypot(point.x - centerX, point.y - centerY) <= radius).length;
 }
 
 function bandY(random, x, width, height) {


### PR DESCRIPTION
## What changed

- apply a smooth preparation-time radial density taper to the static space background
- keep the foreground Luminet animation and its 1,979 moving dots unchanged
- preserve all 1,000 static stars by resampling rejected center candidates outward
- keep the prepared background layer at opacity 0.5
- record and validate the center-density contract in the generated catalog

There is no clip path, hard silhouette cutoff, runtime filtering, or added per-frame work.

## Evidence

- landscape center within 160px: 29 stars before, 7 after
- landscape and portrait core within 96px: 0 static stars
- `pnpm prepare:luminet`
- `pnpm test:luminet` (7/7)
- `pnpm test:luminet:browser` (desktop, 27-inch, mobile, DPR2; 60 fps; 1,979 moving leaves)
- `pnpm typecheck`
- `git diff --check`
- headless visual inspection confirms a clean center without a visible hard circular boundary