### PR TITLE
fix(blackhole): restore faithful orbital pacing

### DIFF
--- a/src/adapters/blackhole/NOTICE.md
+++ b/src/adapters/blackhole/NOTICE.md
@@ -10,7 +10,7 @@ License; the complete license is included in `LICENSE.LUMINET-MIT`.
 
 The adapter's selected inclinations, exact-loop radii, 2,000 direct and 1,000
 first-order ghost samples, five-second sequencing, two-second smooth transition,
-0.5 speed scale, fixed cross-configuration exposure, PowerNorm display transfer,
+0.25 speed scale, fixed cross-configuration exposure, PowerNorm display transfer,
 minimum opacity, viewport mapping, quantization, and white-to-purple palette are
 presentation or transport decisions. They are not scientific-default or
 pixel-parity claims.

--- a/src/adapters/blackhole/README.md
+++ b/src/adapters/blackhole/README.md
@@ -15,15 +15,15 @@ color selection, morph calculation, or DOM reconstruction.
 The three moving source fields use Luminet at 85 degrees for the side view,
 60 degrees for the angled view, and 0 degrees for the top-down view. Their
 endless presentation sequence is side, angled, top, angled. A new configuration
-arrives after variable 8, 4.5, 3, and 4.5-second slots. Those slots hold their
-views for 6, 2.5, 1, and 2.5 seconds respectively, followed by a two-second
+arrives after variable 7, 4.5, 4, and 4.5-second slots. Those slots hold their
+views for 5, 2.5, 2, and 2.5 seconds respectively, followed by a two-second
 prepared smoothstep transition to the next concurrently moving field. Orbital
-motion remains at the accepted 0.5 presentation scale. The four-slot 20-second
+motion remains at the accepted 0.25 presentation scale. The four-slot 20-second
 view sequence and 90-second source motion close together exactly after 180 seconds.
 
 Luminet observed flux determines opacity. The fixed white, off-white, lavender,
 and purple palette, `PowerNorm(gamma=0.35)`, 0.22 opacity floor, prepare-time
-nearest-decile opacity, inclination sequence, and 0.5 speed are explicit
+nearest-decile opacity, inclination sequence, and 0.25 speed are explicit
 presentation choices. The browser receives only `0`, `0.1` through `0.9`, or
 `1`, and the sparse prepared schedule omits changes that remain in the same
 display decile. Sixteen source-valid periodic radii keep visible orbital rails

--- a/src/adapters/blackhole/src/cssblackhole/client.mjs
+++ b/src/adapters/blackhole/src/cssblackhole/client.mjs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { createBlackHolePreparedPlayer } from "./preparedPlayback.mjs";
+import { resolveBlackHoleLocalPlaybackMode } from "./localPlayback.mjs";
 import { mountPreparedBlackHoleSnapshot } from "./polycssScene.mjs";
 import {
   createBlackHolePreparedBankWindow,
@@ -9,10 +10,14 @@ import {
   loadBlackHolePreparedSnapshot,
 } from "./preparedStream.mjs";
 import { installBlackHoleStagePresentation } from "./stagePresentation.mjs";
+import { blackHolePresentationProfile } from
+  "../shared/cssblackhole/presentationProfiles.mjs";
 
 export function mountBlackHoleClient(host) {
   let shouldPlay = true;
   let destroyed = false;
+  const localPlaybackMode = resolveBlackHoleLocalPlaybackMode(window.location);
+  const presentationProfile = blackHolePresentationProfile(localPlaybackMode ?? "full");
   const state = {
     ready: false,
     errors: [],
@@ -22,6 +27,8 @@ export function mountBlackHoleClient(host) {
     player: null,
     dom: null,
     presentation: null,
+    localPlaybackMode,
+    presentationProfile: presentationProfile.id,
   };
   const controller = Object.freeze({
     pause() {
@@ -56,20 +63,23 @@ export function mountBlackHoleClient(host) {
   return controller;
 
   async function main() {
-    const metadata = await fetchJson("/cssblackhole/prepared.json");
+    const metadata = await fetchJson(`${presentationProfile.assetRoot}/prepared.json`);
     if (metadata?.schema !== "cssblackhole-prepared-scene@1" ||
         metadata.status !== "ready" ||
+        (metadata.presentationProfile ?? "full") !== presentationProfile.id ||
+        (metadata.assetRoot ?? "/cssblackhole") !== presentationProfile.assetRoot ||
         metadata.renderer?.kind !== "retained-dom-polycss-prepared-playback" ||
         metadata.renderer.runtimePhysics !== false ||
         metadata.renderer.runtimeRasterization !== false ||
         metadata.renderer.retainedPointLeafCount !== 1979 ||
         metadata.viewport?.width !== 800 ||
         metadata.viewport?.height !== 600 ||
-        metadata.presentation?.orbitalSpeedScale !== 0.5 ||
+        metadata.presentation?.orbitalSpeedScale !== 0.25 ||
+        (metadata.presentation?.profile ?? "full") !== presentationProfile.id ||
         JSON.stringify(metadata.presentation?.slotHoldSeconds) !==
-          JSON.stringify([6, 2.5, 1, 2.5]) ||
+          JSON.stringify(presentationProfile.holdSeconds) ||
         JSON.stringify(metadata.presentation?.slotDurationSeconds) !==
-          JSON.stringify([8, 4.5, 3, 4.5]) ||
+          JSON.stringify(presentationProfile.durationSeconds) ||
         metadata.presentation?.transitionSeconds !== 2 ||
         metadata.presentation?.publicationYearPointCount !== 1979 ||
         metadata.presentation?.displayPowerGamma !== 0.35 ||
@@ -170,6 +180,8 @@ function installDebugApi(state, controller) {
           transitionCadenceSecondsBySlot:
             state.catalog.configurationLoop.transitionCadenceSecondsBySlot,
           transitionDurationSeconds: state.catalog.configurationLoop.transitionSeconds,
+          localPlaybackMode: state.localPlaybackMode,
+          presentationProfile: state.presentationProfile,
           pointSize: 2,
           pointSizePolicy: "2px-all-resolution-tiers",
           cameraMode: "fixed",

--- a/src/adapters/blackhole/src/cssblackhole/localPlayback.mjs
+++ b/src/adapters/blackhole/src/cssblackhole/localPlayback.mjs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+export const CSSBLACKHOLE_LOCAL_SIDE_TILT_MODE = "side-tilt";
+
+export function resolveBlackHoleLocalPlaybackMode(location) {
+  const hostname = location?.hostname;
+  const isLoopback = hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+  if (!isLoopback) return null;
+  return new URLSearchParams(location.search).get("topdown") === "0"
+    ? CSSBLACKHOLE_LOCAL_SIDE_TILT_MODE
+    : null;
+}

--- a/src/adapters/blackhole/src/cssblackhole/preparedStream.mjs
+++ b/src/adapters/blackhole/src/cssblackhole/preparedStream.mjs
@@ -11,16 +11,13 @@ import {
   CSSBLACKHOLE_GALACTIC_DOT_COLORS,
   CSSBLACKHOLE_GHOST_IMAGE_DOT_COLORS,
 } from "../shared/cssblackhole/preparedColorPresentation.mjs";
+import { blackHolePresentationProfile } from
+  "../shared/cssblackhole/presentationProfiles.mjs";
 
 const TRANSFORM_RESPONSE_CHUNK_SIZE = 4_096;
 const EXPECTED_PERIODIC_ORBIT_COUNTS = Object.freeze([
-  9, 10, 11, 12, 13, 14, 16, 19, 22, 25, 29, 35, 43, 54, 70, 97,
+  5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 18, 22, 27, 35, 41, 48,
 ]);
-const EXPECTED_PRESENTATION_SLOT_HOLD_SECONDS = Object.freeze([6, 2.5, 1, 2.5]);
-const EXPECTED_PRESENTATION_SLOT_DURATION_SECONDS = Object.freeze([8, 4.5, 3, 4.5]);
-const EXPECTED_PRESENTATION_SLOT_FRAME_COUNTS = Object.freeze([480, 270, 180, 270]);
-const EXPECTED_PRESENTATION_SLOT_START_FRAME_INDICES = Object.freeze([0, 480, 750, 930]);
-const EXPECTED_TRANSITION_START_FRAME_INDICES = Object.freeze([360, 150, 60, 150]);
 
 export async function loadBlackHolePreparedCatalog(descriptor) {
   validateCatalogDescriptor(descriptor);
@@ -475,11 +472,15 @@ export function createBlackHolePreparedStreamLoader(catalog) {
 
 function validateCatalog(catalog) {
   const snapshot = catalog?.snapshot;
+  const profileId = catalog?.presentationProfile ?? "full";
+  const profile = blackHolePresentationProfile(profileId);
+  const assetRoot = catalog?.assetRoot ?? "/cssblackhole";
   if (catalog?.schema !== "cssblackhole-prepared-stream-catalog@1" ||
+      assetRoot !== profile.assetRoot ||
       catalog.starCount !== 1979 || catalog.configurationCount !== 3 ||
-      catalog.presentationConfigurationCount !== 4 ||
+      catalog.presentationConfigurationCount !== profile.presentationConfigurationCount ||
       catalog.transportSeed !== 6477 ||
-      !validPointSelection(catalog.pointSelection) ||
+      !validPointSelection(catalog.pointSelection, catalog.streamFrameCount, profileId) ||
       catalog.presentationColors?.schema !== "cssblackhole-galactic-color-source-luminance@4" ||
       catalog.presentationColors?.mode !==
         "prepared-source-image-color-with-source-luminance-opacity" ||
@@ -509,13 +510,14 @@ function validateCatalog(catalog) {
         "fixed-zero-to-global-maximum-over-all-moving-source-configurations" ||
       !validSpaceContext(catalog.spaceContext) ||
       !validPreparedOpacityPalette(catalog.preparedOpacityPalette) ||
-      !validMaterialization(catalog.materialization) ||
+      !validMaterialization(catalog.materialization, catalog.blockCount) ||
       catalog.sourceFramesPerSecond !== 60 || catalog.framesPerSecond !== 60 ||
       Math.abs(catalog.frameMilliseconds - 1000 / 60) > 1e-9 ||
       catalog.blockFrameCount !== 60 || catalog.blocksPerBank !== 5 ||
       catalog.bankFrameCount !== 300 || catalog.bankSeconds !== 5 ||
-      catalog.bankCount !== 36 || catalog.blockCount !== 180 ||
-      catalog.streamFrameCount !== 10800 || catalog.streamDurationMilliseconds !== 180000 ||
+      catalog.bankCount !== profile.bankCount || catalog.blockCount !== profile.blockCount ||
+      catalog.streamFrameCount !== profile.streamFrameCount ||
+      Math.abs(catalog.streamDurationMilliseconds - profile.streamFrameCount * 1000 / 60) > 1e-9 ||
       catalog.publication?.schema !== "cssblackhole-prepared-useful-publication@1" ||
       catalog.publication.mode !== "complete-1979-point-state-at-sixty-hertz" ||
       catalog.publication.sourceFrameStep !== 1 ||
@@ -533,41 +535,39 @@ function validateCatalog(catalog) {
         "independent-five-second-bank-one-second-block-coordinate-second-difference-plus-prepared-sparse-opacity-ranges" ||
       catalog.configurationLoop?.schema !==
         "cssblackhole-luminet-moving-configuration-loop@4" ||
-      catalog.configurationLoop.mode !==
-        "prepared-variable-dwell-side-angled-top-angled-luminet-photon-configuration-loop" ||
+      (catalog.configurationLoop.profile ?? "full") !== profile.id ||
+      catalog.configurationLoop.mode !== profile.mode ||
       catalog.configurationLoop.sourceFrameStep !== 1 ||
-      catalog.configurationLoop.presentationSequenceSeconds !== 20 ||
-      catalog.configurationLoop.presentationSequenceFrameCount !== 1200 ||
+      catalog.configurationLoop.presentationSequenceSeconds !== profile.sequenceSeconds ||
+      catalog.configurationLoop.presentationSequenceFrameCount !== profile.sequenceFrameCount ||
       JSON.stringify(catalog.configurationLoop.presentationSlotHoldSeconds) !==
-        JSON.stringify(EXPECTED_PRESENTATION_SLOT_HOLD_SECONDS) ||
+        JSON.stringify(profile.holdSeconds) ||
       JSON.stringify(catalog.configurationLoop.presentationSlotDurationSeconds) !==
-        JSON.stringify(EXPECTED_PRESENTATION_SLOT_DURATION_SECONDS) ||
+        JSON.stringify(profile.durationSeconds) ||
       JSON.stringify(catalog.configurationLoop.presentationSlotFrameCounts) !==
-        JSON.stringify(EXPECTED_PRESENTATION_SLOT_FRAME_COUNTS) ||
+        JSON.stringify(profile.frameCounts) ||
       JSON.stringify(catalog.configurationLoop.presentationSlotStartFrameIndices) !==
-        JSON.stringify(EXPECTED_PRESENTATION_SLOT_START_FRAME_INDICES) ||
+        JSON.stringify(profile.startFrameIndices) ||
       JSON.stringify(catalog.configurationLoop.transitionStartFrameIndices) !==
-        JSON.stringify(EXPECTED_TRANSITION_START_FRAME_INDICES) ||
-      catalog.configurationLoop.transitionFrameCount !== 120 ||
-      catalog.configurationLoop.transitionSeconds !== 2 ||
-      catalog.configurationLoop.configurationTransitionCount !== 36 ||
+        JSON.stringify(profile.transitionStartFrameIndices) ||
+      catalog.configurationLoop.transitionFrameCount !== profile.transitionFrameCount ||
+      catalog.configurationLoop.transitionSeconds !== profile.transitionSeconds ||
+      catalog.configurationLoop.configurationTransitionCount !==
+        profile.streamFrameCount / profile.sequenceFrameCount *
+        profile.presentationConfigurationCount ||
       JSON.stringify(catalog.configurationLoop.transitionCadenceSecondsBySlot) !==
-        JSON.stringify(EXPECTED_PRESENTATION_SLOT_DURATION_SECONDS) ||
+        JSON.stringify(profile.durationSeconds) ||
       JSON.stringify(catalog.configurationLoop.sourceMotionSecondsBeforeTransitionBySlot) !==
-        JSON.stringify(EXPECTED_PRESENTATION_SLOT_HOLD_SECONDS) ||
-      catalog.configurationLoop.orbitalSpeedScale !== 0.5 ||
-      catalog.configurationLoop.sourceMotionReferenceSeconds !== 10 ||
+        JSON.stringify(profile.holdSeconds) ||
+      catalog.configurationLoop.orbitalSpeedScale !== 0.25 ||
+      catalog.configurationLoop.sourceMotionReferenceSeconds !== 20 ||
       catalog.configurationLoop.sourceLoopSeconds !== 90 ||
       catalog.configurationLoop.sourceLoopFrameCount !== 5400 ||
-      catalog.configurationLoop.combinedLoopSeconds !== 180 ||
-      catalog.configurationLoop.combinedLoopFrameCount !== 10800 ||
-      catalog.configurationLoop.combinedSourceFrameCount !== 10800 ||
-      JSON.stringify(catalog.configurationLoop.configurationSequence) !== JSON.stringify([
-        "luminet-inclination-85deg",
-        "luminet-inclination-60deg",
-        "luminet-inclination-0deg",
-        "luminet-inclination-60deg",
-      ]) ||
+      catalog.configurationLoop.combinedLoopSeconds !== profile.combinedLoopSeconds ||
+      catalog.configurationLoop.combinedLoopFrameCount !== profile.streamFrameCount ||
+      catalog.configurationLoop.combinedSourceFrameCount !== profile.streamFrameCount ||
+      JSON.stringify(catalog.configurationLoop.configurationSequence) !==
+        JSON.stringify(profile.configurationSequence) ||
       catalog.configurationLoop.transitionMotion !==
         "prepared-smoothstep-between-concurrently-moving-source-geodesic-fields" ||
       catalog.configurationLoop.opacityOwner !==
@@ -578,19 +578,19 @@ function validateCatalog(catalog) {
       catalog.runtimeLookaheadBankCount !== 1 || catalog.runtimeMaterializedLookaheadBlockCount !== 1 ||
       catalog.startupMaterializedLookaheadBlockCount !== 0 ||
       catalog.luminetPreparedState?.schema !== "cssblackhole-luminet-prepared-state@9" ||
-      catalog.luminetPreparedState.orbitalSpeedScale !== 0.5 ||
-      catalog.luminetPreparedState.sourceMotionReferenceSeconds !== 10 ||
+      catalog.luminetPreparedState.orbitalSpeedScale !== 0.25 ||
+      catalog.luminetPreparedState.sourceMotionReferenceSeconds !== 20 ||
       catalog.luminetPreparedState.naturalTimePerSourceMotionReference !== 1000 ||
       JSON.stringify(catalog.luminetPreparedState.naturalTimePerPresentationSlot) !==
-        JSON.stringify([800, 450, 300, 450]) ||
+        JSON.stringify(profile.naturalTimePerSlot) ||
       JSON.stringify(catalog.luminetPreparedState.naturalTimePerPresentationHold) !==
-        JSON.stringify([600, 250, 100, 250]) ||
-      catalog.luminetPreparedState.naturalTimePerSourceLoop !== 9000 ||
+        JSON.stringify(profile.naturalTimePerHold) ||
+      catalog.luminetPreparedState.naturalTimePerSourceLoop !== 4500 ||
       catalog.luminetPreparedState.sourceLoopSeconds !== 90 ||
       catalog.luminetPreparedState.sourceLoopFrameCount !== 5400 ||
-      catalog.luminetPreparedState.combinedLoopSeconds !== 180 ||
-      catalog.luminetPreparedState.combinedLoopFrameCount !== 10800 ||
-      catalog.luminetPreparedState.availablePeriodicRadiusCount !== 89 ||
+      catalog.luminetPreparedState.combinedLoopSeconds !== profile.combinedLoopSeconds ||
+      catalog.luminetPreparedState.combinedLoopFrameCount !== profile.streamFrameCount ||
+      catalog.luminetPreparedState.availablePeriodicRadiusCount !== 44 ||
       catalog.luminetPreparedState.periodicRadiusCount !== EXPECTED_PERIODIC_ORBIT_COUNTS.length ||
       JSON.stringify(catalog.luminetPreparedState.periodicOrbitCounts) !==
         JSON.stringify(EXPECTED_PERIODIC_ORBIT_COUNTS) ||
@@ -609,28 +609,32 @@ function validateCatalog(catalog) {
         "prepared-source-luminance-used-as-colored-dot-opacity-over-black" ||
       catalog.luminetPreparedState.configurationSequence?.schema !==
         "cssblackhole-luminet-moving-configuration-sequence@3" ||
+      (catalog.luminetPreparedState.configurationSequence.profile ?? "full") !== profile.id ||
       catalog.luminetPreparedState.configurationSequence.distinctConfigurationCount !== 3 ||
-      catalog.luminetPreparedState.configurationSequence.presentationConfigurationCount !== 4 ||
-      catalog.luminetPreparedState.configurationSequence.presentationSequenceSeconds !== 20 ||
-      catalog.luminetPreparedState.configurationSequence.presentationSequenceFrameCount !== 1200 ||
+      catalog.luminetPreparedState.configurationSequence.presentationConfigurationCount !==
+        profile.presentationConfigurationCount ||
+      catalog.luminetPreparedState.configurationSequence.presentationSequenceSeconds !==
+        profile.sequenceSeconds ||
+      catalog.luminetPreparedState.configurationSequence.presentationSequenceFrameCount !==
+        profile.sequenceFrameCount ||
       JSON.stringify(
         catalog.luminetPreparedState.configurationSequence.presentationSlotHoldSeconds) !==
-        JSON.stringify(EXPECTED_PRESENTATION_SLOT_HOLD_SECONDS) ||
+        JSON.stringify(profile.holdSeconds) ||
       JSON.stringify(
         catalog.luminetPreparedState.configurationSequence.presentationSlotDurationSeconds) !==
-        JSON.stringify(EXPECTED_PRESENTATION_SLOT_DURATION_SECONDS) ||
+        JSON.stringify(profile.durationSeconds) ||
       JSON.stringify(
         catalog.luminetPreparedState.configurationSequence.presentationSlotFrameCounts) !==
-        JSON.stringify(EXPECTED_PRESENTATION_SLOT_FRAME_COUNTS) ||
+        JSON.stringify(profile.frameCounts) ||
       JSON.stringify(
         catalog.luminetPreparedState.configurationSequence.presentationSlotStartFrameIndices) !==
-        JSON.stringify(EXPECTED_PRESENTATION_SLOT_START_FRAME_INDICES) ||
+        JSON.stringify(profile.startFrameIndices) ||
       JSON.stringify(
         catalog.luminetPreparedState.configurationSequence.transitionStartFrameIndices) !==
-        JSON.stringify(EXPECTED_TRANSITION_START_FRAME_INDICES) ||
+        JSON.stringify(profile.transitionStartFrameIndices) ||
       JSON.stringify(
         catalog.luminetPreparedState.configurationSequence.presentationStateIndices) !==
-        JSON.stringify([0, 1, 2, 1]) ||
+        JSON.stringify(profile.stateIndices) ||
       JSON.stringify(catalog.luminetPreparedState.configurationSequence.states?.map(
         ({ id, view, inclinationDegrees }) => ({ id, view, inclinationDegrees }))) !==
         JSON.stringify([
@@ -639,7 +643,7 @@ function validateCatalog(catalog) {
           { id: "luminet-inclination-0deg", view: "top", inclinationDegrees: 0 },
         ]) ||
       snapshot?.schema !== "cssblackhole-prepared-polycss-snapshot@1" ||
-      snapshot.url !== `/cssblackhole/snapshot.html?sha256=${snapshot.sha256}` ||
+      snapshot.url !== `${assetRoot}/snapshot.html?sha256=${snapshot.sha256}` ||
       !/^[a-f0-9]{64}$/u.test(snapshot.sha256 ?? "") || snapshot.encoding !== "identity" ||
       !Number.isSafeInteger(snapshot.byteLength) || snapshot.byteLength < catalog.starCount * 7 ||
       snapshot.initialStreamFrame !== 0 || snapshot.preparedTransformCount !== catalog.starCount ||
@@ -683,7 +687,7 @@ function validateTransport(catalog) {
         !/^[a-f0-9]{64}$/u.test(bank.sha256 ?? "") ||
         !/^[a-f0-9]{64}$/u.test(bank.decodedSha256 ?? "") ||
         typeof bank.assetUrl !== "string" ||
-        !bank.assetUrl.startsWith("/cssblackhole/banks/") ||
+        !bank.assetUrl.startsWith(`${catalog.assetRoot ?? "/cssblackhole"}/banks/`) ||
         !/^bank-\d{2}-[a-f0-9]{64}\.bin\.br$/u.test(bank.assetUrl.split("/").at(-1))) {
       throw new Error(`BlackHole transport bank ${bankIndex} drifted`);
     }
@@ -695,7 +699,7 @@ function validPreparedOpacityPalette(palette) {
     JSON.stringify(palette) === JSON.stringify(CSSBLACKHOLE_OPACITY_PALETTE);
 }
 
-function validMaterialization(materialization) {
+function validMaterialization(materialization, blockCount) {
   return materialization?.schema === "cssblackhole-bounded-materialized-block@1" &&
     materialization.policy === "galaxy-style-multiple-playback-blocks-per-transport-bank" &&
     materialization.maximumRetainedBlockCount === 2 &&
@@ -715,7 +719,7 @@ function validMaterialization(materialization) {
     materialization.maximumScheduleBytes <= materialization.scheduleByteLimit &&
     Number.isSafeInteger(materialization.maximumTransformCharacterBlockIndex) &&
     materialization.maximumTransformCharacterBlockIndex >= 0 &&
-    materialization.maximumTransformCharacterBlockIndex < 180;
+    materialization.maximumTransformCharacterBlockIndex < blockCount;
 }
 
 function validSpaceContext(context) {
@@ -804,7 +808,7 @@ function validPresentationBounds(bounds, viewport) {
     bounds.minimumX < bounds.maximumX && bounds.minimumY < bounds.maximumY;
 }
 
-function validPointSelection(selection) {
+function validPointSelection(selection, streamFrameCount, profileId) {
   if (selection?.schema !== "cssblackhole-source-point-selection@3" ||
       selection.mode !==
         "publication-year-count-proportional-non-overlapping-prepared-source-identity-subset" ||
@@ -824,16 +828,14 @@ function validPointSelection(selection) {
       selection.sourcePeriodicRadiusCount !== 16 ||
       selection.selectedDirectPeriodicRadiusCount !== 16 ||
       selection.selectedGhostPeriodicRadiusCount !== 16 ||
-      selection.selectedDirectMaximumPointsPerRadius !== 110 ||
-      selection.selectedGhostMaximumPointsPerRadius !== 55 ||
-      selection.analyzedSourceFrameCount !== 10800 ||
+      selection.selectedDirectMaximumPointsPerRadius !== 230 ||
+      selection.selectedGhostMaximumPointsPerRadius !== 115 ||
+      selection.analyzedSourceFrameCount !== streamFrameCount ||
       selection.retainedStratifiedPointCount !== 1979 ||
-      selection.framesWithPreparedCollisionSeparation !== 10800 ||
-      selection.preparedCollisionSeparationCount !== 229107 ||
-      selection.maximumPreparedCollisionSeparationCount !== 47 ||
-      selection.maximumPreparedCollisionSeparationPixels !== 1.414 ||
-      selection.sourceCoordinateSampleCount !== 21373200 ||
-      selection.sourceExactCoordinateSampleCount !== 21144093 ||
+      !validPointSelectionCollisionReport(selection, streamFrameCount, profileId) ||
+      selection.sourceCoordinateSampleCount !== streamFrameCount * 1979 ||
+      selection.sourceExactCoordinateSampleCount !==
+        selection.sourceCoordinateSampleCount - selection.preparedCollisionSeparationCount ||
       selection.selectedExactCoordinateConflictPairCount !== 0 ||
       !Array.isArray(selection.sourcePointIndices) || selection.sourcePointIndices.length !== 1979) {
     return false;
@@ -846,12 +848,32 @@ function validPointSelection(selection) {
       (selectedIndex === 0 || sourceIndex > selection.sourcePointIndices[selectedIndex - 1]));
 }
 
+function validPointSelectionCollisionReport(selection, streamFrameCount, profileId) {
+  if (profileId === "full") {
+    return selection.framesWithPreparedCollisionSeparation === 10800 &&
+      selection.preparedCollisionSeparationCount === 303464 &&
+      selection.maximumPreparedCollisionSeparationCount === 54 &&
+      selection.maximumPreparedCollisionSeparationPixels === 1.414;
+  }
+  return Number.isSafeInteger(selection.framesWithPreparedCollisionSeparation) &&
+    selection.framesWithPreparedCollisionSeparation > 0 &&
+    selection.framesWithPreparedCollisionSeparation <= streamFrameCount &&
+    Number.isSafeInteger(selection.preparedCollisionSeparationCount) &&
+    selection.preparedCollisionSeparationCount >=
+      selection.framesWithPreparedCollisionSeparation &&
+    Number.isSafeInteger(selection.maximumPreparedCollisionSeparationCount) &&
+    selection.maximumPreparedCollisionSeparationCount > 0 &&
+    selection.maximumPreparedCollisionSeparationCount <= 1979 &&
+    selection.maximumPreparedCollisionSeparationPixels > 0 &&
+    selection.maximumPreparedCollisionSeparationPixels <= 8 * Math.SQRT2;
+}
+
 function validateCatalogDescriptor(descriptor) {
   if (descriptor?.schema !== "cssblackhole-prepared-catalog-descriptor@1" ||
       !Number.isSafeInteger(descriptor.byteLength) || descriptor.byteLength < 1 ||
       !/^[a-f0-9]{64}$/u.test(descriptor.sha256 ?? "") || typeof descriptor.url !== "string" ||
-      descriptor.url !== "/cssblackhole/catalog.json" +
-        `?sha256=${descriptor.sha256}` ||
+      !["/cssblackhole", "/cssblackhole-side-tilt"].some((assetRoot) =>
+        descriptor.url === `${assetRoot}/catalog.json?sha256=${descriptor.sha256}`) ||
       new URLSearchParams(descriptor.url.split("?")[1]).get("sha256") !== descriptor.sha256) {
     throw new Error("BlackHole catalog descriptor drifted");
   }

--- a/src/adapters/blackhole/src/shared/cssblackhole/presentationProfiles.mjs
+++ b/src/adapters/blackhole/src/shared/cssblackhole/presentationProfiles.mjs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+const sourceConfigurationIds = Object.freeze([
+  "luminet-inclination-85deg",
+  "luminet-inclination-60deg",
+  "luminet-inclination-0deg",
+]);
+
+export const CSSBLACKHOLE_PRESENTATION_PROFILES = Object.freeze({
+  full: profile({
+    id: "full",
+    assetDirectory: "cssblackhole",
+    mode: "prepared-variable-dwell-side-angled-top-angled-luminet-photon-configuration-loop",
+    stateIndices: [0, 1, 2, 1],
+    holdSeconds: [5, 2.5, 2, 2.5],
+    combinedLoopSeconds: 180,
+  }),
+  "side-tilt": profile({
+    id: "side-tilt",
+    assetDirectory: "cssblackhole-side-tilt",
+    mode: "prepared-variable-dwell-side-angled-luminet-photon-configuration-loop",
+    stateIndices: [0, 1],
+    holdSeconds: [6, 2.5],
+    combinedLoopSeconds: 450,
+  }),
+});
+
+export function blackHolePresentationProfile(id) {
+  const result = CSSBLACKHOLE_PRESENTATION_PROFILES[id];
+  if (!result) throw new RangeError(`Unsupported BlackHole presentation profile: ${id}`);
+  return result;
+}
+
+function profile({ id, assetDirectory, mode, stateIndices, holdSeconds, combinedLoopSeconds }) {
+  const transitionSeconds = 2;
+  const framesPerSecond = 60;
+  const durationSeconds = holdSeconds.map((hold) => hold + transitionSeconds);
+  const frameCounts = durationSeconds.map((duration) => duration * framesPerSecond);
+  const startFrameIndices = frameCounts.map((_, index) =>
+    frameCounts.slice(0, index).reduce((sum, count) => sum + count, 0));
+  const transitionStartFrameIndices = holdSeconds.map((hold) => hold * framesPerSecond);
+  const sequenceFrameCount = frameCounts.reduce((sum, count) => sum + count, 0);
+  const streamFrameCount = combinedLoopSeconds * framesPerSecond;
+  return Object.freeze({
+    id,
+    assetDirectory,
+    assetRoot: `/${assetDirectory}`,
+    cacheSuffix: id === "full" ? "" : `-${id}`,
+    mode,
+    stateIndices: Object.freeze(stateIndices),
+    configurationSequence: Object.freeze(stateIndices.map((index) => sourceConfigurationIds[index])),
+    presentationConfigurationCount: stateIndices.length,
+    holdSeconds: Object.freeze(holdSeconds),
+    durationSeconds: Object.freeze(durationSeconds),
+    frameCounts: Object.freeze(frameCounts),
+    startFrameIndices: Object.freeze(startFrameIndices),
+    transitionStartFrameIndices: Object.freeze(transitionStartFrameIndices),
+    transitionSeconds,
+    transitionFrameCount: transitionSeconds * framesPerSecond,
+    sequenceSeconds: sequenceFrameCount / framesPerSecond,
+    sequenceFrameCount,
+    combinedLoopSeconds,
+    streamFrameCount,
+    bankCount: streamFrameCount / (framesPerSecond * 5),
+    blockCount: streamFrameCount / framesPerSecond,
+    naturalTimePerSlot: Object.freeze(durationSeconds.map((seconds) => seconds * 50)),
+    naturalTimePerHold: Object.freeze(holdSeconds.map((seconds) => seconds * 50)),
+  });
+}

--- a/src/adapters/blackhole/test/cssblackhole-assets.test.mjs
+++ b/src/adapters/blackhole/test/cssblackhole-assets.test.mjs
@@ -22,7 +22,7 @@ const palette = ["#ffffff", "#f8f5ff", "#eee7ff", "#dfd1ff", "#c7abff", "#aa82ee
 const directImagePalette = palette.slice(0, 4);
 const ghostImagePalette = palette.slice(3);
 const periodicOrbitCounts = [
-  9, 10, 11, 12, 13, 14, 16, 19, 22, 25, 29, 35, 43, 54, 70, 97,
+  5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 18, 22, 27, 35, 41, 48,
 ];
 
 test("Luminet adapter owns a standalone prepared cssblackhole contract", async () => {
@@ -63,10 +63,10 @@ test("Luminet adapter owns a standalone prepared cssblackhole contract", async (
     transformCharacterLimit: 3_200_000,
     scheduleByteLimit: 260_000,
     maximumTransformAssignmentCount: 118_740,
-    maximumOpacityAssignmentCount: 5_252,
-    maximumTransformCharacters: 3_159_406,
-    maximumScheduleBytes: 253_720,
-    maximumTransformCharacterBlockIndex: 176,
+    maximumOpacityAssignmentCount: 3_876,
+    maximumTransformCharacters: 3_159_508,
+    maximumScheduleBytes: 249_592,
+    maximumTransformCharacterBlockIndex: 136,
   });
   assert.equal(catalog.streamFrameCount, 10800);
   assert.equal(catalog.streamDurationMilliseconds, 180_000);
@@ -121,16 +121,16 @@ test("Luminet adapter owns a standalone prepared cssblackhole contract", async (
   assert.equal(catalog.publication.runtimeIntermediateFrameGeneration, false);
   assert.equal(catalog.publication.runtimeCatchupPublication, false);
   assert.equal(catalog.configurationLoop.sourceFrameStep, 1);
-  assert.deepEqual(catalog.configurationLoop.presentationSlotHoldSeconds, [6, 2.5, 1, 2.5]);
-  assert.deepEqual(catalog.configurationLoop.presentationSlotDurationSeconds, [8, 4.5, 3, 4.5]);
-  assert.deepEqual(catalog.configurationLoop.presentationSlotFrameCounts, [480, 270, 180, 270]);
-  assert.deepEqual(catalog.configurationLoop.presentationSlotStartFrameIndices, [0, 480, 750, 930]);
-  assert.deepEqual(catalog.configurationLoop.transitionStartFrameIndices, [360, 150, 60, 150]);
+  assert.deepEqual(catalog.configurationLoop.presentationSlotHoldSeconds, [5, 2.5, 2, 2.5]);
+  assert.deepEqual(catalog.configurationLoop.presentationSlotDurationSeconds, [7, 4.5, 4, 4.5]);
+  assert.deepEqual(catalog.configurationLoop.presentationSlotFrameCounts, [420, 270, 240, 270]);
+  assert.deepEqual(catalog.configurationLoop.presentationSlotStartFrameIndices, [0, 420, 690, 930]);
+  assert.deepEqual(catalog.configurationLoop.transitionStartFrameIndices, [300, 150, 120, 150]);
   assert.equal(catalog.configurationLoop.transitionFrameCount, 120);
   assert.equal(catalog.configurationLoop.transitionSeconds, 2);
-  assert.deepEqual(catalog.configurationLoop.transitionCadenceSecondsBySlot, [8, 4.5, 3, 4.5]);
-  assert.equal(catalog.configurationLoop.orbitalSpeedScale, 0.5);
-  assert.equal(catalog.configurationLoop.sourceMotionReferenceSeconds, 10);
+  assert.deepEqual(catalog.configurationLoop.transitionCadenceSecondsBySlot, [7, 4.5, 4, 4.5]);
+  assert.equal(catalog.configurationLoop.orbitalSpeedScale, 0.25);
+  assert.equal(catalog.configurationLoop.sourceMotionReferenceSeconds, 20);
   assert.equal(catalog.configurationLoop.sourceLoopSeconds, 90);
   assert.equal(catalog.configurationLoop.sourceLoopFrameCount, 5400);
   assert.equal(catalog.configurationLoop.combinedLoopSeconds, 180);
@@ -153,33 +153,33 @@ test("Luminet adapter owns a standalone prepared cssblackhole contract", async (
   assert.equal(catalog.pointSelection.selectedDirectPeriodicRadiusCount, 16);
   assert.equal(catalog.pointSelection.selectedGhostPeriodicRadiusCount, 16);
   assert.equal(catalog.pointSelection.analyzedSourceFrameCount, 10800);
-  assert.equal(catalog.pointSelection.selectedDirectMaximumPointsPerRadius, 110);
-  assert.equal(catalog.pointSelection.selectedGhostMaximumPointsPerRadius, 55);
-  assert.equal(catalog.pointSelection.preparedCollisionSeparationCount, 229107);
-  assert.equal(catalog.pointSelection.maximumPreparedCollisionSeparationCount, 47);
+  assert.equal(catalog.pointSelection.selectedDirectMaximumPointsPerRadius, 230);
+  assert.equal(catalog.pointSelection.selectedGhostMaximumPointsPerRadius, 115);
+  assert.equal(catalog.pointSelection.preparedCollisionSeparationCount, 303464);
+  assert.equal(catalog.pointSelection.maximumPreparedCollisionSeparationCount, 54);
   assert.equal(catalog.pointSelection.maximumPreparedCollisionSeparationPixels, 1.414);
   assert.equal(catalog.pointSelection.sourceCoordinateSampleCount, 21_373_200);
-  assert.equal(catalog.pointSelection.sourceExactCoordinateSampleCount, 21_144_093);
+  assert.equal(catalog.pointSelection.sourceExactCoordinateSampleCount, 21_069_736);
   assert.equal(catalog.pointSelection.selectedExactCoordinateConflictPairCount, 0);
   assert.equal(catalog.pointSelection.sourcePointIndices.length, 1979);
   assert.ok(catalog.pointSelection.sourcePointIndices.slice(0, 1319)
     .every((sourceIndex) => sourceIndex < 2000));
   assert.ok(catalog.pointSelection.sourcePointIndices.slice(1319)
     .every((sourceIndex) => sourceIndex >= 2000));
-  assert.equal(state.orbitalSpeedScale, 0.5);
-  assert.equal(state.sourceMotionReferenceSeconds, 10);
+  assert.equal(state.orbitalSpeedScale, 0.25);
+  assert.equal(state.sourceMotionReferenceSeconds, 20);
   assert.equal(state.sourceLoopSeconds, 90);
   assert.equal(state.sourceLoopFrameCount, 5400);
-  assert.equal(state.availablePeriodicRadiusCount, 89);
+  assert.equal(state.availablePeriodicRadiusCount, 44);
   assert.equal(state.periodicRadiusCount, 16);
   assert.deepEqual(state.periodicOrbitCounts, periodicOrbitCounts);
   assert.equal(state.periodicRadiusSelection,
     "source-valid-greedy-maximin-radius-coverage");
   assert.equal(state.particlePeriodicOrbitCounts.length, 3000);
-  assert.deepEqual(state.configurationSequence.presentationSlotHoldSeconds, [6, 2.5, 1, 2.5]);
-  assert.deepEqual(state.configurationSequence.presentationSlotDurationSeconds, [8, 4.5, 3, 4.5]);
+  assert.deepEqual(state.configurationSequence.presentationSlotHoldSeconds, [5, 2.5, 2, 2.5]);
+  assert.deepEqual(state.configurationSequence.presentationSlotDurationSeconds, [7, 4.5, 4, 4.5]);
   assert.deepEqual(state.configurationSequence.sourceMotionSecondsBeforeTransitionBySlot,
-    [6, 2.5, 1, 2.5]);
+    [5, 2.5, 2, 2.5]);
   assert.equal(state.configurationSequence.transitionSeconds, 2);
   assert.equal(state.configurationSequence.distinctConfigurationCount, 3);
   assert.equal(state.configurationSequence.presentationConfigurationCount, 4);
@@ -367,8 +367,8 @@ test("prepared transport reproduces the pinned moving coordinate and flux state"
   const coordinateFrameBytes = catalog.pointSelection.sourcePointCount * 2 * 4;
   const coordinateHashAt = (frame) => sha256(sourceCoordinates.subarray(
     frame * coordinateFrameBytes, (frame + 1) * coordinateFrameBytes));
-  assert.equal(new Set([0, 480, 750, 930].map(coordinateHashAt)).size, 4);
-  for (const startFrame of [0, 480, 750, 930]) {
+  assert.equal(new Set([0, 420, 690, 930].map(coordinateHashAt)).size, 4);
+  for (const startFrame of [0, 420, 690, 930]) {
     assert.equal(new Set([0, 30, 60, 120, 239]
       .map((offset) => coordinateHashAt(startFrame + offset))).size, 5);
   }
@@ -379,7 +379,7 @@ test("prepared transport reproduces the pinned moving coordinate and flux state"
         catalog.pointSelection.sourcePointCount));
   }
   for (let sequenceStart = 0; sequenceStart < sourceFrameCount; sequenceStart += 1200) {
-    for (const localBoundary of [479, 749, 929, 1199]) {
+    for (const localBoundary of [419, 689, 929, 1199]) {
       const transitionBoundary = sequenceStart + localBoundary;
       const nextFrame = (transitionBoundary + 1) % sourceFrameCount;
       assert.ok(maximumFrameDisplacement(

--- a/src/adapters/blackhole/test/cssblackhole-local-playback.test.mjs
+++ b/src/adapters/blackhole/test/cssblackhole-local-playback.test.mjs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+import { brotliDecompressSync } from "node:zlib";
+import { CSSBLACKHOLE_LOCAL_SIDE_TILT_MODE, resolveBlackHoleLocalPlaybackMode } from
+  "../src/cssblackhole/localPlayback.mjs";
+import {
+  createBlackHolePreparedBlockCoordinateDecoder,
+  readBlackHolePreparedBankSections,
+} from "../src/shared/cssblackhole/preparedBlockTransport.mjs";
+import { blackHolePresentationProfile } from
+  "../src/shared/cssblackhole/presentationProfiles.mjs";
+
+const repositoryRoot = resolve(import.meta.dirname, "../../../..");
+const generatedRoot = resolve(
+  repositoryRoot, "build/generated/public/cssblackhole-side-tilt");
+
+test("topdown=0 selects the dedicated side-tilt bank only on loopback", () => {
+  assert.equal(resolveBlackHoleLocalPlaybackMode(new URL(
+    "http://127.0.0.1:5173/?topdown=0")), CSSBLACKHOLE_LOCAL_SIDE_TILT_MODE);
+  assert.equal(resolveBlackHoleLocalPlaybackMode(new URL(
+    "http://localhost:5173/?topdown=0")), CSSBLACKHOLE_LOCAL_SIDE_TILT_MODE);
+  assert.equal(resolveBlackHoleLocalPlaybackMode(new URL(
+    "https://css.graphics/blackhole/?topdown=0")), null);
+  assert.equal(resolveBlackHoleLocalPlaybackMode(new URL(
+    "http://127.0.0.1:5173/")), null);
+});
+
+test("side-tilt bank preserves the approved holds and morph durations", () => {
+  const profile = blackHolePresentationProfile(CSSBLACKHOLE_LOCAL_SIDE_TILT_MODE);
+  assert.equal(profile.assetRoot, "/cssblackhole-side-tilt");
+  assert.deepEqual(profile.stateIndices, [0, 1]);
+  assert.deepEqual(profile.holdSeconds, [6, 2.5]);
+  assert.deepEqual(profile.durationSeconds, [8, 4.5]);
+  assert.deepEqual(profile.transitionStartFrameIndices, [360, 150]);
+  assert.equal(profile.transitionSeconds, 2);
+  assert.equal(profile.sequenceSeconds, 12.5);
+  assert.equal(profile.combinedLoopSeconds, 450);
+  assert.equal(profile.streamFrameCount, 27_000);
+});
+
+test("default playback profile keeps its bounded 20-second loop", () => {
+  const profile = blackHolePresentationProfile("full");
+  assert.equal(profile.assetRoot, "/cssblackhole");
+  assert.deepEqual(profile.stateIndices, [0, 1, 2, 1]);
+  assert.deepEqual(profile.holdSeconds, [5, 2.5, 2, 2.5]);
+  assert.equal(profile.sequenceSeconds, 20);
+  assert.equal(profile.streamFrameCount, 10_800);
+});
+
+test("side-tilt transport is a complete continuous prepared bank", async () => {
+  const [preparedBytes, catalogBytes] = await Promise.all([
+    readFile(resolve(generatedRoot, "prepared.json")),
+    readFile(resolve(generatedRoot, "catalog.json")),
+  ]);
+  const prepared = JSON.parse(preparedBytes);
+  const catalog = JSON.parse(catalogBytes);
+  assert.equal(prepared.presentationProfile, "side-tilt");
+  assert.equal(prepared.assetRoot, "/cssblackhole-side-tilt");
+  assert.equal(prepared.catalog.sha256, sha256(catalogBytes));
+  assert.equal(prepared.catalog.byteLength, catalogBytes.byteLength);
+  assert.equal(catalog.presentationProfile, "side-tilt");
+  assert.equal(catalog.assetRoot, "/cssblackhole-side-tilt");
+  assert.equal(catalog.bankCount, 90);
+  assert.equal(catalog.blockCount, 450);
+  assert.equal(catalog.streamFrameCount, 27_000);
+  assert.equal(catalog.banks.reduce((sum, bank) => sum + bank.byteLength, 0), 24_408_128);
+  assert.deepEqual(catalog.configurationLoop.configurationSequence, [
+    "luminet-inclination-85deg",
+    "luminet-inclination-60deg",
+  ]);
+  assert.deepEqual(catalog.configurationLoop.presentationSlotHoldSeconds, [6, 2.5]);
+  assert.deepEqual(catalog.configurationLoop.presentationSlotDurationSeconds, [8, 4.5]);
+
+  const [returnMorphBlock, cycleBoundaryBlock, finalBlock, initialBlock] = await Promise.all([
+    decodeCoordinateBlock(catalog, 2, 0),
+    decodeCoordinateBlock(catalog, 2, 2),
+    decodeCoordinateBlock(catalog, 89, 4),
+    decodeCoordinateBlock(catalog, 0, 0),
+  ]);
+  assertContinuousBoundary(frameCoordinates(returnMorphBlock, 29, catalog.starCount),
+    frameCoordinates(returnMorphBlock, 30, catalog.starCount));
+  assertContinuousBoundary(frameCoordinates(cycleBoundaryBlock, 29, catalog.starCount),
+    frameCoordinates(cycleBoundaryBlock, 30, catalog.starCount));
+  assertContinuousBoundary(frameCoordinates(finalBlock, 59, catalog.starCount),
+    frameCoordinates(initialBlock, 0, catalog.starCount));
+});
+
+async function decodeCoordinateBlock(catalog, bankIndex, bankBlockIndex) {
+  const descriptor = catalog.banks[bankIndex];
+  const compressed = await readFile(resolve(
+    generatedRoot, "banks", descriptor.assetUrl.split("/").at(-1)));
+  assert.equal(compressed.byteLength, descriptor.byteLength);
+  assert.equal(sha256(compressed), descriptor.sha256);
+  const expanded = brotliDecompressSync(compressed);
+  assert.equal(expanded.byteLength, descriptor.decodedByteLength);
+  assert.equal(sha256(expanded), descriptor.decodedSha256);
+  const bank = readBlackHolePreparedBankSections(expanded, descriptor, catalog);
+  const decoder = createBlackHolePreparedBlockCoordinateDecoder(bank, bankBlockIndex, catalog);
+  while (!decoder.step()) {}
+  return decoder.coordinates;
+}
+
+function frameCoordinates(block, frameIndex, starCount) {
+  return block.subarray(frameIndex * starCount * 2, (frameIndex + 1) * starCount * 2);
+}
+
+function assertContinuousBoundary(from, to) {
+  const displacements = [];
+  for (let offset = 0; offset < from.length; offset += 2) {
+    displacements.push(Math.hypot(to[offset] - from[offset], to[offset + 1] - from[offset + 1]) /
+      10);
+  }
+  displacements.sort((left, right) => left - right);
+  assert.ok(displacements[Math.floor(displacements.length * 0.5)] < 3);
+  assert.ok(displacements[Math.floor(displacements.length * 0.95)] < 7.5);
+  assert.ok(displacements.at(-1) < 30);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/src/adapters/blackhole/tools/prepare-cssblackhole.mjs
+++ b/src/adapters/blackhole/tools/prepare-cssblackhole.mjs
@@ -23,6 +23,8 @@ import {
   CSSBLACKHOLE_GHOST_IMAGE_DOT_COLORS,
   preparedBlackHoleColorAt,
 } from "../src/shared/cssblackhole/preparedColorPresentation.mjs";
+import { blackHolePresentationProfile } from
+  "../src/shared/cssblackhole/presentationProfiles.mjs";
 import { selectNonOverlappingLuminetPointFrames } from "./select-luminet-points.mjs";
 import { prepareBlackHoleSpaceContext } from "./prepare-space-context.mjs";
 
@@ -30,16 +32,24 @@ const execFileAsync = promisify(execFile);
 const repositoryRoot = resolve(import.meta.dirname, "../../../..");
 const generatedPublicDir = resolve(process.env.CSSBLACKHOLE_GENERATED_PUBLIC_DIR ??
   resolve(repositoryRoot, "build/generated/public"));
-const outputRoot = resolve(generatedPublicDir, "cssblackhole");
-const stagingRoot = resolve(generatedPublicDir, `.cssblackhole-${process.pid}`);
+const presentationProfile = blackHolePresentationProfile(
+  process.env.CSSBLACKHOLE_SEQUENCE ?? "full");
+const assetRoot = presentationProfile.assetRoot;
+const outputRoot = resolve(generatedPublicDir, presentationProfile.assetDirectory);
+const stagingRoot = resolve(
+  generatedPublicDir, `.${presentationProfile.assetDirectory}-${process.pid}`);
 const banksRoot = resolve(stagingRoot, "banks");
 const sourceRoot = resolve(repositoryRoot, `.local/sources/luminet-${sourceLock.commit.slice(0, 7)}`);
 const venvRoot = resolve(repositoryRoot, `.local/venvs/luminet-${sourceLock.commit.slice(0, 7)}`);
 const pythonPath = process.env.CSSBLACKHOLE_PYTHON || resolve(venvRoot, "bin/python");
-const coordinatePath = resolve(repositoryRoot, ".local/cache/cssblackhole-luminet-coordinates.bin");
-const luminancePath = resolve(repositoryRoot, ".local/cache/cssblackhole-luminet-luminance.bin");
-const stateMetadataPath = resolve(repositoryRoot, ".local/cache/cssblackhole-luminet-state.json");
-const oraclePpmPath = resolve(repositoryRoot, "build/oracle/cssblackhole/luminet-frame-0000.ppm");
+const coordinatePath = resolve(repositoryRoot,
+  `.local/cache/cssblackhole-luminet${presentationProfile.cacheSuffix}-coordinates.bin`);
+const luminancePath = resolve(repositoryRoot,
+  `.local/cache/cssblackhole-luminet${presentationProfile.cacheSuffix}-luminance.bin`);
+const stateMetadataPath = resolve(repositoryRoot,
+  `.local/cache/cssblackhole-luminet${presentationProfile.cacheSuffix}-state.json`);
+const oraclePpmPath = resolve(repositoryRoot,
+  `build/oracle/cssblackhole/luminet${presentationProfile.cacheSuffix}-frame-0000.ppm`);
 const transportSeed = 6477;
 const sourcePointCount = 3000;
 const sourceDirectPointCount = 2000;
@@ -48,10 +58,10 @@ const starCount = 1979;
 const directPointCount = 1319;
 const ghostPointCount = 660;
 const expectedPeriodicOrbitCounts = Object.freeze([
-  9, 10, 11, 12, 13, 14, 16, 19, 22, 25, 29, 35, 43, 54, 70, 97,
+  5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 18, 22, 27, 35, 41, 48,
 ]);
 const configurationCount = 3;
-const presentationConfigurationCount = 4;
+const presentationConfigurationCount = presentationProfile.presentationConfigurationCount;
 const sourceFramesPerSecond = 60;
 const framesPerSecond = 60;
 const sourceFrameStep = sourceFramesPerSecond / framesPerSecond;
@@ -59,7 +69,7 @@ const frameMilliseconds = 1000 / framesPerSecond;
 const blockFrameCount = 60 / sourceFrameStep;
 const blocksPerBank = 5;
 const bankFrameCount = blockFrameCount * blocksPerBank;
-const bankCount = 36;
+const bankCount = presentationProfile.bankCount;
 const blockCount = bankCount * blocksPerBank;
 const streamFrameCount = bankCount * bankFrameCount;
 const preparedOpacityPalette = CSSBLACKHOLE_OPACITY_PALETTE;
@@ -67,6 +77,10 @@ const materializedBlockTransformCharacterLimit = 3_200_000;
 const materializedBlockScheduleByteLimit = 260_000;
 
 if (endianness() !== "LE") throw new Error("Luminet preparation requires little endian");
+if (streamFrameCount !== presentationProfile.streamFrameCount ||
+    blockCount !== presentationProfile.blockCount) {
+  throw new Error("Luminet presentation profile transport cardinality drifted");
+}
 await ensurePinnedSource();
 await mkdir(resolve(repositoryRoot, ".local/cache"), { recursive: true });
 await mkdir(resolve(repositoryRoot, "build/oracle/cssblackhole"), { recursive: true });
@@ -159,7 +173,7 @@ for (let bankIndex = 0; bankIndex < bankCount; bankIndex += 1) {
     sourceLoopStartFrameIndex,
     sourceContinuousFromPrevious: true,
     presentationContinuousFromPrevious: true,
-    assetUrl: `/cssblackhole/banks/${filename}`,
+    assetUrl: `${assetRoot}/banks/${filename}`,
     byteLength: compressed.byteLength,
     sha256: hash,
     decodedByteLength: decoded.byteLength,
@@ -216,7 +230,8 @@ const presentationColors = Object.freeze({
 });
 const configurationLoop = Object.freeze({
   schema: "cssblackhole-luminet-moving-configuration-loop@4",
-  mode: "prepared-variable-dwell-side-angled-top-angled-luminet-photon-configuration-loop",
+  profile: presentationProfile.id,
+  mode: presentationProfile.mode,
   sourceFrameStep,
   presentationSequenceSeconds: sourceState.configurationSequence.presentationSequenceSeconds,
   presentationSequenceFrameCount:
@@ -285,6 +300,8 @@ const pointSelection = Object.freeze({
 });
 const catalog = Object.freeze({
   schema: "cssblackhole-prepared-stream-catalog@1",
+  presentationProfile: presentationProfile.id,
+  assetRoot,
   starCount,
   configurationCount,
   presentationConfigurationCount,
@@ -354,7 +371,7 @@ const catalog = Object.freeze({
   luminetPreparedState: sourceState,
   snapshot: Object.freeze({
     schema: "cssblackhole-prepared-polycss-snapshot@1",
-    url: `/cssblackhole/snapshot.html?sha256=${snapshotHash}`,
+    url: `${assetRoot}/snapshot.html?sha256=${snapshotHash}`,
     sha256: snapshotHash,
     encoding: "identity",
     byteLength: snapshotBytes.byteLength,
@@ -373,6 +390,8 @@ await writeFile(resolve(stagingRoot, "catalog.json"), catalogBytes);
 const prepared = Object.freeze({
   schema: "cssblackhole-prepared-scene@1",
   status: "ready",
+  presentationProfile: presentationProfile.id,
+  assetRoot,
   source: catalog.source,
   renderer: Object.freeze({
     kind: "retained-dom-polycss-prepared-playback",
@@ -391,6 +410,7 @@ const prepared = Object.freeze({
     streamSeconds: streamFrameCount / framesPerSecond,
   }),
   presentation: Object.freeze({
+    profile: presentationProfile.id,
     orbitalSpeedScale: sourceState.orbitalSpeedScale,
     slotHoldSeconds: sourceState.configurationSequence.presentationSlotHoldSeconds,
     slotDurationSeconds: sourceState.configurationSequence.presentationSlotDurationSeconds,
@@ -404,7 +424,7 @@ const prepared = Object.freeze({
   }),
   catalog: Object.freeze({
     schema: "cssblackhole-prepared-catalog-descriptor@1",
-    url: `/cssblackhole/catalog.json?sha256=${catalogHash}`,
+    url: `${assetRoot}/catalog.json?sha256=${catalogHash}`,
     sha256: catalogHash,
     byteLength: catalogBytes.byteLength,
   }),
@@ -443,17 +463,18 @@ async function readPreparedSourceState() {
         sourceState.ghostPointCount !== sourceGhostPointCount ||
         sourceState.frameCount !== streamFrameCount ||
         sourceState.framesPerSecond !== sourceFramesPerSecond ||
-        sourceState.orbitalSpeedScale !== 0.5 ||
-        sourceState.sourceMotionReferenceSeconds !== 10 ||
+        sourceState.orbitalSpeedScale !== 0.25 ||
+        sourceState.sourceMotionReferenceSeconds !== 20 ||
         sourceState.naturalTimePerSourceMotionReference !== 1000 ||
         JSON.stringify(sourceState.naturalTimePerPresentationSlot) !==
-          JSON.stringify([800, 450, 300, 450]) ||
+          JSON.stringify(presentationProfile.naturalTimePerSlot) ||
         JSON.stringify(sourceState.naturalTimePerPresentationHold) !==
-          JSON.stringify([600, 250, 100, 250]) ||
-        sourceState.naturalTimePerSourceLoop !== 9000 ||
+          JSON.stringify(presentationProfile.naturalTimePerHold) ||
+        sourceState.naturalTimePerSourceLoop !== 4500 ||
         sourceState.sourceLoopSeconds !== 90 || sourceState.sourceLoopFrameCount !== 5400 ||
-        sourceState.combinedLoopSeconds !== 180 || sourceState.combinedLoopFrameCount !== 10800 ||
-        sourceState.availablePeriodicRadiusCount !== 89 ||
+        sourceState.combinedLoopSeconds !== presentationProfile.combinedLoopSeconds ||
+        sourceState.combinedLoopFrameCount !== presentationProfile.streamFrameCount ||
+        sourceState.availablePeriodicRadiusCount !== 44 ||
         sourceState.periodicRadiusCount !== expectedPeriodicOrbitCounts.length ||
         sourceState.periodicOrbitCounts?.length !== expectedPeriodicOrbitCounts.length ||
         sourceState.periodicOrbitCounts.some(
@@ -475,56 +496,53 @@ async function readPreparedSourceState() {
         sourceState.photometry?.displayOpacityFloor !== 0.22 ||
         sourceState.configurationSequence?.schema !==
           "cssblackhole-luminet-moving-configuration-sequence@3" ||
+        sourceState.configurationSequence.profile !== presentationProfile.id ||
         sourceState.configurationSequence.distinctConfigurationCount !== configurationCount ||
         sourceState.configurationSequence.presentationConfigurationCount !==
           presentationConfigurationCount ||
-        sourceState.configurationSequence.presentationSequenceSeconds !== 20 ||
-        sourceState.configurationSequence.presentationSequenceFrameCount !== 1200 ||
+        sourceState.configurationSequence.presentationSequenceSeconds !==
+          presentationProfile.sequenceSeconds ||
+        sourceState.configurationSequence.presentationSequenceFrameCount !==
+          presentationProfile.sequenceFrameCount ||
         JSON.stringify(sourceState.configurationSequence.presentationSlotHoldSeconds) !==
-          JSON.stringify([6, 2.5, 1, 2.5]) ||
+          JSON.stringify(presentationProfile.holdSeconds) ||
         JSON.stringify(sourceState.configurationSequence.presentationSlotDurationSeconds) !==
-          JSON.stringify([8, 4.5, 3, 4.5]) ||
+          JSON.stringify(presentationProfile.durationSeconds) ||
         JSON.stringify(sourceState.configurationSequence.presentationSlotFrameCounts) !==
-          JSON.stringify([480, 270, 180, 270]) ||
+          JSON.stringify(presentationProfile.frameCounts) ||
         JSON.stringify(sourceState.configurationSequence.presentationSlotStartFrameIndices) !==
-          JSON.stringify([0, 480, 750, 930]) ||
+          JSON.stringify(presentationProfile.startFrameIndices) ||
         JSON.stringify(sourceState.configurationSequence.transitionCadenceSecondsBySlot) !==
-          JSON.stringify([8, 4.5, 3, 4.5]) ||
+          JSON.stringify(presentationProfile.durationSeconds) ||
         JSON.stringify(sourceState.configurationSequence.sourceMotionSecondsBeforeTransitionBySlot) !==
-          JSON.stringify([6, 2.5, 1, 2.5]) ||
+          JSON.stringify(presentationProfile.holdSeconds) ||
         JSON.stringify(sourceState.configurationSequence.sourceMotionFrameCountsBeforeTransition) !==
-          JSON.stringify([360, 150, 60, 150]) ||
+          JSON.stringify(presentationProfile.transitionStartFrameIndices) ||
         JSON.stringify(sourceState.configurationSequence.transitionStartFrameIndices) !==
-          JSON.stringify([360, 150, 60, 150]) ||
+          JSON.stringify(presentationProfile.transitionStartFrameIndices) ||
         sourceState.configurationSequence.transitionSeconds !== 2 ||
         sourceState.configurationSequence.transitionFrameCount !== 120 ||
         sourceState.configurationSequence.states?.length !== configurationCount ||
         sourceState.configurationSequence.states.some((state) => state.dynamic !== true) ||
         JSON.stringify(sourceState.configurationSequence.presentationStateIndices) !==
-          JSON.stringify([0, 1, 2, 1]) ||
-        JSON.stringify(sourceState.configurationSequence.presentationSequence) !== JSON.stringify([
-          "luminet-inclination-85deg",
-          "luminet-inclination-60deg",
-          "luminet-inclination-0deg",
-          "luminet-inclination-60deg",
-        ]) ||
+          JSON.stringify(presentationProfile.stateIndices) ||
+        JSON.stringify(sourceState.configurationSequence.presentationSequence) !==
+          JSON.stringify(presentationProfile.configurationSequence) ||
         JSON.stringify(sourceState.configurationSequence.presentationSlots?.map(
           ({ stateIndex, view, holdSeconds, durationSeconds, frameCount, startFrameIndex,
             transitionStartFrameIndex, transitionFrameCount }) => ({
             stateIndex, view, holdSeconds, durationSeconds, frameCount, startFrameIndex,
             transitionStartFrameIndex, transitionFrameCount,
-          }))) !== JSON.stringify([
-          { stateIndex: 0, view: "side", holdSeconds: 6, durationSeconds: 8, frameCount: 480,
-            startFrameIndex: 0, transitionStartFrameIndex: 360, transitionFrameCount: 120 },
-          { stateIndex: 1, view: "angled", holdSeconds: 2.5, durationSeconds: 4.5,
-            frameCount: 270, startFrameIndex: 480, transitionStartFrameIndex: 150,
-            transitionFrameCount: 120 },
-          { stateIndex: 2, view: "top", holdSeconds: 1, durationSeconds: 3, frameCount: 180,
-            startFrameIndex: 750, transitionStartFrameIndex: 60, transitionFrameCount: 120 },
-          { stateIndex: 1, view: "angled", holdSeconds: 2.5, durationSeconds: 4.5,
-            frameCount: 270, startFrameIndex: 930, transitionStartFrameIndex: 150,
-            transitionFrameCount: 120 },
-        ])) return null;
+          }))) !== JSON.stringify(presentationProfile.stateIndices.map((stateIndex, index) => ({
+          stateIndex,
+          view: stateIndex === 0 ? "side" : stateIndex === 1 ? "angled" : "top",
+          holdSeconds: presentationProfile.holdSeconds[index],
+          durationSeconds: presentationProfile.durationSeconds[index],
+          frameCount: presentationProfile.frameCounts[index],
+          startFrameIndex: presentationProfile.startFrameIndices[index],
+          transitionStartFrameIndex: presentationProfile.transitionStartFrameIndices[index],
+          transitionFrameCount: presentationProfile.transitionFrameCount,
+        })))) return null;
     return Object.freeze({ sourceState, coordinateBytes, luminanceBytes });
   } catch {
     return null;
@@ -640,6 +658,7 @@ async function ensurePythonEnvironment() {
 async function runPythonPreparation() {
   await new Promise((resolvePromise, rejectPromise) => {
     const child = spawn(pythonPath, [resolve(import.meta.dirname, "prepare-luminet-state.py"),
+      "--sequence", presentationProfile.id,
       "--source-root", sourceRoot, "--source-commit", sourceLock.commit,
       "--output", coordinatePath, "--luminance-output", luminancePath,
       "--metadata", stateMetadataPath, "--oracle", oraclePpmPath,

--- a/src/adapters/blackhole/tools/prepare-luminet-state.py
+++ b/src/adapters/blackhole/tools/prepare-luminet-state.py
@@ -23,7 +23,7 @@ GHOST_COUNT = 1_000
 SOURCE_CONFIGURATION_COUNT = 3
 TRANSITION_SECONDS = 2
 TRANSITION_FRAME_COUNT = TRANSITION_SECONDS * FRAMES_PER_SECOND
-ORBITAL_SPEED_SCALE = 0.5
+ORBITAL_SPEED_SCALE = 0.25
 SOURCE_MOTION_REFERENCE_SECONDS = 5 / ORBITAL_SPEED_SCALE
 NATURAL_TIME_PER_SOURCE_MOTION_REFERENCE = 1_000.0
 NATURAL_TIME_PER_SECOND = \
@@ -31,36 +31,8 @@ NATURAL_TIME_PER_SECOND = \
 SOURCE_LOOP_SECONDS = 90
 SOURCE_LOOP_FRAME_COUNT = round(SOURCE_LOOP_SECONDS * FRAMES_PER_SECOND)
 NATURAL_TIME_PER_SOURCE_LOOP = NATURAL_TIME_PER_SECOND * SOURCE_LOOP_SECONDS
-AVAILABLE_PERIODIC_RADIUS_COUNT = 89
+AVAILABLE_PERIODIC_RADIUS_COUNT = 44
 PERIODIC_RADIUS_COUNT = 16
-PRESENTATION_CONFIGURATION_SEQUENCE = (0, 1, 2, 1)
-PRESENTATION_CONFIGURATION_COUNT = len(PRESENTATION_CONFIGURATION_SEQUENCE)
-PRESENTATION_SLOT_HOLD_SECONDS = (6, 2.5, 1, 2.5)
-PRESENTATION_SLOT_DURATION_SECONDS = tuple(
-    hold_seconds + TRANSITION_SECONDS
-    for hold_seconds in PRESENTATION_SLOT_HOLD_SECONDS
-)
-PRESENTATION_SLOT_FRAME_COUNTS = tuple(
-    round(duration * FRAMES_PER_SECOND)
-    for duration in PRESENTATION_SLOT_DURATION_SECONDS
-)
-PRESENTATION_SLOT_TRANSITION_START_FRAME_INDICES = tuple(
-    frame_count - TRANSITION_FRAME_COUNT
-    for frame_count in PRESENTATION_SLOT_FRAME_COUNTS
-)
-PRESENTATION_SLOT_START_FRAME_INDICES = tuple(
-    sum(PRESENTATION_SLOT_FRAME_COUNTS[:index])
-    for index in range(PRESENTATION_CONFIGURATION_COUNT)
-)
-PRESENTATION_SEQUENCE_FRAME_COUNT = sum(PRESENTATION_SLOT_FRAME_COUNTS)
-PRESENTATION_SEQUENCE_SECONDS = \
-    PRESENTATION_SEQUENCE_FRAME_COUNT / FRAMES_PER_SECOND
-COMBINED_LOOP_FRAME_COUNT = math.lcm(
-    SOURCE_LOOP_FRAME_COUNT,
-    PRESENTATION_SEQUENCE_FRAME_COUNT,
-)
-COMBINED_LOOP_SECONDS = COMBINED_LOOP_FRAME_COUNT / FRAMES_PER_SECOND
-FRAME_COUNT = COMBINED_LOOP_FRAME_COUNT
 MASS = 1.0
 MINIMUM_RADIUS = 6.0
 MAXIMUM_RADIUS = 30.0
@@ -93,24 +65,22 @@ CONFIGURATIONS = (
         "sourceEvidence": "luminet/isoradial.py:0 degrees is top-down",
     },
 )
-if len(CONFIGURATIONS) != SOURCE_CONFIGURATION_COUNT or \
-        any(index < 0 or index >= SOURCE_CONFIGURATION_COUNT
-            for index in PRESENTATION_CONFIGURATION_SEQUENCE):
-    raise RuntimeError("Luminet source or presentation configuration count drifted")
+if len(CONFIGURATIONS) != SOURCE_CONFIGURATION_COUNT:
+    raise RuntimeError("Luminet source configuration count drifted")
 
 
 def main() -> None:
     arguments = parse_arguments()
+    presentation = presentation_profile(arguments.sequence)
     source_root = pathlib.Path(arguments.source_root).resolve()
     sys.path.insert(0, str(source_root))
     from luminet import black_hole_math as bhmath
     from luminet.spatial import polar_to_cartesian
 
-    if SOURCE_MOTION_REFERENCE_SECONDS != 10 or SOURCE_LOOP_FRAME_COUNT != 5_400 or \
-            PRESENTATION_SEQUENCE_FRAME_COUNT != 1_200 or \
-            COMBINED_LOOP_SECONDS != 180 or FRAME_COUNT != 10_800:
+    if SOURCE_MOTION_REFERENCE_SECONDS != 20 or SOURCE_LOOP_FRAME_COUNT != 5_400 or \
+            presentation["combinedLoopFrameCount"] != presentation["frameCount"]:
         raise RuntimeError(
-            "Variable-hold Luminet cadence did not produce the 180-second combined loop")
+            "Variable-hold Luminet cadence did not produce an exact combined loop")
 
     particles = create_particles()
     started_at = time.perf_counter()
@@ -132,7 +102,7 @@ def main() -> None:
     source_luminances = np.ascontiguousarray(rgba[..., 0], dtype=np.uint8)
 
     coordinates, luminances = prepare_moving_configuration_loop(
-        source_coordinates, source_luminances)
+        source_coordinates, source_luminances, presentation)
 
     for configuration_index, configuration in enumerate(CONFIGURATIONS):
         inclination = math.radians(configuration["inclinationDegrees"])
@@ -168,24 +138,24 @@ def main() -> None:
         "pointCount": POINT_COUNT,
         "directPointCount": DIRECT_COUNT,
         "ghostPointCount": GHOST_COUNT,
-        "frameCount": FRAME_COUNT,
+        "frameCount": presentation["frameCount"],
         "framesPerSecond": FRAMES_PER_SECOND,
         "orbitalSpeedScale": ORBITAL_SPEED_SCALE,
         "naturalTimePerSourceMotionReference": NATURAL_TIME_PER_SOURCE_MOTION_REFERENCE,
         "naturalTimePerPresentationSlot": [
             NATURAL_TIME_PER_SECOND * duration
-            for duration in PRESENTATION_SLOT_DURATION_SECONDS
+            for duration in presentation["slotDurationSeconds"]
         ],
         "naturalTimePerPresentationHold": [
             NATURAL_TIME_PER_SECOND * duration
-            for duration in PRESENTATION_SLOT_HOLD_SECONDS
+            for duration in presentation["slotHoldSeconds"]
         ],
         "sourceMotionReferenceSeconds": SOURCE_MOTION_REFERENCE_SECONDS,
         "naturalTimePerSourceLoop": NATURAL_TIME_PER_SOURCE_LOOP,
         "sourceLoopSeconds": SOURCE_LOOP_SECONDS,
         "sourceLoopFrameCount": SOURCE_LOOP_FRAME_COUNT,
-        "combinedLoopSeconds": COMBINED_LOOP_SECONDS,
-        "combinedLoopFrameCount": FRAME_COUNT,
+        "combinedLoopSeconds": presentation["combinedLoopSeconds"],
+        "combinedLoopFrameCount": presentation["combinedLoopFrameCount"],
         "mass": MASS,
         "minimumRadius": MINIMUM_RADIUS,
         "maximumRadius": MAXIMUM_RADIUS,
@@ -218,22 +188,23 @@ def main() -> None:
         },
         "configurationSequence": {
             "schema": "cssblackhole-luminet-moving-configuration-sequence@3",
+            "profile": presentation["id"],
             "distinctConfigurationCount": SOURCE_CONFIGURATION_COUNT,
-            "presentationConfigurationCount": PRESENTATION_CONFIGURATION_COUNT,
-            "presentationSequenceSeconds": PRESENTATION_SEQUENCE_SECONDS,
-            "presentationSequenceFrameCount": PRESENTATION_SEQUENCE_FRAME_COUNT,
-            "presentationSlotHoldSeconds": list(PRESENTATION_SLOT_HOLD_SECONDS),
-            "presentationSlotDurationSeconds": list(PRESENTATION_SLOT_DURATION_SECONDS),
-            "presentationSlotFrameCounts": list(PRESENTATION_SLOT_FRAME_COUNTS),
+            "presentationConfigurationCount": presentation["configurationCount"],
+            "presentationSequenceSeconds": presentation["sequenceSeconds"],
+            "presentationSequenceFrameCount": presentation["sequenceFrameCount"],
+            "presentationSlotHoldSeconds": list(presentation["slotHoldSeconds"]),
+            "presentationSlotDurationSeconds": list(presentation["slotDurationSeconds"]),
+            "presentationSlotFrameCounts": list(presentation["slotFrameCounts"]),
             "presentationSlotStartFrameIndices":
-                list(PRESENTATION_SLOT_START_FRAME_INDICES),
-            "transitionCadenceSecondsBySlot": list(PRESENTATION_SLOT_DURATION_SECONDS),
+                list(presentation["slotStartFrameIndices"]),
+            "transitionCadenceSecondsBySlot": list(presentation["slotDurationSeconds"]),
             "sourceMotionSecondsBeforeTransitionBySlot":
-                list(PRESENTATION_SLOT_HOLD_SECONDS),
+                list(presentation["slotHoldSeconds"]),
             "sourceMotionFrameCountsBeforeTransition":
-                list(PRESENTATION_SLOT_TRANSITION_START_FRAME_INDICES),
+                list(presentation["slotTransitionStartFrameIndices"]),
             "transitionStartFrameIndices":
-                list(PRESENTATION_SLOT_TRANSITION_START_FRAME_INDICES),
+                list(presentation["slotTransitionStartFrameIndices"]),
             "transitionSeconds": TRANSITION_SECONDS,
             "transitionFrameCount": TRANSITION_FRAME_COUNT,
             "orbitalSpeedScale": ORBITAL_SPEED_SCALE,
@@ -243,10 +214,10 @@ def main() -> None:
                 "prepared-smoothstep-between-concurrently-moving-source-geodesic-fields",
             "identityCorrespondence":
                 "same-source-emitter-radius-order-and-index-across-configurations",
-            "presentationStateIndices": list(PRESENTATION_CONFIGURATION_SEQUENCE),
+            "presentationStateIndices": list(presentation["configurationSequence"]),
             "presentationSequence": [
                 CONFIGURATIONS[index]["id"]
-                for index in PRESENTATION_CONFIGURATION_SEQUENCE
+                for index in presentation["configurationSequence"]
             ],
             "presentationSlots": [
                 {
@@ -254,16 +225,16 @@ def main() -> None:
                     "stateIndex": state_index,
                     "id": CONFIGURATIONS[state_index]["id"],
                     "view": CONFIGURATIONS[state_index]["view"],
-                    "holdSeconds": PRESENTATION_SLOT_HOLD_SECONDS[presentation_index],
-                    "durationSeconds": PRESENTATION_SLOT_DURATION_SECONDS[presentation_index],
-                    "frameCount": PRESENTATION_SLOT_FRAME_COUNTS[presentation_index],
-                    "startFrameIndex": PRESENTATION_SLOT_START_FRAME_INDICES[presentation_index],
+                    "holdSeconds": presentation["slotHoldSeconds"][presentation_index],
+                    "durationSeconds": presentation["slotDurationSeconds"][presentation_index],
+                    "frameCount": presentation["slotFrameCounts"][presentation_index],
+                    "startFrameIndex": presentation["slotStartFrameIndices"][presentation_index],
                     "transitionStartFrameIndex":
-                        PRESENTATION_SLOT_TRANSITION_START_FRAME_INDICES[presentation_index],
+                        presentation["slotTransitionStartFrameIndices"][presentation_index],
                     "transitionFrameCount": TRANSITION_FRAME_COUNT,
                 }
                 for presentation_index, state_index in
-                enumerate(PRESENTATION_CONFIGURATION_SEQUENCE)
+                enumerate(presentation["configurationSequence"])
             ],
             "states": [
                 {
@@ -305,34 +276,42 @@ def main() -> None:
 def prepare_moving_configuration_loop(
         source_coordinates: np.ndarray,
         source_luminances: np.ndarray,
+        presentation: dict[str, object],
 ) -> tuple[np.ndarray, np.ndarray]:
-    coordinates = np.empty((FRAME_COUNT, POINT_COUNT, 2), dtype="<i4")
-    luminances = np.empty((FRAME_COUNT, POINT_COUNT), dtype=np.uint8)
-    for global_frame_index in range(FRAME_COUNT):
-        sequence_frame_index = global_frame_index % PRESENTATION_SEQUENCE_FRAME_COUNT
+    frame_count = presentation["frameCount"]
+    configuration_sequence = presentation["configurationSequence"]
+    slot_start_frame_indices = presentation["slotStartFrameIndices"]
+    slot_frame_counts = presentation["slotFrameCounts"]
+    slot_transition_start_frame_indices = presentation["slotTransitionStartFrameIndices"]
+    sequence_frame_count = presentation["sequenceFrameCount"]
+    configuration_count = presentation["configurationCount"]
+    coordinates = np.empty((frame_count, POINT_COUNT, 2), dtype="<i4")
+    luminances = np.empty((frame_count, POINT_COUNT), dtype=np.uint8)
+    for global_frame_index in range(frame_count):
+        sequence_frame_index = global_frame_index % sequence_frame_count
         presentation_index = next(
             index
             for index, start_frame_index in
-            enumerate(PRESENTATION_SLOT_START_FRAME_INDICES)
+            enumerate(slot_start_frame_indices)
             if sequence_frame_index <
-            start_frame_index + PRESENTATION_SLOT_FRAME_COUNTS[index]
+            start_frame_index + slot_frame_counts[index]
         )
-        configuration_index = PRESENTATION_CONFIGURATION_SEQUENCE[presentation_index]
+        configuration_index = configuration_sequence[presentation_index]
         local_frame_index = sequence_frame_index - \
-            PRESENTATION_SLOT_START_FRAME_INDICES[presentation_index]
+            slot_start_frame_indices[presentation_index]
         source_loop_frame_index = global_frame_index % SOURCE_LOOP_FRAME_COUNT
         current_coordinates = source_coordinates[configuration_index, source_loop_frame_index]
         current_luminances = source_luminances[configuration_index, source_loop_frame_index]
         transition_start_frame_index = \
-            PRESENTATION_SLOT_TRANSITION_START_FRAME_INDICES[presentation_index]
+            slot_transition_start_frame_indices[presentation_index]
         if local_frame_index < transition_start_frame_index:
             coordinates[global_frame_index] = current_coordinates
             luminances[global_frame_index] = current_luminances
             continue
         next_presentation_index = \
-            (presentation_index + 1) % PRESENTATION_CONFIGURATION_COUNT
+            (presentation_index + 1) % configuration_count
         next_configuration_index = \
-            PRESENTATION_CONFIGURATION_SEQUENCE[next_presentation_index]
+            configuration_sequence[next_presentation_index]
         next_coordinates = source_coordinates[next_configuration_index, source_loop_frame_index]
         next_luminances = source_luminances[next_configuration_index, source_loop_frame_index]
         progress = (local_frame_index - transition_start_frame_index + 1) / \
@@ -343,6 +322,59 @@ def prepare_moving_configuration_loop(
         luminances[global_frame_index] = np.rint(
             current_luminances * (1 - eased) + next_luminances * eased).astype(np.uint8)
     return np.ascontiguousarray(coordinates), np.ascontiguousarray(luminances)
+
+
+def presentation_profile(sequence_id: str) -> dict[str, object]:
+    if sequence_id == "full":
+        configuration_sequence = (0, 1, 2, 1)
+        slot_hold_seconds = (5, 2.5, 2, 2.5)
+        expected_combined_loop_seconds = 180
+    elif sequence_id == "side-tilt":
+        configuration_sequence = (0, 1)
+        slot_hold_seconds = (6, 2.5)
+        expected_combined_loop_seconds = 450
+    else:
+        raise RuntimeError(f"Unsupported Luminet presentation sequence: {sequence_id}")
+    if any(index < 0 or index >= SOURCE_CONFIGURATION_COUNT
+           for index in configuration_sequence):
+        raise RuntimeError("Luminet presentation configuration index drifted")
+    slot_duration_seconds = tuple(
+        hold_seconds + TRANSITION_SECONDS
+        for hold_seconds in slot_hold_seconds
+    )
+    slot_frame_counts = tuple(
+        round(duration * FRAMES_PER_SECOND)
+        for duration in slot_duration_seconds
+    )
+    slot_transition_start_frame_indices = tuple(
+        frame_count - TRANSITION_FRAME_COUNT
+        for frame_count in slot_frame_counts
+    )
+    slot_start_frame_indices = tuple(
+        sum(slot_frame_counts[:index])
+        for index in range(len(configuration_sequence))
+    )
+    sequence_frame_count = sum(slot_frame_counts)
+    combined_loop_frame_count = math.lcm(
+        SOURCE_LOOP_FRAME_COUNT, sequence_frame_count)
+    combined_loop_seconds = combined_loop_frame_count / FRAMES_PER_SECOND
+    if combined_loop_seconds != expected_combined_loop_seconds:
+        raise RuntimeError("Luminet presentation combined-loop closure drifted")
+    return {
+        "id": sequence_id,
+        "configurationSequence": configuration_sequence,
+        "configurationCount": len(configuration_sequence),
+        "slotHoldSeconds": slot_hold_seconds,
+        "slotDurationSeconds": slot_duration_seconds,
+        "slotFrameCounts": slot_frame_counts,
+        "slotTransitionStartFrameIndices": slot_transition_start_frame_indices,
+        "slotStartFrameIndices": slot_start_frame_indices,
+        "sequenceFrameCount": sequence_frame_count,
+        "sequenceSeconds": sequence_frame_count / FRAMES_PER_SECOND,
+        "combinedLoopFrameCount": combined_loop_frame_count,
+        "combinedLoopSeconds": combined_loop_seconds,
+        "frameCount": combined_loop_frame_count,
+    }
 
 
 def available_periodic_orbits() -> tuple[np.ndarray, np.ndarray]:
@@ -532,6 +564,7 @@ def render_oracle(frame: np.ndarray, luminances: np.ndarray, output_path: pathli
 
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--sequence", choices=("full", "side-tilt"), default="full")
     parser.add_argument("--source-root", required=True)
     parser.add_argument("--source-commit", required=True)
     parser.add_argument("--output", required=True)

--- a/src/adapters/blackhole/tools/smoke-browser.mjs
+++ b/src/adapters/blackhole/tools/smoke-browser.mjs
@@ -252,11 +252,11 @@ function assertSmoke(report) {
       report.initial.stats?.configurationCount !== 3 ||
       report.initial.stats?.sourceFramesPerSecond !== 60 ||
       report.initial.stats?.framesPerSecond !== 60 ||
-      report.initial.stats?.orbitalSpeedScale !== 0.5 ||
+      report.initial.stats?.orbitalSpeedScale !== 0.25 ||
       JSON.stringify(report.initial.stats?.presentationSlotHoldSeconds) !==
-        JSON.stringify([6, 2.5, 1, 2.5]) ||
+        JSON.stringify([5, 2.5, 2, 2.5]) ||
       JSON.stringify(report.initial.stats?.transitionCadenceSecondsBySlot) !==
-        JSON.stringify([8, 4.5, 3, 4.5]) ||
+        JSON.stringify([7, 4.5, 4, 4.5]) ||
       report.initial.stats?.transitionDurationSeconds !== 2 ||
       report.initial.leafCount !== 1979 ||
       report.initial.inlineTransformCount !== 1979 ||
@@ -269,8 +269,8 @@ function assertSmoke(report) {
       report.initial.stats?.runtimeDomReconstructionCount !== 0 ||
       report.initial.stats?.materializedBlockTransformCharacterLimit !== 3_200_000 ||
       report.initial.stats?.materializedBlockScheduleByteLimit !== 260_000 ||
-      report.initial.stats?.maximumPreparedBlockTransformCharacters !== 3_159_406 ||
-      report.initial.stats?.maximumPreparedBlockScheduleBytes !== 253_720 ||
+      report.initial.stats?.maximumPreparedBlockTransformCharacters !== 3_159_508 ||
+      report.initial.stats?.maximumPreparedBlockScheduleBytes !== 249_592 ||
       report.initial.stats?.retainedMaterializedBlockCount !== 1 ||
       report.initial.stats?.retainedMaterializedTransformBytes > 3_200_000 ||
       report.initial.stats?.retainedMaterializedScheduleBytes > 260_000 ||

--- a/src/adapters/blackhole/vite.config.mjs
+++ b/src/adapters/blackhole/vite.config.mjs
@@ -15,7 +15,8 @@ function createBlackHolePreparedBrotliPlugin() {
     server.middlewares.use(async (request, response, next) => {
       if (!request.url || !["GET", "HEAD"].includes(request.method ?? "GET")) return next();
       const pathname = new URL(request.url, "http://css.graphics").pathname;
-      if (!/^\/cssblackhole\/banks\/bank-\d{2}-[a-f0-9]{64}\.bin\.br$/u.test(pathname)) {
+      if (!/^\/cssblackhole(?:-side-tilt)?\/banks\/bank-\d{2}-[a-f0-9]{64}\.bin\.br$/u
+        .test(pathname)) {
         return next();
       }
       try {


### PR DESCRIPTION
## Summary
- slow Luminet orbital presentation to the approved 0.25 scale
- use 5 / 2.5 / 2 / 2.5-second holds with unchanged 2-second morphs
- keep the optional side/tilt-only prepared profile loopback-only
- regenerate bounded prepared-state contracts and exact validators

## Verification
- `pnpm test:luminet` (12/12)
- `pnpm build:deploy`
- `pnpm test:luminet:deploy` (desktop, 27-inch, mobile, DPR2; 60 Hz, 1,979 leaves)