### PR TITLE
Compress Luminet playback into prepared rails

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -131,6 +131,13 @@
     Content-Encoding = "br"
 
 [[headers]]
+  for = "/cssblackhole/rails/*.bin.br"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+    Content-Type = "application/octet-stream"
+    Content-Encoding = "br"
+
+[[headers]]
   for = "/cssblackhole/*.json"
   [headers.values]
     Cache-Control = "no-cache"

--- a/src/adapters/blackhole/src/cssblackhole/preparedBlockWorker.mjs
+++ b/src/adapters/blackhole/src/cssblackhole/preparedBlockWorker.mjs
@@ -3,15 +3,30 @@ import {
   createBlackHolePreparedBlockCoordinateDecoder,
   decodeBlackHolePreparedOpacitySchedule,
   formatBlackHolePreparedTransform,
+  quantizeBlackHolePreparedOpacityIndex,
   readBlackHolePreparedBankSections,
 } from "../shared/cssblackhole/preparedBlockTransport.mjs";
+import {
+  CSSBLACKHOLE_RAIL_ENCODING,
+  readBlackHolePreparedRailAsset,
+  readBlackHolePreparedRepairBank,
+  unpackBlackHolePreparedRailDescriptor,
+} from "../shared/cssblackhole/preparedRailTransport.mjs";
 
 const MAXIMUM_MATERIALIZATION_SLICE_MILLISECONDS = 2;
 const TRANSFORM_RESPONSE_CHUNK_SIZE = 4_096;
+const REPAIR_DIRECTIONS = Object.freeze([
+  Object.freeze([1, 0]), Object.freeze([-1, 0]),
+  Object.freeze([0, 1]), Object.freeze([0, -1]),
+  Object.freeze([1, 1]), Object.freeze([-1, 1]),
+  Object.freeze([1, -1]), Object.freeze([-1, -1]),
+]);
 let catalog = null;
 let tail = Promise.resolve();
 const retainedBanks = new Uint8Array(256);
 const banks = new Map();
+let sourceRails = null;
+const sourceRailConfigurations = [];
 
 self.addEventListener("message", ({ data }) => {
   try {
@@ -45,6 +60,11 @@ self.addEventListener("message", ({ data }) => {
         .catch((error) => postError(error, data.requestId));
       return;
     }
+    if (data.type === "register-rails" && data.bytes instanceof Uint8Array) {
+      tail = tail.then(() => registerRails(data), () => registerRails(data))
+        .catch((error) => postError(error, data.requestId));
+      return;
+    }
     if (data.type === "materialize-block" && Number.isSafeInteger(data.blockIndex) &&
         typeof data.eager === "boolean") {
       tail = tail.then(() => materializeBlock(data), () => materializeBlock(data))
@@ -68,7 +88,9 @@ async function registerBank(data) {
   await verify(decoded, descriptor.decodedByteLength, descriptor.decodedSha256, "decoded");
   await yieldTask();
   const sliceStartedAt = performance.now();
-  const bank = readBlackHolePreparedBankSections(decoded, descriptor, catalog);
+  const bank = catalog.transport.encoding === CSSBLACKHOLE_RAIL_ENCODING ?
+    readBlackHolePreparedRepairBank(decoded, descriptor, catalog) :
+    readBlackHolePreparedBankSections(decoded, descriptor, catalog);
   const maximumSliceMilliseconds = performance.now() - sliceStartedAt;
   banks.set(descriptor.index, bank);
   trimBanks();
@@ -82,6 +104,63 @@ async function registerBank(data) {
   });
 }
 
+async function registerRails(data) {
+  const startedAt = performance.now();
+  const configurationIndex = data.descriptor?.configurationIndex;
+  const expectedDescriptor = catalog.sourceRails?.[configurationIndex];
+  if (!Number.isSafeInteger(configurationIndex) ||
+      sourceRailConfigurations[configurationIndex] !== undefined ||
+      data.descriptor?.decodedSha256 !== expectedDescriptor?.decodedSha256) {
+    throw new Error("BlackHole worker source rail registration drifted");
+  }
+  const decoded = data.bytes;
+  await yieldTask();
+  await verify(decoded, expectedDescriptor.decodedByteLength,
+    expectedDescriptor.decodedSha256, `source rails ${configurationIndex} decoded`);
+  await yieldTask();
+  const sliceStartedAt = performance.now();
+  const rails = readBlackHolePreparedRailAsset(decoded, expectedDescriptor, catalog);
+  if (sourceRails === null) {
+    const phaseFrameIndices = new Uint16Array(catalog.starCount);
+    const turns = new Uint8Array(catalog.starCount);
+    const baseRailSampleIndices = new Uint32Array(catalog.starCount);
+    for (let leafIndex = 0; leafIndex < catalog.starCount; leafIndex += 1) {
+      const descriptor = unpackBlackHolePreparedRailDescriptor(rails.descriptors[leafIndex]);
+      phaseFrameIndices[leafIndex] = descriptor.phaseFrameIndex;
+      turns[leafIndex] = rails.periodicOrbitCounts[descriptor.radiusIndex];
+      baseRailSampleIndices[leafIndex] =
+        (descriptor.order * rails.radiusCount + descriptor.radiusIndex) * rails.sourceFrameCount;
+    }
+    sourceRails = Object.freeze({
+      imageOrderCount: rails.imageOrderCount,
+      radiusCount: rails.radiusCount,
+      sourceFrameCount: rails.sourceFrameCount,
+      descriptors: rails.descriptors,
+      easing: rails.easing,
+      periodicOrbitCounts: rails.periodicOrbitCounts,
+      phaseFrameIndices,
+      turns,
+      baseRailSampleIndices,
+    });
+  } else if (!equalTypedValues(sourceRails.descriptors, rails.descriptors) ||
+      !equalTypedValues(sourceRails.easing, rails.easing) ||
+      !equalTypedValues(sourceRails.periodicOrbitCounts, rails.periodicOrbitCounts)) {
+    throw new Error(`BlackHole source rail identity ${configurationIndex} drifted`);
+  }
+  sourceRailConfigurations[configurationIndex] = Object.freeze({
+    coordinates: rails.coordinates,
+    luminances: rails.luminances,
+  });
+  self.postMessage({
+    type: "registered-rails",
+    requestId: data.requestId,
+    configurationIndex,
+    decodedByteLength: decoded.byteLength,
+    workerDurationMilliseconds: performance.now() - startedAt,
+    workerMaximumSliceMilliseconds: performance.now() - sliceStartedAt,
+  });
+}
+
 async function materializeBlock(data) {
   const startedAt = performance.now();
   const blockIndex = normalize(data.blockIndex, catalog.blockCount);
@@ -91,21 +170,33 @@ async function materializeBlock(data) {
   if (!bank) throw new Error(`BlackHole bank ${bankIndex} was not registered before block materialization`);
   let maximumSliceMilliseconds = 0;
   let sliceCount = 0;
-  const decoder = createBlackHolePreparedBlockCoordinateDecoder(bank, bankBlockIndex, catalog);
-  while (!decoder.finished) {
-    const sliceStartedAt = performance.now();
-    decoder.step(1_024);
+  let coordinates;
+  let opacitySchedule;
+  if (catalog.transport.encoding === CSSBLACKHOLE_RAIL_ENCODING) {
+    if (sourceRails === null) throw new Error("BlackHole source rails were not registered");
+    const prepared = await materializeRailBlockState(blockIndex, bank, bankBlockIndex);
+    coordinates = prepared.coordinates;
+    opacitySchedule = prepared.opacitySchedule;
+    maximumSliceMilliseconds = prepared.maximumSliceMilliseconds;
+    sliceCount = prepared.sliceCount;
+  } else {
+    const decoder = createBlackHolePreparedBlockCoordinateDecoder(bank, bankBlockIndex, catalog);
+    while (!decoder.finished) {
+      const sliceStartedAt = performance.now();
+      decoder.step(1_024);
+      maximumSliceMilliseconds = Math.max(maximumSliceMilliseconds,
+        performance.now() - sliceStartedAt);
+      sliceCount += 1;
+      if (!decoder.finished) await yieldTask();
+    }
+    coordinates = decoder.coordinates;
+    const opacityScheduleStartedAt = performance.now();
+    opacitySchedule = decodeBlackHolePreparedOpacitySchedule(bank, bankBlockIndex);
     maximumSliceMilliseconds = Math.max(maximumSliceMilliseconds,
-      performance.now() - sliceStartedAt);
+      performance.now() - opacityScheduleStartedAt);
     sliceCount += 1;
-    if (!decoder.finished) await yieldTask();
+    await yieldTask();
   }
-  const opacityScheduleStartedAt = performance.now();
-  const opacitySchedule = decodeBlackHolePreparedOpacitySchedule(bank, bankBlockIndex);
-  maximumSliceMilliseconds = Math.max(maximumSliceMilliseconds,
-    performance.now() - opacityScheduleStartedAt);
-  sliceCount += 1;
-  await yieldTask();
 
   const frameOffsets = new Uint32Array(catalog.blockFrameCount + 1);
   let frameIndex = 0;
@@ -114,10 +205,10 @@ async function materializeBlock(data) {
   while (frameIndex < catalog.blockFrameCount) {
     const sampleIndex = frameIndex * catalog.starCount + leafIndex;
     const coordinateOffset = sampleIndex * 2;
-    const x = decoder.coordinates[coordinateOffset];
-    const y = decoder.coordinates[coordinateOffset + 1];
-    const changed = frameIndex === 0 || x !== decoder.coordinates[coordinateOffset - catalog.starCount * 2] ||
-      y !== decoder.coordinates[coordinateOffset - catalog.starCount * 2 + 1];
+    const x = coordinates[coordinateOffset];
+    const y = coordinates[coordinateOffset + 1];
+    const changed = frameIndex === 0 || x !== coordinates[coordinateOffset - catalog.starCount * 2] ||
+      y !== coordinates[coordinateOffset - catalog.starCount * 2 + 1];
     if (changed) frameOffsets[frameIndex + 1] += 1;
     leafIndex += 1;
     if (leafIndex === catalog.starCount) {
@@ -149,10 +240,10 @@ async function materializeBlock(data) {
   while (frameIndex < catalog.blockFrameCount) {
     const sampleIndex = frameIndex * catalog.starCount + leafIndex;
     const coordinateOffset = sampleIndex * 2;
-    const x = decoder.coordinates[coordinateOffset];
-    const y = decoder.coordinates[coordinateOffset + 1];
-    const changed = frameIndex === 0 || x !== decoder.coordinates[coordinateOffset - catalog.starCount * 2] ||
-      y !== decoder.coordinates[coordinateOffset - catalog.starCount * 2 + 1];
+    const x = coordinates[coordinateOffset];
+    const y = coordinates[coordinateOffset + 1];
+    const changed = frameIndex === 0 || x !== coordinates[coordinateOffset - catalog.starCount * 2] ||
+      y !== coordinates[coordinateOffset - catalog.starCount * 2 + 1];
     if (changed) {
       assignmentLeafIndices[assignmentIndex] = leafIndex;
       transforms[assignmentIndex] = formatBlackHolePreparedTransform(x, y);
@@ -198,7 +289,7 @@ async function materializeBlock(data) {
     opacityFrameOffsets: opacitySchedule.frameOffsets,
     opacityLeafIndices: opacitySchedule.leafIndices,
     opacityIndices: opacitySchedule.opacityIndices,
-    decodedCoordinateByteLength: decoder.coordinates.byteLength,
+    decodedCoordinateByteLength: coordinates.byteLength,
   }, [
     frameOffsets.buffer,
     assignmentLeafIndices.buffer,
@@ -238,6 +329,145 @@ async function materializeBlock(data) {
     workerMaximumSliceMilliseconds: maximumSliceMilliseconds,
     workerSliceCount: sliceCount,
   });
+}
+
+async function materializeRailBlockState(blockIndex, bank, bankBlockIndex) {
+  const coordinates = new Int32Array(catalog.blockFrameCount * catalog.starCount * 2);
+  const opacityFrameOffsets = new Uint32Array(catalog.blockFrameCount + 1);
+  const opacityLeafIndices = new Uint16Array(
+    catalog.materialization.maximumOpacityAssignmentCount);
+  const opacityAssignmentIndices = new Uint8Array(
+    catalog.materialization.maximumOpacityAssignmentCount);
+  const previousOpacityIndices = new Uint8Array(catalog.starCount);
+  const sequenceFrameCount = catalog.configurationLoop.presentationSequenceFrameCount;
+  const sourceFrameCount = sourceRails.sourceFrameCount;
+  const slots = catalog.configurationLoop.presentationSlots;
+  const phaseFrameIndices = new Uint16Array(catalog.starCount);
+  const blockStartSourceFrameIndex = blockIndex * catalog.blockFrameCount % sourceFrameCount;
+  for (let leafIndex = 0; leafIndex < catalog.starCount; leafIndex += 1) {
+    phaseFrameIndices[leafIndex] = (
+      sourceRails.phaseFrameIndices[leafIndex] +
+      sourceRails.turns[leafIndex] * blockStartSourceFrameIndex
+    ) % sourceFrameCount;
+  }
+  let opacityAssignmentCount = 0;
+  let maximumSliceMilliseconds = 0;
+  let sliceCount = 0;
+  let sliceStartedAt = performance.now();
+  for (let localFrameIndex = 0; localFrameIndex < catalog.blockFrameCount; localFrameIndex += 1) {
+    const globalFrameIndex = blockIndex * catalog.blockFrameCount + localFrameIndex;
+    const sequenceFrameIndex = globalFrameIndex % sequenceFrameCount;
+    const presentationIndex = slots.findIndex((slot) =>
+      sequenceFrameIndex >= slot.startFrameIndex &&
+      sequenceFrameIndex < slot.startFrameIndex + slot.frameCount);
+    const slot = slots[presentationIndex];
+    if (!slot) throw new Error(`BlackHole presentation slot for frame ${globalFrameIndex} drifted`);
+    const slotFrameIndex = sequenceFrameIndex - slot.startFrameIndex;
+    const transitionIndex = slotFrameIndex - slot.transitionStartFrameIndex;
+    const transitioning = transitionIndex >= 0;
+    const nextSlot = transitioning ? slots[(presentationIndex + 1) % slots.length] : null;
+    const eased = transitioning ? sourceRails.easing[transitionIndex] : 0;
+    const currentRails = sourceRailConfigurations[slot.stateIndex];
+    const nextRails = transitioning ? sourceRailConfigurations[nextSlot.stateIndex] : null;
+    if (!currentRails || transitioning && !nextRails) {
+      throw new Error(`BlackHole required source rails for frame ${globalFrameIndex} were not registered`);
+    }
+    const repairFrameIndex = bankBlockIndex * catalog.blockFrameCount + localFrameIndex;
+    let repairIndex = bank.frameOffsets[repairFrameIndex];
+    const repairEnd = bank.frameOffsets[repairFrameIndex + 1];
+    for (let leafIndex = 0; leafIndex < catalog.starCount; leafIndex += 1) {
+      const phaseFrameIndex = phaseFrameIndices[leafIndex];
+      const currentRailSampleIndex =
+        sourceRails.baseRailSampleIndices[leafIndex] + phaseFrameIndex;
+      let x = currentRails.coordinates[currentRailSampleIndex * 2];
+      let y = currentRails.coordinates[currentRailSampleIndex * 2 + 1];
+      let luminance = currentRails.luminances[currentRailSampleIndex];
+      if (transitioning) {
+        const nextRailSampleIndex =
+          sourceRails.baseRailSampleIndices[leafIndex] + phaseFrameIndex;
+        x = roundTiesToEven(
+          x * (1 - eased) + nextRails.coordinates[nextRailSampleIndex * 2] * eased);
+        y = roundTiesToEven(
+          y * (1 - eased) + nextRails.coordinates[nextRailSampleIndex * 2 + 1] * eased);
+        luminance = roundTiesToEven(
+          luminance * (1 - eased) + nextRails.luminances[nextRailSampleIndex] * eased);
+      }
+      if (repairIndex < repairEnd) {
+        const packedRepair = bank.packedRepairs[repairIndex];
+        const repairLeafIndex = packedRepair & 0x7ff;
+        if (repairLeafIndex < leafIndex) {
+          throw new Error(`BlackHole prepared repair order for frame ${globalFrameIndex} drifted`);
+        }
+        if (repairLeafIndex === leafIndex) {
+          const direction = REPAIR_DIRECTIONS[packedRepair >> 11 & 0x7];
+          const radius = (packedRepair >> 14 & 0x7) + 1;
+          x += direction[0] * 10 * radius;
+          y += direction[1] * 10 * radius;
+          repairIndex += 1;
+        }
+      }
+      const sampleIndex = localFrameIndex * catalog.starCount + leafIndex;
+      const coordinateOffset = sampleIndex * 2;
+      coordinates[coordinateOffset] = x;
+      coordinates[coordinateOffset + 1] = y;
+      const opacityIndex = quantizeBlackHolePreparedOpacityIndex(luminance);
+      if (localFrameIndex === 0 || opacityIndex !== previousOpacityIndices[leafIndex]) {
+        if (opacityAssignmentCount >= opacityLeafIndices.length) {
+          throw new Error("BlackHole rail opacity assignments exceeded prepared bound");
+        }
+        opacityLeafIndices[opacityAssignmentCount] = leafIndex;
+        opacityAssignmentIndices[opacityAssignmentCount] = opacityIndex;
+        opacityAssignmentCount += 1;
+      }
+      previousOpacityIndices[leafIndex] = opacityIndex;
+      let nextPhaseFrameIndex = phaseFrameIndex + sourceRails.turns[leafIndex];
+      if (nextPhaseFrameIndex >= sourceFrameCount) nextPhaseFrameIndex -= sourceFrameCount;
+      phaseFrameIndices[leafIndex] = nextPhaseFrameIndex;
+      if ((sampleIndex & 0xff) === 0 &&
+          performance.now() - sliceStartedAt >= MAXIMUM_MATERIALIZATION_SLICE_MILLISECONDS) {
+        maximumSliceMilliseconds = Math.max(maximumSliceMilliseconds,
+          performance.now() - sliceStartedAt);
+        sliceCount += 1;
+        await yieldTask();
+        sliceStartedAt = performance.now();
+      }
+    }
+    if (repairIndex !== repairEnd) {
+      throw new Error(`BlackHole prepared repairs for frame ${globalFrameIndex} were not consumed`);
+    }
+    opacityFrameOffsets[localFrameIndex + 1] = opacityAssignmentCount;
+  }
+  maximumSliceMilliseconds = Math.max(maximumSliceMilliseconds,
+    performance.now() - sliceStartedAt);
+  sliceCount += 1;
+  await yieldTask();
+
+  if (opacityFrameOffsets.at(-1) !== opacityAssignmentCount ||
+      opacityFrameOffsets[1] !== catalog.starCount) {
+    throw new Error("BlackHole rail opacity schedule drifted");
+  }
+  return Object.freeze({
+    coordinates,
+    opacitySchedule: Object.freeze({
+      frameOffsets: opacityFrameOffsets,
+      leafIndices: opacityLeafIndices.slice(0, opacityAssignmentCount),
+      opacityIndices: opacityAssignmentIndices.slice(0, opacityAssignmentCount),
+    }),
+    maximumSliceMilliseconds,
+    sliceCount,
+  });
+}
+
+function roundTiesToEven(value) {
+  const lower = Math.floor(value);
+  const fraction = value - lower;
+  if (fraction < 0.5) return lower;
+  if (fraction > 0.5) return lower + 1;
+  return lower % 2 === 0 ? lower : lower + 1;
+}
+
+function equalTypedValues(left, right) {
+  return left?.length === right?.length && left.every((value, index) => value === right[index]);
 }
 
 function trimBanks() {

--- a/src/adapters/blackhole/src/cssblackhole/preparedStream.mjs
+++ b/src/adapters/blackhole/src/cssblackhole/preparedStream.mjs
@@ -7,6 +7,11 @@ import {
   CSSBLACKHOLE_OPACITY_PALETTE,
 } from "../shared/cssblackhole/preparedBlockTransport.mjs";
 import {
+  CSSBLACKHOLE_RAIL_ASSET_SCHEMA,
+  CSSBLACKHOLE_RAIL_ENCODING,
+  CSSBLACKHOLE_REPAIR_BANK_SCHEMA,
+} from "../shared/cssblackhole/preparedRailTransport.mjs";
+import {
   CSSBLACKHOLE_DIRECT_IMAGE_DOT_COLORS,
   CSSBLACKHOLE_GALACTIC_DOT_COLORS,
   CSSBLACKHOLE_GHOST_IMAGE_DOT_COLORS,
@@ -53,6 +58,8 @@ export function createBlackHolePreparedBlockWindow(catalog, activeBlockIndex) {
 export function createBlackHolePreparedStreamLoader(catalog) {
   const worker = new Worker(new URL("./preparedBlockWorker.mjs", import.meta.url), { type: "module" });
   const bankPending = new Map();
+  const railPending = new Map();
+  const registeredRails = new Uint8Array(catalog.configurationCount);
   const registerPending = new Map();
   const registeredBanks = new Set();
   const materializedBlocks = new Map();
@@ -64,6 +71,8 @@ export function createBlackHolePreparedStreamLoader(catalog) {
   let destroyed = false;
   let transportBankFetchCount = 0;
   let transportBankFetchBytes = 0;
+  let sourceRailFetchCount = 0;
+  let sourceRailFetchBytes = 0;
   let registeredBankCount = 0;
   let materializedBlockCount = 0;
   let workerBankRegistrationMilliseconds = 0;
@@ -197,6 +206,25 @@ export function createBlackHolePreparedStreamLoader(catalog) {
       trim();
       return;
     }
+    if (data.type === "registered-rails") {
+      const descriptor = catalog.sourceRails?.[request.index];
+      if (request.kind !== "rails" || registeredRails[request.index] !== 0 ||
+          data.configurationIndex !== request.index ||
+          data.decodedByteLength !== descriptor?.decodedByteLength ||
+          !Number.isFinite(data.workerDurationMilliseconds) ||
+          !Number.isFinite(data.workerMaximumSliceMilliseconds)) {
+        rejectAll(new Error("BlackHole worker source rail registration response drifted"));
+        return;
+      }
+      registeredRails[request.index] = 1;
+      workerBankRegistrationMilliseconds += data.workerDurationMilliseconds;
+      workerMaximumSliceMilliseconds = Math.max(
+        workerMaximumSliceMilliseconds, data.workerMaximumSliceMilliseconds);
+      requests.delete(data.requestId);
+      railPending.delete(request.index);
+      request.resolve(true);
+      return;
+    }
     if (data.type === "materialized-start") {
       if (request.kind !== "block" || request.response !== undefined ||
           data.descriptor?.index !== request.index ||
@@ -299,6 +327,44 @@ export function createBlackHolePreparedStreamLoader(catalog) {
     return pending;
   }
 
+  async function ensureRail(configurationIndex) {
+    if (!catalog.sourceRails) return true;
+    if (!Number.isSafeInteger(configurationIndex) || configurationIndex < 0 ||
+        configurationIndex >= catalog.configurationCount) {
+      throw new RangeError("BlackHole source rail configuration index drifted");
+    }
+    if (registeredRails[configurationIndex] === 1) return true;
+    if (railPending.has(configurationIndex)) return railPending.get(configurationIndex);
+    const pending = (async () => {
+      await initialized;
+      if (registeredRails[configurationIndex] === 1) return true;
+      const descriptor = catalog.sourceRails[configurationIndex];
+      const bytes = await fetchHttpExpandedAsset(
+        descriptor, `source rails ${configurationIndex}`);
+      sourceRailFetchCount += 1;
+      sourceRailFetchBytes += descriptor.byteLength;
+      const id = ++requestId;
+      const response = new Promise((resolve, reject) => {
+        requests.set(id, { kind: "rails", index: configurationIndex, resolve, reject });
+      });
+      let workerBytes = bytes;
+      if (bytes.byteOffset !== 0 || bytes.byteLength !== bytes.buffer.byteLength) {
+        workerBytes = bytes.slice();
+        decodedBankTransferCopyCount += 1;
+      }
+      decodedBankTransferCount += 1;
+      worker.postMessage({
+        type: "register-rails", requestId: id, descriptor, bytes: workerBytes,
+      }, [workerBytes.buffer]);
+      return response;
+    })();
+    railPending.set(configurationIndex, pending);
+    return pending.catch((error) => {
+      railPending.delete(configurationIndex);
+      throw error;
+    });
+  }
+
   async function prefetchBank(index) {
     if (destroyed) throw new Error("BlackHole loader is destroyed");
     const descriptor = bankDescriptorAt(index);
@@ -306,6 +372,9 @@ export function createBlackHolePreparedStreamLoader(catalog) {
     if (registerPending.has(descriptor.index)) return registerPending.get(descriptor.index);
     const pending = (async () => {
       await initialized;
+      if (catalog.sourceRails) {
+        await Promise.all(descriptor.requiredSourceConfigurationIndices.map(ensureRail));
+      }
       if (registeredBanks.has(descriptor.index)) return descriptor.index;
       const bytes = await fetchExpandedBank(descriptor.index);
       const id = ++requestId;
@@ -438,6 +507,9 @@ export function createBlackHolePreparedStreamLoader(catalog) {
         pendingMaterializedBlockCount: materializePending.size,
         transportBankFetchCount,
         transportBankFetchBytes,
+        sourceRailFetchCount,
+        sourceRailFetchBytes,
+        registeredSourceRailCount: registeredRails.reduce((sum, value) => sum + value, 0),
         registeredBankCount,
         materializedBlockCount,
         workerBankRegistrationMilliseconds:
@@ -475,6 +547,7 @@ function validateCatalog(catalog) {
   const profileId = catalog?.presentationProfile ?? "full";
   const profile = blackHolePresentationProfile(profileId);
   const assetRoot = catalog?.assetRoot ?? "/cssblackhole";
+  const railTransport = catalog?.transport?.encoding === CSSBLACKHOLE_RAIL_ENCODING;
   if (catalog?.schema !== "cssblackhole-prepared-stream-catalog@1" ||
       assetRoot !== profile.assetRoot ||
       catalog.starCount !== 1979 || catalog.configurationCount !== 3 ||
@@ -525,14 +598,21 @@ function validateCatalog(catalog) {
       catalog.publication.runtimeIntermediateFrameGeneration !== false ||
       catalog.publication.runtimeCatchupPublication !== false ||
       catalog.transport?.schema !== "cssblackhole-prepared-bank-transport@1" ||
-      catalog.transport.encoding !== CSSBLACKHOLE_BANK_ENCODING ||
+      ![CSSBLACKHOLE_BANK_ENCODING, CSSBLACKHOLE_RAIL_ENCODING]
+        .includes(catalog.transport.encoding) ||
       catalog.transport.contentEncoding !== "br" ||
       catalog.transport.bankSeconds !== 5 ||
       catalog.transport.coordinateScale !== CSSBLACKHOLE_COORDINATE_SCALE ||
       catalog.transport.maximumCoordinateQuantizationErrorPixels !==
         CSSBLACKHOLE_MAXIMUM_COORDINATE_QUANTIZATION_ERROR_PIXELS ||
-      catalog.transport.predictor !==
-        "independent-five-second-bank-one-second-block-coordinate-second-difference-plus-prepared-sparse-opacity-ranges" ||
+      catalog.transport.predictor !== (railTransport ?
+        "shared-source-phase-rails-plus-five-second-prepared-sparse-collision-repair-banks" :
+        "independent-five-second-bank-one-second-block-coordinate-second-difference-plus-prepared-sparse-opacity-ranges") ||
+      catalog.transport.runtimeSourcePhysics !== false ||
+      catalog.transport.runtimeCollisionSearch !== false ||
+      catalog.transport.workerRailLookupMaterialization !== railTransport ||
+      (railTransport ? !validSourceRails(catalog.sourceRails, catalog) :
+        catalog.sourceRails !== undefined) ||
       catalog.configurationLoop?.schema !==
         "cssblackhole-luminet-moving-configuration-loop@4" ||
       (catalog.configurationLoop.profile ?? "full") !== profile.id ||
@@ -657,6 +737,7 @@ function validateCatalog(catalog) {
 }
 
 function validateTransport(catalog) {
+  const railTransport = catalog.transport.encoding === CSSBLACKHOLE_RAIL_ENCODING;
   for (let bankIndex = 0; bankIndex < catalog.banks.length; bankIndex += 1) {
     const bank = catalog.banks[bankIndex];
     if (!bank || bank.index !== bankIndex || bank.startFrameIndex !== bankIndex * catalog.bankFrameCount ||
@@ -668,22 +749,39 @@ function validateTransport(catalog) {
         !Number.isSafeInteger(bank.byteLength) || bank.byteLength < 1 ||
         !Number.isSafeInteger(bank.decodedByteLength) || bank.decodedByteLength < bank.byteLength ||
         bank.blockCount !== catalog.blocksPerBank ||
-        !Number.isSafeInteger(bank.visibleSampleCount) || bank.visibleSampleCount < 1 ||
-        bank.visibleSampleCount > bank.sourceSampleCount ||
         bank.sourceSampleCount !== catalog.bankFrameCount * catalog.starCount ||
-        !Number.isSafeInteger(bank.opacityAssignmentCount) ||
-        bank.opacityAssignmentCount < catalog.blocksPerBank * catalog.starCount ||
-        bank.opacityAssignmentCount > 0xffff ||
-        bank.opacityAssignmentCount > bank.sourceSampleCount ||
-        bank.sourceLuminanceSampleCount !== bank.sourceSampleCount ||
         bank.contentEncoding !== "br" ||
         !Number.isFinite(bank.maximumCoordinateQuantizationErrorPixels) ||
         bank.maximumCoordinateQuantizationErrorPixels < 0 ||
         bank.maximumCoordinateQuantizationErrorPixels >
           CSSBLACKHOLE_MAXIMUM_COORDINATE_QUANTIZATION_ERROR_PIXELS ||
-        bank.coordinateEncoding !==
-          "leaf-major-axis-split-signed-zigzag-varint-second-difference-decimal1" ||
-        bank.opacityEncoding !== CSSBLACKHOLE_OPACITY_ENCODING ||
+        (railTransport ?
+          (bank.schema !== CSSBLACKHOLE_REPAIR_BANK_SCHEMA ||
+            !Array.isArray(bank.requiredSourceConfigurationIndices) ||
+            bank.requiredSourceConfigurationIndices.length < 1 ||
+            bank.requiredSourceConfigurationIndices.some((configurationIndex, index, values) =>
+              !Number.isSafeInteger(configurationIndex) || configurationIndex < 0 ||
+              configurationIndex >= catalog.configurationCount ||
+              (index > 0 && configurationIndex <= values[index - 1])) ||
+            !Number.isSafeInteger(bank.preparedCollisionRepairCount) ||
+            bank.preparedCollisionRepairCount < 1 ||
+            bank.preparedCollisionRepairCount > bank.sourceSampleCount ||
+            bank.coordinateEncoding !==
+              "prepared-source-rail-lookup-plus-sparse-prepared-collision-repair" ||
+            bank.opacityEncoding !==
+              "prepared-source-rail-rgb8-to-nearest-decile-materialization" ||
+            bank.visibleSampleCount !== undefined || bank.opacityAssignmentCount !== undefined ||
+            bank.sourceLuminanceSampleCount !== undefined) :
+          (!Number.isSafeInteger(bank.visibleSampleCount) || bank.visibleSampleCount < 1 ||
+            bank.visibleSampleCount > bank.sourceSampleCount ||
+            !Number.isSafeInteger(bank.opacityAssignmentCount) ||
+            bank.opacityAssignmentCount < catalog.blocksPerBank * catalog.starCount ||
+            bank.opacityAssignmentCount > 0xffff ||
+            bank.opacityAssignmentCount > bank.sourceSampleCount ||
+            bank.sourceLuminanceSampleCount !== bank.sourceSampleCount ||
+            bank.coordinateEncoding !==
+              "leaf-major-axis-split-signed-zigzag-varint-second-difference-decimal1" ||
+            bank.opacityEncoding !== CSSBLACKHOLE_OPACITY_ENCODING)) ||
         !/^[a-f0-9]{64}$/u.test(bank.sha256 ?? "") ||
         !/^[a-f0-9]{64}$/u.test(bank.decodedSha256 ?? "") ||
         typeof bank.assetUrl !== "string" ||
@@ -692,6 +790,34 @@ function validateTransport(catalog) {
       throw new Error(`BlackHole transport bank ${bankIndex} drifted`);
     }
   }
+}
+
+function validSourceRails(descriptors, catalog) {
+  return Array.isArray(descriptors) && descriptors.length === catalog.configurationCount &&
+    descriptors.every((descriptor, configurationIndex) =>
+      validSourceRail(descriptor, catalog, configurationIndex));
+}
+
+function validSourceRail(descriptor, catalog, configurationIndex) {
+  return descriptor?.schema === CSSBLACKHOLE_RAIL_ASSET_SCHEMA &&
+    descriptor.configurationIndex === configurationIndex &&
+    typeof descriptor.assetUrl === "string" &&
+    descriptor.assetUrl.startsWith(`${catalog.assetRoot}/rails/`) &&
+    new RegExp(`^rails-${configurationIndex}-[a-f0-9]{64}\\.bin\\.br$`, "u")
+      .test(descriptor.assetUrl.split("/").at(-1)) &&
+    Number.isSafeInteger(descriptor.byteLength) && descriptor.byteLength > 0 &&
+    Number.isSafeInteger(descriptor.decodedByteLength) &&
+    descriptor.decodedByteLength > descriptor.byteLength &&
+    /^[a-f0-9]{64}$/u.test(descriptor.sha256 ?? "") &&
+    /^[a-f0-9]{64}$/u.test(descriptor.decodedSha256 ?? "") &&
+    descriptor.contentEncoding === "br" && descriptor.imageOrderCount === 2 &&
+    descriptor.radiusCount === 16 && descriptor.sourceFrameCount === 5_400 &&
+    descriptor.coordinateEncoding ===
+      "configuration-order-radius-phase-xy-u16le-decimal1" &&
+    descriptor.luminanceEncoding === "configuration-order-radius-phase-u8-rgb8" &&
+    descriptor.selectedParticleDescriptorEncoding === "u32-phase13-radius4-order1" &&
+    descriptor.transitionEasingEncoding === "prepared-f64le-smoothstep-120-samples" &&
+    descriptor.periodicOrbitCountEncoding === "radius-major-u8";
 }
 
 function validPreparedOpacityPalette(palette) {
@@ -891,14 +1017,18 @@ async function fetchVerifiedBytes(url, expectedLength, expectedSha256, label, ca
 }
 
 async function fetchHttpExpandedBank(descriptor) {
+  return fetchHttpExpandedAsset(descriptor, `bank ${descriptor.index}`);
+}
+
+async function fetchHttpExpandedAsset(descriptor, label) {
   const response = await fetch(descriptor.assetUrl, { cache: "force-cache" });
   if (!response.ok) {
     throw new Error(
-      `BlackHole bank ${descriptor.index} failed: ${response.status} ${descriptor.assetUrl}`);
+      `BlackHole ${label} failed: ${response.status} ${descriptor.assetUrl}`);
   }
   const bytes = new Uint8Array(await response.arrayBuffer());
   await verifyByteIdentity(bytes, descriptor.decodedByteLength, descriptor.decodedSha256,
-    `bank ${descriptor.index} HTTP expansion`);
+    `${label} HTTP expansion`);
   return bytes;
 }
 

--- a/src/adapters/blackhole/src/shared/cssblackhole/preparedRailTransport.mjs
+++ b/src/adapters/blackhole/src/shared/cssblackhole/preparedRailTransport.mjs
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: MIT
+
+export const CSSBLACKHOLE_RAIL_ENCODING =
+  "http-brotli-luminet-source-rails-plus-prepared-sparse-collision-repairs@1";
+export const CSSBLACKHOLE_RAIL_ASSET_SCHEMA = "cssblackhole-prepared-source-rails@1";
+export const CSSBLACKHOLE_REPAIR_BANK_SCHEMA = "cssblackhole-prepared-repair-bank@1";
+
+const RAIL_MAGIC = "CSBLKHR1";
+const RAIL_VERSION = 1;
+const RAIL_HEADER_BYTE_LENGTH = 96;
+const REPAIR_MAGIC = "CSBLKHRP";
+const REPAIR_VERSION = 1;
+const REPAIR_HEADER_BYTE_LENGTH = 64;
+const COORDINATE_SCALE = 10;
+const DESCRIPTOR_PHASE_BITS = 13;
+const DESCRIPTOR_PHASE_MASK = (1 << DESCRIPTOR_PHASE_BITS) - 1;
+const DESCRIPTOR_RADIUS_SHIFT = DESCRIPTOR_PHASE_BITS;
+const DESCRIPTOR_ORDER_SHIFT = 17;
+const REPAIR_LEAF_BITS = 11;
+const REPAIR_LEAF_MASK = (1 << REPAIR_LEAF_BITS) - 1;
+const REPAIR_DIRECTION_SHIFT = REPAIR_LEAF_BITS;
+const REPAIR_RADIUS_SHIFT = 14;
+const REPAIR_DIRECTIONS = Object.freeze([
+  Object.freeze([1, 0]),
+  Object.freeze([-1, 0]),
+  Object.freeze([0, 1]),
+  Object.freeze([0, -1]),
+  Object.freeze([1, 1]),
+  Object.freeze([-1, 1]),
+  Object.freeze([1, -1]),
+  Object.freeze([-1, -1]),
+]);
+
+export function encodeBlackHolePreparedRailAsset({
+  transportSeed,
+  starCount,
+  configurationCount,
+  sourceConfigurationIndex,
+  imageOrderCount,
+  radiusCount,
+  sourceFrameCount,
+  transitionFrameCount,
+  railCoordinates,
+  railLuminances,
+  particleOrders,
+  particleRadiusIndices,
+  particlePhaseFrameIndices,
+  particlePeriodicOrbitCounts,
+  selectedSourcePointIndices,
+  periodicOrbitCounts,
+}) {
+  const railSampleCount = imageOrderCount * radiusCount * sourceFrameCount;
+  if (!Number.isSafeInteger(transportSeed) || transportSeed < 1 ||
+      !Number.isSafeInteger(starCount) || starCount < 1 || starCount > REPAIR_LEAF_MASK ||
+      configurationCount !== 3 || !Number.isSafeInteger(sourceConfigurationIndex) ||
+      sourceConfigurationIndex < 0 || sourceConfigurationIndex >= configurationCount ||
+      imageOrderCount !== 2 || radiusCount !== 16 ||
+      sourceFrameCount !== 5_400 || transitionFrameCount !== 120 ||
+      !(railCoordinates instanceof Uint16Array) ||
+      railCoordinates.length !== railSampleCount * 2 ||
+      !(railLuminances instanceof Uint8Array) || railLuminances.length !== railSampleCount ||
+      !Array.isArray(particleOrders) || !Array.isArray(particleRadiusIndices) ||
+      !Array.isArray(particlePhaseFrameIndices) || !Array.isArray(particlePeriodicOrbitCounts) ||
+      particleOrders.length !== 3_000 || particleRadiusIndices.length !== 3_000 ||
+      particlePhaseFrameIndices.length !== 3_000 || particlePeriodicOrbitCounts.length !== 3_000 ||
+      !Array.isArray(selectedSourcePointIndices) || selectedSourcePointIndices.length !== starCount ||
+      !Array.isArray(periodicOrbitCounts) || periodicOrbitCounts.length !== radiusCount) {
+    throw new TypeError("Complete prepared Luminet rail values are required");
+  }
+  const coordinateByteLength = railCoordinates.byteLength;
+  const luminanceByteLength = railLuminances.byteLength;
+  const descriptorByteLength = starCount * Uint32Array.BYTES_PER_ELEMENT;
+  const easingByteLength = transitionFrameCount * Float64Array.BYTES_PER_ELEMENT;
+  const orbitCountByteLength = radiusCount;
+  const coordinateOffset = RAIL_HEADER_BYTE_LENGTH;
+  const luminanceOffset = coordinateOffset + coordinateByteLength;
+  const descriptorOffset = align(luminanceOffset + luminanceByteLength, 4);
+  const easingOffset = align(descriptorOffset + descriptorByteLength, 8);
+  const orbitCountOffset = easingOffset + easingByteLength;
+  const bytes = new Uint8Array(orbitCountOffset + orbitCountByteLength);
+  const view = new DataView(bytes.buffer);
+  writeMagic(bytes, RAIL_MAGIC);
+  view.setUint16(8, RAIL_HEADER_BYTE_LENGTH, true);
+  view.setUint16(10, RAIL_VERSION, true);
+  view.setUint32(12, transportSeed, true);
+  view.setUint16(16, starCount, true);
+  view.setUint8(18, configurationCount);
+  view.setUint8(19, imageOrderCount);
+  view.setUint16(20, radiusCount, true);
+  view.setUint16(22, sourceFrameCount, true);
+  view.setUint16(24, transitionFrameCount, true);
+  view.setUint16(26, COORDINATE_SCALE, true);
+  view.setUint32(28, coordinateOffset, true);
+  view.setUint32(32, coordinateByteLength, true);
+  view.setUint32(36, luminanceOffset, true);
+  view.setUint32(40, luminanceByteLength, true);
+  view.setUint32(44, descriptorOffset, true);
+  view.setUint32(48, descriptorByteLength, true);
+  view.setUint32(52, easingOffset, true);
+  view.setUint32(56, easingByteLength, true);
+  view.setUint32(60, orbitCountOffset, true);
+  view.setUint32(64, orbitCountByteLength, true);
+  view.setUint8(68, sourceConfigurationIndex);
+  view.setUint8(69, 1);
+  bytes.set(new Uint8Array(
+    railCoordinates.buffer, railCoordinates.byteOffset, railCoordinates.byteLength), coordinateOffset);
+  bytes.set(railLuminances, luminanceOffset);
+  for (let leafIndex = 0; leafIndex < starCount; leafIndex += 1) {
+    const sourceIndex = selectedSourcePointIndices[leafIndex];
+    const order = particleOrders[sourceIndex];
+    const radiusIndex = particleRadiusIndices[sourceIndex];
+    const phaseFrameIndex = particlePhaseFrameIndices[sourceIndex];
+    const turns = particlePeriodicOrbitCounts[sourceIndex];
+    if (!Number.isSafeInteger(sourceIndex) || sourceIndex < 0 || sourceIndex >= 3_000 ||
+        !Number.isSafeInteger(order) || order < 0 || order >= imageOrderCount ||
+        !Number.isSafeInteger(radiusIndex) || radiusIndex < 0 || radiusIndex >= radiusCount ||
+        !Number.isSafeInteger(phaseFrameIndex) || phaseFrameIndex < 0 ||
+        phaseFrameIndex >= sourceFrameCount || turns !== periodicOrbitCounts[radiusIndex]) {
+      throw new Error(`Luminet selected rail descriptor ${leafIndex} drifted`);
+    }
+    const packed = phaseFrameIndex | radiusIndex << DESCRIPTOR_RADIUS_SHIFT |
+      order << DESCRIPTOR_ORDER_SHIFT;
+    view.setUint32(descriptorOffset + leafIndex * 4, packed, true);
+  }
+  for (let transitionIndex = 0; transitionIndex < transitionFrameCount; transitionIndex += 1) {
+    const progress = (transitionIndex + 1) / transitionFrameCount;
+    view.setFloat64(
+      easingOffset + transitionIndex * 8,
+      progress * progress * (3 - 2 * progress),
+      true,
+    );
+  }
+  for (let radiusIndex = 0; radiusIndex < radiusCount; radiusIndex += 1) {
+    const turns = periodicOrbitCounts[radiusIndex];
+    if (!Number.isSafeInteger(turns) || turns < 1 || turns > 0xff) {
+      throw new Error(`Luminet periodic orbit ${radiusIndex} drifted`);
+    }
+    bytes[orbitCountOffset + radiusIndex] = turns;
+  }
+  return bytes;
+}
+
+export function readBlackHolePreparedRailAsset(bytes, descriptor, catalog) {
+  const source = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  if (source.byteLength < RAIL_HEADER_BYTE_LENGTH || readMagic(source) !== RAIL_MAGIC) {
+    throw new Error("BlackHole source rail binary header drifted");
+  }
+  const view = new DataView(source.buffer, source.byteOffset, source.byteLength);
+  const coordinateOffset = view.getUint32(28, true);
+  const coordinateByteLength = view.getUint32(32, true);
+  const luminanceOffset = view.getUint32(36, true);
+  const luminanceByteLength = view.getUint32(40, true);
+  const descriptorOffset = view.getUint32(44, true);
+  const descriptorByteLength = view.getUint32(48, true);
+  const easingOffset = view.getUint32(52, true);
+  const easingByteLength = view.getUint32(56, true);
+  const orbitCountOffset = view.getUint32(60, true);
+  const orbitCountByteLength = view.getUint32(64, true);
+  const railSampleCount = descriptor.imageOrderCount * descriptor.radiusCount *
+    descriptor.sourceFrameCount;
+  if (view.getUint16(8, true) !== RAIL_HEADER_BYTE_LENGTH ||
+      view.getUint16(10, true) !== RAIL_VERSION ||
+      view.getUint32(12, true) !== catalog.transportSeed ||
+      view.getUint16(16, true) !== catalog.starCount ||
+      view.getUint8(18) !== catalog.configurationCount ||
+      view.getUint8(19) !== descriptor.imageOrderCount ||
+      view.getUint16(20, true) !== descriptor.radiusCount ||
+      view.getUint16(22, true) !== descriptor.sourceFrameCount ||
+      view.getUint16(24, true) !== catalog.configurationLoop.transitionFrameCount ||
+      view.getUint16(26, true) !== COORDINATE_SCALE ||
+      view.getUint8(68) !== descriptor.configurationIndex || view.getUint8(69) !== 1 ||
+      coordinateOffset !== RAIL_HEADER_BYTE_LENGTH ||
+      coordinateByteLength !== railSampleCount * 2 * Uint16Array.BYTES_PER_ELEMENT ||
+      luminanceOffset !== coordinateOffset + coordinateByteLength ||
+      luminanceByteLength !== railSampleCount ||
+      descriptorOffset !== align(luminanceOffset + luminanceByteLength, 4) ||
+      descriptorByteLength !== catalog.starCount * Uint32Array.BYTES_PER_ELEMENT ||
+      easingOffset !== align(descriptorOffset + descriptorByteLength, 8) ||
+      easingByteLength !== catalog.configurationLoop.transitionFrameCount *
+        Float64Array.BYTES_PER_ELEMENT ||
+      orbitCountOffset !== easingOffset + easingByteLength ||
+      orbitCountByteLength !== descriptor.radiusCount ||
+      orbitCountOffset + orbitCountByteLength !== source.byteLength ||
+      descriptor.decodedByteLength !== source.byteLength) {
+    throw new Error("BlackHole source rail binary contract drifted");
+  }
+  return Object.freeze({
+    bytes: source,
+    imageOrderCount: descriptor.imageOrderCount,
+    radiusCount: descriptor.radiusCount,
+    sourceFrameCount: descriptor.sourceFrameCount,
+    sourceConfigurationIndex: descriptor.configurationIndex,
+    coordinates: new Uint16Array(
+      source.buffer, source.byteOffset + coordinateOffset, coordinateByteLength / 2),
+    luminances: source.subarray(luminanceOffset, luminanceOffset + luminanceByteLength),
+    descriptors: new Uint32Array(
+      source.buffer, source.byteOffset + descriptorOffset, descriptorByteLength / 4),
+    easing: new Float64Array(
+      source.buffer, source.byteOffset + easingOffset, easingByteLength / 8),
+    periodicOrbitCounts: source.subarray(
+      orbitCountOffset, orbitCountOffset + orbitCountByteLength),
+  });
+}
+
+export function encodeBlackHolePreparedRepairBank({
+  transportSeed,
+  starCount,
+  bankIndex,
+  startFrameIndex,
+  frameCount,
+  blockFrameCount,
+  rawCoordinates,
+  repairedCoordinates,
+}) {
+  if (!Number.isSafeInteger(transportSeed) || transportSeed < 1 ||
+      !Number.isSafeInteger(starCount) || starCount < 1 || starCount > REPAIR_LEAF_MASK ||
+      !Number.isSafeInteger(bankIndex) || bankIndex < 0 || bankIndex > 0xffff ||
+      !Number.isSafeInteger(startFrameIndex) || startFrameIndex < 0 ||
+      !Number.isSafeInteger(frameCount) || frameCount < 1 || frameCount > 0xffff ||
+      !Number.isSafeInteger(blockFrameCount) || blockFrameCount < 1 ||
+      frameCount % blockFrameCount !== 0 ||
+      !(rawCoordinates instanceof Int32Array) || !(repairedCoordinates instanceof Int32Array) ||
+      rawCoordinates.length !== frameCount * starCount * 2 ||
+      repairedCoordinates.length !== rawCoordinates.length) {
+    throw new TypeError("Complete prepared Luminet repair-bank values are required");
+  }
+  const frameOffsets = new Uint16Array(frameCount + 1);
+  const entries = [];
+  for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
+    for (let leafIndex = 0; leafIndex < starCount; leafIndex += 1) {
+      const coordinateOffset = (frameIndex * starCount + leafIndex) * 2;
+      const deltaX = repairedCoordinates[coordinateOffset] - rawCoordinates[coordinateOffset];
+      const deltaY = repairedCoordinates[coordinateOffset + 1] - rawCoordinates[coordinateOffset + 1];
+      if (deltaX === 0 && deltaY === 0) continue;
+      entries.push(packRepair(leafIndex, deltaX, deltaY));
+    }
+    if (entries.length > 0xffff) {
+      throw new RangeError("Luminet repair bank exceeded uint16 frame offsets");
+    }
+    frameOffsets[frameIndex + 1] = entries.length;
+  }
+  const frameOffsetByteLength = frameOffsets.byteLength;
+  const entryByteLength = entries.length * Uint32Array.BYTES_PER_ELEMENT;
+  const frameOffsetOffset = REPAIR_HEADER_BYTE_LENGTH;
+  const entryOffset = align(frameOffsetOffset + frameOffsetByteLength, 4);
+  const bytes = new Uint8Array(entryOffset + entryByteLength);
+  const view = new DataView(bytes.buffer);
+  writeMagic(bytes, REPAIR_MAGIC);
+  view.setUint16(8, REPAIR_HEADER_BYTE_LENGTH, true);
+  view.setUint16(10, REPAIR_VERSION, true);
+  view.setUint32(12, transportSeed, true);
+  view.setUint16(16, starCount, true);
+  view.setUint16(18, bankIndex, true);
+  view.setUint32(20, startFrameIndex, true);
+  view.setUint16(24, frameCount, true);
+  view.setUint16(26, blockFrameCount, true);
+  view.setUint32(28, entries.length, true);
+  view.setUint32(32, frameOffsetOffset, true);
+  view.setUint32(36, frameOffsetByteLength, true);
+  view.setUint32(40, entryOffset, true);
+  view.setUint32(44, entryByteLength, true);
+  view.setUint16(48, COORDINATE_SCALE, true);
+  for (let index = 0; index < frameOffsets.length; index += 1) {
+    view.setUint16(frameOffsetOffset + index * 2, frameOffsets[index], true);
+  }
+  for (let index = 0; index < entries.length; index += 1) {
+    view.setUint32(entryOffset + index * 4, entries[index], true);
+  }
+  return bytes;
+}
+
+export function readBlackHolePreparedRepairBank(bytes, descriptor, catalog) {
+  const source = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  if (source.byteLength < REPAIR_HEADER_BYTE_LENGTH || readMagic(source) !== REPAIR_MAGIC) {
+    throw new Error(`BlackHole repair bank ${descriptor?.index ?? "unknown"} header drifted`);
+  }
+  const view = new DataView(source.buffer, source.byteOffset, source.byteLength);
+  const repairCount = view.getUint32(28, true);
+  const frameOffsetOffset = view.getUint32(32, true);
+  const frameOffsetByteLength = view.getUint32(36, true);
+  const entryOffset = view.getUint32(40, true);
+  const entryByteLength = view.getUint32(44, true);
+  if (view.getUint16(8, true) !== REPAIR_HEADER_BYTE_LENGTH ||
+      view.getUint16(10, true) !== REPAIR_VERSION ||
+      view.getUint32(12, true) !== catalog.transportSeed ||
+      view.getUint16(16, true) !== catalog.starCount ||
+      view.getUint16(18, true) !== descriptor.index ||
+      view.getUint32(20, true) !== descriptor.startFrameIndex ||
+      view.getUint16(24, true) !== descriptor.frameCount ||
+      view.getUint16(26, true) !== catalog.blockFrameCount ||
+      repairCount !== descriptor.preparedCollisionRepairCount ||
+      frameOffsetOffset !== REPAIR_HEADER_BYTE_LENGTH ||
+      frameOffsetByteLength !== (descriptor.frameCount + 1) * 2 ||
+      entryOffset !== align(frameOffsetOffset + frameOffsetByteLength, 4) ||
+      entryByteLength !== repairCount * 4 || entryOffset + entryByteLength !== source.byteLength ||
+      view.getUint16(48, true) !== COORDINATE_SCALE ||
+      descriptor.decodedByteLength !== source.byteLength) {
+    throw new Error(`BlackHole repair bank ${descriptor.index} contract drifted`);
+  }
+  const frameOffsets = new Uint16Array(descriptor.frameCount + 1);
+  for (let index = 0; index < frameOffsets.length; index += 1) {
+    frameOffsets[index] = view.getUint16(frameOffsetOffset + index * 2, true);
+  }
+  const packedRepairs = new Uint32Array(repairCount);
+  for (let index = 0; index < repairCount; index += 1) {
+    packedRepairs[index] = view.getUint32(entryOffset + index * 4, true);
+  }
+  if (frameOffsets[0] !== 0 || frameOffsets.at(-1) !== repairCount) {
+    throw new Error(`BlackHole repair bank ${descriptor.index} offsets drifted`);
+  }
+  return Object.freeze({ frameOffsets, packedRepairs });
+}
+
+export function unpackBlackHolePreparedRailDescriptor(packed) {
+  return Object.freeze({
+    phaseFrameIndex: packed & DESCRIPTOR_PHASE_MASK,
+    radiusIndex: packed >> DESCRIPTOR_RADIUS_SHIFT & 0xf,
+    order: packed >> DESCRIPTOR_ORDER_SHIFT & 0x1,
+  });
+}
+
+export function unpackBlackHolePreparedRepair(packed) {
+  const radius = (packed >> REPAIR_RADIUS_SHIFT & 0x7) + 1;
+  const direction = REPAIR_DIRECTIONS[packed >> REPAIR_DIRECTION_SHIFT & 0x7];
+  return Object.freeze({
+    leafIndex: packed & REPAIR_LEAF_MASK,
+    deltaX: direction[0] * COORDINATE_SCALE * radius,
+    deltaY: direction[1] * COORDINATE_SCALE * radius,
+  });
+}
+
+function packRepair(leafIndex, deltaX, deltaY) {
+  if (deltaX % COORDINATE_SCALE !== 0 || deltaY % COORDINATE_SCALE !== 0) {
+    throw new Error("Luminet prepared repair lost tenth-pixel grid alignment");
+  }
+  const unitX = deltaX / COORDINATE_SCALE;
+  const unitY = deltaY / COORDINATE_SCALE;
+  const radius = Math.max(Math.abs(unitX), Math.abs(unitY));
+  const directionX = Math.sign(unitX);
+  const directionY = Math.sign(unitY);
+  const directionIndex = REPAIR_DIRECTIONS.findIndex(
+    ([candidateX, candidateY]) => candidateX === directionX && candidateY === directionY);
+  if (leafIndex < 0 || leafIndex > REPAIR_LEAF_MASK || radius < 1 || radius > 8 ||
+      directionIndex < 0 ||
+      (directionX !== 0 && Math.abs(unitX) !== radius) ||
+      (directionY !== 0 && Math.abs(unitY) !== radius)) {
+    throw new Error(`Luminet prepared repair for leaf ${leafIndex} drifted`);
+  }
+  return leafIndex | directionIndex << REPAIR_DIRECTION_SHIFT |
+    (radius - 1) << REPAIR_RADIUS_SHIFT;
+}
+
+function writeMagic(bytes, magic) {
+  for (let index = 0; index < magic.length; index += 1) bytes[index] = magic.charCodeAt(index);
+}
+
+function readMagic(bytes) {
+  return String.fromCharCode(...bytes.subarray(0, 8));
+}
+
+function align(value, alignment) {
+  return Math.ceil(value / alignment) * alignment;
+}

--- a/src/adapters/blackhole/test/cssblackhole-assets.test.mjs
+++ b/src/adapters/blackhole/test/cssblackhole-assets.test.mjs
@@ -8,11 +8,15 @@ import { brotliDecompressSync } from "node:zlib";
 import sharp from "sharp";
 import sourceLock from "../notes/references/source-lock.json" with { type: "json" };
 import {
-  CSSBLACKHOLE_OPACITY_ENCODING,
   CSSBLACKHOLE_OPACITY_PALETTE,
-  decodeBlackHolePreparedBank,
   quantizeBlackHolePreparedOpacityIndex,
 } from "../src/shared/cssblackhole/preparedBlockTransport.mjs";
+import {
+  CSSBLACKHOLE_RAIL_ENCODING,
+  readBlackHolePreparedRailAsset,
+  readBlackHolePreparedRepairBank,
+  unpackBlackHolePreparedRailDescriptor,
+} from "../src/shared/cssblackhole/preparedRailTransport.mjs";
 import { selectNonOverlappingLuminetPointFrames } from
   "../tools/select-luminet-points.mjs";
 
@@ -56,6 +60,19 @@ test("Luminet adapter owns a standalone prepared cssblackhole contract", async (
   assert.equal(catalog.bankFrameCount, 300);
   assert.equal(catalog.bankCount, 36);
   assert.equal(catalog.blockCount, 180);
+  assert.equal(catalog.transport.encoding, CSSBLACKHOLE_RAIL_ENCODING);
+  assert.equal(catalog.transport.runtimeSourcePhysics, false);
+  assert.equal(catalog.transport.runtimeCollisionSearch, false);
+  assert.equal(catalog.transport.workerRailLookupMaterialization, true);
+  assert.deepEqual(catalog.sourceRails.map(({ configurationIndex, byteLength }) =>
+    ({ configurationIndex, byteLength })), [
+    { configurationIndex: 0, byteLength: 189_802 },
+    { configurationIndex: 1, byteLength: 218_798 },
+    { configurationIndex: 2, byteLength: 230_258 },
+  ]);
+  assert.equal(catalog.banks.reduce((sum, bank) => sum + bank.byteLength, 0), 121_741);
+  assert.equal(catalog.banks.reduce(
+    (sum, bank) => sum + bank.preparedCollisionRepairCount, 0), 303_464);
   assert.deepEqual(catalog.materialization, {
     schema: "cssblackhole-bounded-materialized-block@1",
     policy: "galaxy-style-multiple-playback-blocks-per-transport-bank",
@@ -333,12 +350,28 @@ test("prepared transport reproduces the pinned moving coordinate and flux state"
   assert.deepEqual(catalog.banks.map(({ sourceLoopStartFrameIndex }) => sourceLoopStartFrameIndex),
     Array.from({ length: 36 }, (_, index) => index * 300));
   const descriptor = catalog.banks[0];
-  assert.equal(descriptor.opacityEncoding, CSSBLACKHOLE_OPACITY_ENCODING);
-  const expanded = brotliDecompressSync(await readFile(resolve(
-    generatedRoot, "banks", descriptor.assetUrl.split("/").at(-1))));
-  const bank = decodeBlackHolePreparedBank(expanded, descriptor, catalog);
-  const firstBlock = bank.decodedBlocks[0].coordinates;
-  const firstBlockBytes = Buffer.from(firstBlock.buffer, firstBlock.byteOffset, firstBlock.byteLength);
+  assert.equal(descriptor.opacityEncoding,
+    "prepared-source-rail-rgb8-to-nearest-decile-materialization");
+  const [expanded, ...expandedRailAssets] = await Promise.all([
+    brotliDecompressSync(await readFile(resolve(
+      generatedRoot, "banks", descriptor.assetUrl.split("/").at(-1)))),
+    ...catalog.sourceRails.map(async (railDescriptor) => brotliDecompressSync(await readFile(resolve(
+      generatedRoot, "rails", railDescriptor.assetUrl.split("/").at(-1))))),
+  ]);
+  const repairBank = readBlackHolePreparedRepairBank(expanded, descriptor, catalog);
+  const rails = expandedRailAssets.map((bytes, configurationIndex) =>
+    readBlackHolePreparedRailAsset(bytes, catalog.sourceRails[configurationIndex], catalog));
+  const firstBlock = reconstructRailBlock(catalog, rails, repairBank, 0, 0);
+  assert.equal(repairBank.frameOffsets.at(-1), descriptor.preparedCollisionRepairCount);
+  for (let configurationIndex = 0; configurationIndex < rails.length; configurationIndex += 1) {
+    assert.equal(sha256(expandedRailAssets[configurationIndex]),
+      catalog.sourceRails[configurationIndex].decodedSha256);
+  }
+  assert.equal(sha256(expanded), descriptor.decodedSha256);
+  const firstBlockBytes = Buffer.from(
+    firstBlock.coordinates.buffer,
+    firstBlock.coordinates.byteOffset,
+    firstBlock.coordinates.byteLength);
   const preparedFirstBlockBytes = Buffer.from(
     preparedSelection.selectedCoordinates.buffer,
     preparedSelection.selectedCoordinates.byteOffset,
@@ -347,7 +380,7 @@ test("prepared transport reproduces the pinned moving coordinate and flux state"
 
   const reconstructed = Buffer.alloc(catalog.blockFrameCount * catalog.starCount);
   const current = new Uint8Array(catalog.starCount);
-  const opacity = bank.decodedBlocks[0].opacitySchedule;
+  const opacity = firstBlock.opacitySchedule;
   for (let frameIndex = 0; frameIndex < catalog.blockFrameCount; frameIndex += 1) {
     for (let assignmentIndex = opacity.frameOffsets[frameIndex];
       assignmentIndex < opacity.frameOffsets[frameIndex + 1]; assignmentIndex += 1) {
@@ -362,6 +395,40 @@ test("prepared transport reproduces the pinned moving coordinate and flux state"
     selectedSourceLuminances, quantizeBlackHolePreparedOpacityIndex);
   assert.equal(sha256(reconstructed), sha256(expectedOpacityIndices));
   assert.ok(reconstructed.every((opacityIndex) => opacityIndex < 11));
+  for (const blockIndex of [5, 11, 12, 15, 19, 35, 179]) {
+    const bankIndex = Math.floor(blockIndex / catalog.blocksPerBank);
+    const bankBlockIndex = blockIndex % catalog.blocksPerBank;
+    const bankDescriptor = catalog.banks[bankIndex];
+    const repairBytes = brotliDecompressSync(await readFile(resolve(
+      generatedRoot, "banks", bankDescriptor.assetUrl.split("/").at(-1))));
+    const preparedRepairBank = readBlackHolePreparedRepairBank(
+      repairBytes, bankDescriptor, catalog);
+    const block = reconstructRailBlock(
+      catalog, rails, preparedRepairBank, blockIndex, bankBlockIndex);
+    const expectedCoordinateStart = blockIndex * catalog.blockFrameCount * catalog.starCount * 2;
+    const expectedCoordinateEnd = expectedCoordinateStart +
+      catalog.blockFrameCount * catalog.starCount * 2;
+    const expectedCoordinateBytes = Buffer.from(
+      preparedSelection.selectedCoordinates.buffer,
+      preparedSelection.selectedCoordinates.byteOffset + expectedCoordinateStart * 4,
+      (expectedCoordinateEnd - expectedCoordinateStart) * 4);
+    assert.equal(sha256(Buffer.from(block.coordinates.buffer)), sha256(expectedCoordinateBytes),
+      `rail coordinates diverged in block ${blockIndex}`);
+    const expandedOpacity = expandOpacitySchedule(
+      block.opacitySchedule, catalog.blockFrameCount, catalog.starCount);
+    const expectedLuminances = selectSourcePointFrames(
+      sourceLuminances,
+      blockIndex * catalog.blockFrameCount,
+      catalog.blockFrameCount,
+      catalog.pointSelection.sourcePointCount,
+      1,
+      catalog.pointSelection.sourcePointIndices,
+      catalog.publication.sourceFrameStep,
+    );
+    assert.equal(sha256(expandedOpacity), sha256(Uint8Array.from(
+      expectedLuminances, quantizeBlackHolePreparedOpacityIndex)),
+    `rail opacity diverged in block ${blockIndex}`);
+  }
   assert.ok(sourceLuminances.reduce((minimum, value) => Math.min(minimum, value), 255) >=
     Math.floor(0.22 * 255));
   const coordinateFrameBytes = catalog.pointSelection.sourcePointCount * 2 * 4;
@@ -433,4 +500,114 @@ function selectSourcePointFrames(
     }
   }
   return selected;
+}
+
+function reconstructRailBlock(catalog, rails, repairBank, blockIndex, bankBlockIndex) {
+  const identity = rails[0];
+  const coordinates = new Int32Array(catalog.blockFrameCount * catalog.starCount * 2);
+  const opacityValues = new Uint8Array(catalog.blockFrameCount * catalog.starCount);
+  const descriptors = Array.from(
+    identity.descriptors, unpackBlackHolePreparedRailDescriptor);
+  const repairDirections = [
+    [1, 0], [-1, 0], [0, 1], [0, -1],
+    [1, 1], [-1, 1], [1, -1], [-1, -1],
+  ];
+  for (let localFrameIndex = 0; localFrameIndex < catalog.blockFrameCount; localFrameIndex += 1) {
+    const globalFrameIndex = blockIndex * catalog.blockFrameCount + localFrameIndex;
+    const sequenceFrameIndex = globalFrameIndex %
+      catalog.configurationLoop.presentationSequenceFrameCount;
+    const presentationIndex = catalog.configurationLoop.presentationSlots.findIndex((slot) =>
+      sequenceFrameIndex >= slot.startFrameIndex &&
+      sequenceFrameIndex < slot.startFrameIndex + slot.frameCount);
+    const slot = catalog.configurationLoop.presentationSlots[presentationIndex];
+    const slotFrameIndex = sequenceFrameIndex - slot.startFrameIndex;
+    const transitionIndex = slotFrameIndex - slot.transitionStartFrameIndex;
+    const transitioning = transitionIndex >= 0;
+    const nextSlot = catalog.configurationLoop.presentationSlots[
+      (presentationIndex + 1) % catalog.configurationLoop.presentationSlots.length];
+    const eased = transitioning ? identity.easing[transitionIndex] : 0;
+    const repairFrameIndex = bankBlockIndex * catalog.blockFrameCount + localFrameIndex;
+    let repairIndex = repairBank.frameOffsets[repairFrameIndex];
+    const repairEnd = repairBank.frameOffsets[repairFrameIndex + 1];
+    for (let leafIndex = 0; leafIndex < catalog.starCount; leafIndex += 1) {
+      const particle = descriptors[leafIndex];
+      const sourceFrameIndex = globalFrameIndex % identity.sourceFrameCount;
+      const phaseFrameIndex = (particle.phaseFrameIndex +
+        identity.periodicOrbitCounts[particle.radiusIndex] * sourceFrameIndex) %
+        identity.sourceFrameCount;
+      const currentRails = rails[slot.stateIndex];
+      const currentIndex = railIndex(identity, particle, phaseFrameIndex);
+      let x = currentRails.coordinates[currentIndex * 2];
+      let y = currentRails.coordinates[currentIndex * 2 + 1];
+      let luminance = currentRails.luminances[currentIndex];
+      if (transitioning) {
+        const nextRails = rails[nextSlot.stateIndex];
+        const nextIndex = railIndex(identity, particle, phaseFrameIndex);
+        x = roundTiesToEven(x * (1 - eased) + nextRails.coordinates[nextIndex * 2] * eased);
+        y = roundTiesToEven(y * (1 - eased) + nextRails.coordinates[nextIndex * 2 + 1] * eased);
+        luminance = roundTiesToEven(
+          luminance * (1 - eased) + nextRails.luminances[nextIndex] * eased);
+      }
+      if (repairIndex < repairEnd && (repairBank.packedRepairs[repairIndex] & 0x7ff) === leafIndex) {
+        const repair = repairBank.packedRepairs[repairIndex];
+        const direction = repairDirections[repair >> 11 & 0x7];
+        const radius = (repair >> 14 & 0x7) + 1;
+        x += direction[0] * radius * 10;
+        y += direction[1] * radius * 10;
+        repairIndex += 1;
+      }
+      const sampleIndex = localFrameIndex * catalog.starCount + leafIndex;
+      coordinates[sampleIndex * 2] = x;
+      coordinates[sampleIndex * 2 + 1] = y;
+      opacityValues[sampleIndex] = quantizeBlackHolePreparedOpacityIndex(luminance);
+    }
+    assert.equal(repairIndex, repairEnd);
+  }
+  const frameOffsets = new Uint32Array(catalog.blockFrameCount + 1);
+  const leafIndices = [];
+  const opacityIndices = [];
+  for (let frameIndex = 0; frameIndex < catalog.blockFrameCount; frameIndex += 1) {
+    for (let leafIndex = 0; leafIndex < catalog.starCount; leafIndex += 1) {
+      const sampleIndex = frameIndex * catalog.starCount + leafIndex;
+      if (frameIndex > 0 && opacityValues[sampleIndex] ===
+          opacityValues[sampleIndex - catalog.starCount]) continue;
+      leafIndices.push(leafIndex);
+      opacityIndices.push(opacityValues[sampleIndex]);
+    }
+    frameOffsets[frameIndex + 1] = leafIndices.length;
+  }
+  return Object.freeze({
+    coordinates,
+    opacitySchedule: Object.freeze({
+      frameOffsets,
+      leafIndices: Uint16Array.from(leafIndices),
+      opacityIndices: Uint8Array.from(opacityIndices),
+    }),
+  });
+}
+
+function railIndex(rails, particle, phaseFrameIndex) {
+  return ((particle.order * rails.radiusCount + particle.radiusIndex) *
+    rails.sourceFrameCount + phaseFrameIndex);
+}
+
+function roundTiesToEven(value) {
+  const lower = Math.floor(value);
+  const fraction = value - lower;
+  if (fraction < 0.5) return lower;
+  if (fraction > 0.5) return lower + 1;
+  return lower % 2 === 0 ? lower : lower + 1;
+}
+
+function expandOpacitySchedule(schedule, frameCount, starCount) {
+  const result = new Uint8Array(frameCount * starCount);
+  const current = new Uint8Array(starCount);
+  for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
+    for (let assignmentIndex = schedule.frameOffsets[frameIndex];
+      assignmentIndex < schedule.frameOffsets[frameIndex + 1]; assignmentIndex += 1) {
+      current[schedule.leafIndices[assignmentIndex]] = schedule.opacityIndices[assignmentIndex];
+    }
+    result.set(current, frameIndex * starCount);
+  }
+  return result;
 }

--- a/src/adapters/blackhole/test/cssblackhole-shell.test.mjs
+++ b/src/adapters/blackhole/test/cssblackhole-shell.test.mjs
@@ -6,10 +6,11 @@ import test from "node:test";
 const adapterRoot = new URL("../", import.meta.url);
 
 test("Luminet owns the shared css.graphics shell at its canonical route", async () => {
-  const [html, config, main] = await Promise.all([
+  const [html, config, main, netlify] = await Promise.all([
     readFile(new URL("index.html", adapterRoot), "utf8"),
     readFile(new URL("vite.config.mjs", adapterRoot), "utf8"),
     readFile(new URL("src/main.mjs", adapterRoot), "utf8"),
+    readFile(new URL("../../../netlify.toml", adapterRoot), "utf8"),
   ]);
   assert.match(html, /cssgraphics-examples-sidebar/u);
   assert.match(html, /https:\/\/css\.graphics\/luminet\//u);
@@ -17,7 +18,10 @@ test("Luminet owns the shared css.graphics shell at its canonical route", async 
   assert.match(html, /<main class="example-stage"><\/main>/u);
   assert.match(config, /createExamplesShellPlugin\("luminet"\)/u);
   assert.match(config, /deployBuild \? "\/luminet\/" : "\/"/u);
+  assert.match(config, /rails\\\/rails-\\d/u);
   assert.match(main, /site\/examples-shell-client\.mjs/u);
+  assert.match(netlify,
+    /for = "\/cssblackhole\/rails\/\*\.bin\.br"[\s\S]*?Content-Encoding = "br"/u);
 });
 
 test("Luminet keeps one retained point topology and no alternate renderer", async () => {

--- a/src/adapters/blackhole/tools/prepare-cssblackhole.mjs
+++ b/src/adapters/blackhole/tools/prepare-cssblackhole.mjs
@@ -18,6 +18,13 @@ import {
   quantizeBlackHolePreparedOpacityIndex,
 } from "../src/shared/cssblackhole/preparedBlockTransport.mjs";
 import {
+  CSSBLACKHOLE_RAIL_ASSET_SCHEMA,
+  CSSBLACKHOLE_RAIL_ENCODING,
+  CSSBLACKHOLE_REPAIR_BANK_SCHEMA,
+  encodeBlackHolePreparedRailAsset,
+  encodeBlackHolePreparedRepairBank,
+} from "../src/shared/cssblackhole/preparedRailTransport.mjs";
+import {
   CSSBLACKHOLE_DIRECT_IMAGE_DOT_COLORS,
   CSSBLACKHOLE_GALACTIC_DOT_COLORS,
   CSSBLACKHOLE_GHOST_IMAGE_DOT_COLORS,
@@ -39,6 +46,7 @@ const outputRoot = resolve(generatedPublicDir, presentationProfile.assetDirector
 const stagingRoot = resolve(
   generatedPublicDir, `.${presentationProfile.assetDirectory}-${process.pid}`);
 const banksRoot = resolve(stagingRoot, "banks");
+const railsRoot = resolve(stagingRoot, "rails");
 const sourceRoot = resolve(repositoryRoot, `.local/sources/luminet-${sourceLock.commit.slice(0, 7)}`);
 const venvRoot = resolve(repositoryRoot, `.local/venvs/luminet-${sourceLock.commit.slice(0, 7)}`);
 const pythonPath = process.env.CSSBLACKHOLE_PYTHON || resolve(venvRoot, "bin/python");
@@ -48,6 +56,12 @@ const luminancePath = resolve(repositoryRoot,
   `.local/cache/cssblackhole-luminet${presentationProfile.cacheSuffix}-luminance.bin`);
 const stateMetadataPath = resolve(repositoryRoot,
   `.local/cache/cssblackhole-luminet${presentationProfile.cacheSuffix}-state.json`);
+const railCoordinatePath = resolve(repositoryRoot,
+  ".local/cache/cssblackhole-luminet-source-rail-coordinates-u16.bin");
+const railLuminancePath = resolve(repositoryRoot,
+  ".local/cache/cssblackhole-luminet-source-rail-luminance.bin");
+const railMetadataPath = resolve(repositoryRoot,
+  ".local/cache/cssblackhole-luminet-source-rails.json");
 const oraclePpmPath = resolve(repositoryRoot,
   `build/oracle/cssblackhole/luminet${presentationProfile.cacheSuffix}-frame-0000.ppm`);
 const transportSeed = 6477;
@@ -75,6 +89,8 @@ const streamFrameCount = bankCount * bankFrameCount;
 const preparedOpacityPalette = CSSBLACKHOLE_OPACITY_PALETTE;
 const materializedBlockTransformCharacterLimit = 3_200_000;
 const materializedBlockScheduleByteLimit = 260_000;
+const useRailTransport = presentationProfile.id === "full" &&
+  process.env.CSSBLACKHOLE_GENERIC_TRANSPORT !== "1";
 
 if (endianness() !== "LE") throw new Error("Luminet preparation requires little endian");
 if (streamFrameCount !== presentationProfile.streamFrameCount ||
@@ -129,11 +145,75 @@ if (materialization.maximumTransformCharacters > materializedBlockTransformChara
 
 await rm(stagingRoot, { recursive: true, force: true });
 await mkdir(banksRoot, { recursive: true });
+if (useRailTransport) await mkdir(railsRoot, { recursive: true });
 const spaceContext = await prepareBlackHoleSpaceContext(stagingRoot, {
   selectedCoordinates,
   starCount,
   sourceState,
 });
+let sourceRails = [];
+if (useRailTransport) {
+  let railCache = await readPreparedRailCache();
+  if (railCache === null) {
+    await ensurePythonEnvironment();
+    await runRailPreparation();
+    railCache = await readPreparedRailCache();
+  }
+  if (railCache === null) throw new Error("Exact prepared Luminet rail cache is unavailable");
+  const coordinateValuesPerConfiguration = railCache.metadata.imageOrderCount *
+    railCache.metadata.radiusCount * railCache.metadata.sourceFrameCount * 2;
+  const luminanceValuesPerConfiguration = railCache.metadata.imageOrderCount *
+    railCache.metadata.radiusCount * railCache.metadata.sourceFrameCount;
+  for (let configurationIndex = 0;
+    configurationIndex < configurationCount;
+    configurationIndex += 1) {
+    const decoded = encodeBlackHolePreparedRailAsset({
+      transportSeed,
+      starCount,
+      configurationCount,
+      sourceConfigurationIndex: configurationIndex,
+      imageOrderCount: railCache.metadata.imageOrderCount,
+      radiusCount: railCache.metadata.radiusCount,
+      sourceFrameCount: railCache.metadata.sourceFrameCount,
+      transitionFrameCount: presentationProfile.transitionFrameCount,
+      railCoordinates: railCache.coordinates.subarray(
+        configurationIndex * coordinateValuesPerConfiguration,
+        (configurationIndex + 1) * coordinateValuesPerConfiguration),
+      railLuminances: railCache.luminances.subarray(
+        configurationIndex * luminanceValuesPerConfiguration,
+        (configurationIndex + 1) * luminanceValuesPerConfiguration),
+      particleOrders: railCache.metadata.particleOrders,
+      particleRadiusIndices: railCache.metadata.particleRadiusIndices,
+      particlePhaseFrameIndices: railCache.metadata.particlePhaseFrameIndices,
+      particlePeriodicOrbitCounts: railCache.metadata.particlePeriodicOrbitCounts,
+      selectedSourcePointIndices,
+      periodicOrbitCounts: expectedPeriodicOrbitCounts,
+    });
+    const compressed = compressPreparedBytes(decoded);
+    const hash = sha256(compressed);
+    const filename = `rails-${configurationIndex}-${hash}.bin.br`;
+    await writeFile(resolve(railsRoot, filename), compressed);
+    sourceRails.push(Object.freeze({
+      schema: CSSBLACKHOLE_RAIL_ASSET_SCHEMA,
+      configurationIndex,
+      assetUrl: `${assetRoot}/rails/${filename}`,
+      byteLength: compressed.byteLength,
+      sha256: hash,
+      decodedByteLength: decoded.byteLength,
+      decodedSha256: sha256(decoded),
+      contentEncoding: "br",
+      imageOrderCount: railCache.metadata.imageOrderCount,
+      radiusCount: railCache.metadata.radiusCount,
+      sourceFrameCount: railCache.metadata.sourceFrameCount,
+      coordinateEncoding: railCache.metadata.coordinateEncoding,
+      luminanceEncoding: railCache.metadata.luminanceEncoding,
+      selectedParticleDescriptorEncoding: "u32-phase13-radius4-order1",
+      transitionEasingEncoding: "prepared-f64le-smoothstep-120-samples",
+      periodicOrbitCountEncoding: "radius-major-u8",
+    }));
+  }
+  sourceRails = Object.freeze(sourceRails);
+}
 const banks = [];
 for (let bankIndex = 0; bankIndex < bankCount; bankIndex += 1) {
   const sourceBankFrameCount = bankFrameCount * sourceFrameStep;
@@ -144,7 +224,23 @@ for (let bankIndex = 0; bankIndex < bankCount; bankIndex += 1) {
   const bankLuminances = selectSourceFrames(
     selectedLuminances, sourceLoopStartFrameIndex, bankFrameCount, starCount, sourceFrameStep,
     sourceState.frameCount);
-  const decoded = encodeBlackHolePreparedBank({
+  const decoded = useRailTransport ? encodeBlackHolePreparedRepairBank({
+    transportSeed,
+    starCount,
+    bankIndex,
+    startFrameIndex: bankIndex * bankFrameCount,
+    frameCount: bankFrameCount,
+    blockFrameCount,
+    rawCoordinates: selectSourcePointFrames(
+      coordinates,
+      sourceLoopStartFrameIndex,
+      bankFrameCount,
+      sourcePointCount,
+      selectedSourcePointIndices,
+      sourceState.frameCount,
+    ),
+    repairedCoordinates: bankCoordinates,
+  }) : encodeBlackHolePreparedBank({
     transportSeed,
     starCount,
     configurationCount,
@@ -156,13 +252,7 @@ for (let bankIndex = 0; bankIndex < bankCount; bankIndex += 1) {
     luminances: bankLuminances,
   });
   const decodedView = new DataView(decoded.buffer, decoded.byteOffset, decoded.byteLength);
-  const compressed = brotliCompressSync(decoded, {
-    params: {
-      [zlibConstants.BROTLI_PARAM_QUALITY]: 11,
-      [zlibConstants.BROTLI_PARAM_MODE]: zlibConstants.BROTLI_MODE_GENERIC,
-      [zlibConstants.BROTLI_PARAM_SIZE_HINT]: decoded.byteLength,
-    },
-  });
+  const compressed = compressPreparedBytes(decoded);
   const hash = sha256(compressed);
   const filename = `bank-${String(bankIndex).padStart(2, "0")}-${hash}.bin.br`;
   await writeFile(resolve(banksRoot, filename), compressed);
@@ -182,13 +272,23 @@ for (let bankIndex = 0; bankIndex < bankCount; bankIndex += 1) {
     maximumCoordinateQuantizationErrorPixels:
       CSSBLACKHOLE_MAXIMUM_COORDINATE_QUANTIZATION_ERROR_PIXELS,
     blockCount: blocksPerBank,
-    visibleSampleCount: decodedView.getUint32(40, true),
+    ...(useRailTransport ? {
+      schema: CSSBLACKHOLE_REPAIR_BANK_SCHEMA,
+      requiredSourceConfigurationIndices: requiredSourceConfigurationIndices(
+        bankIndex * bankFrameCount, bankFrameCount, sourceState.configurationSequence),
+      preparedCollisionRepairCount: decodedView.getUint32(28, true),
+      coordinateEncoding:
+        "prepared-source-rail-lookup-plus-sparse-prepared-collision-repair",
+      opacityEncoding: "prepared-source-rail-rgb8-to-nearest-decile-materialization",
+    } : {
+      visibleSampleCount: decodedView.getUint32(40, true),
+      coordinateEncoding:
+        "leaf-major-axis-split-signed-zigzag-varint-second-difference-decimal1",
+      opacityAssignmentCount: decodedView.getUint32(44, true),
+      sourceLuminanceSampleCount: bankFrameCount * starCount,
+      opacityEncoding: CSSBLACKHOLE_OPACITY_ENCODING,
+    }),
     sourceSampleCount: bankFrameCount * starCount,
-    coordinateEncoding:
-      "leaf-major-axis-split-signed-zigzag-varint-second-difference-decimal1",
-    opacityAssignmentCount: decodedView.getUint32(44, true),
-    sourceLuminanceSampleCount: bankFrameCount * starCount,
-    opacityEncoding: CSSBLACKHOLE_OPACITY_ENCODING,
   }));
 }
 
@@ -358,15 +458,20 @@ const catalog = Object.freeze({
   preparedOpacityPalette,
   transport: Object.freeze({
     schema: "cssblackhole-prepared-bank-transport@1",
-    encoding: CSSBLACKHOLE_BANK_ENCODING,
+    encoding: useRailTransport ? CSSBLACKHOLE_RAIL_ENCODING : CSSBLACKHOLE_BANK_ENCODING,
     contentEncoding: "br",
     bankSeconds: bankFrameCount / framesPerSecond,
     coordinateScale: 10,
     maximumCoordinateQuantizationErrorPixels:
       CSSBLACKHOLE_MAXIMUM_COORDINATE_QUANTIZATION_ERROR_PIXELS,
-    predictor:
+    predictor: useRailTransport ?
+      "shared-source-phase-rails-plus-five-second-prepared-sparse-collision-repair-banks" :
       "independent-five-second-bank-one-second-block-coordinate-second-difference-plus-prepared-sparse-opacity-ranges",
+    runtimeSourcePhysics: false,
+    runtimeCollisionSearch: false,
+    workerRailLookupMaterialization: useRailTransport,
   }),
+  ...(sourceRails.length === 0 ? {} : { sourceRails }),
   configurationLoop,
   luminetPreparedState: sourceState,
   snapshot: Object.freeze({
@@ -433,7 +538,8 @@ await writeFile(resolve(stagingRoot, "prepared.json"), JSON.stringify(prepared))
 await rm(outputRoot, { recursive: true, force: true });
 await rename(stagingRoot, outputRoot);
 
-const compressedBytes = banks.reduce((total, bank) => total + bank.byteLength, 0);
+const compressedBytes = banks.reduce((total, bank) => total + bank.byteLength, 0) +
+  sourceRails.reduce((total, descriptor) => total + descriptor.byteLength, 0);
 process.stdout.write(`${JSON.stringify({
   status: "ready",
   outputRoot,
@@ -448,6 +554,10 @@ process.stdout.write(`${JSON.stringify({
   transitionCadenceSecondsBySlot:
     sourceState.configurationSequence.transitionCadenceSecondsBySlot,
   bankCount,
+  transportEncoding: catalog.transport.encoding,
+  sourceRailCompressedBytes:
+    sourceRails.reduce((total, descriptor) => total + descriptor.byteLength, 0),
+  repairBankCompressedBytes: banks.reduce((total, bank) => total + bank.byteLength, 0),
   compressedBytes,
 }, null, 2)}\n`);
 
@@ -669,12 +779,88 @@ async function runPythonPreparation() {
   });
 }
 
+async function readPreparedRailCache() {
+  try {
+    const [metadataSource, coordinateBytes, luminanceBytes] = await Promise.all([
+      readFile(railMetadataPath, "utf8"), readFile(railCoordinatePath), readFile(railLuminancePath),
+    ]);
+    const metadata = JSON.parse(metadataSource);
+    if (metadata?.schema !== "cssblackhole-luminet-source-rail-cache@1" ||
+        metadata.sourceCommit !== sourceLock.commit || metadata.configurationCount !== 3 ||
+        metadata.imageOrderCount !== 2 || metadata.radiusCount !== 16 ||
+        metadata.sourceFrameCount !== 5_400 || metadata.particleCount !== sourcePointCount ||
+        metadata.coordinateEncoding !==
+          "configuration-order-radius-phase-xy-u16le-decimal1" ||
+        metadata.coordinateByteLength !== coordinateBytes.byteLength ||
+        metadata.coordinateSha256 !== sha256(coordinateBytes) ||
+        metadata.luminanceEncoding !== "configuration-order-radius-phase-u8-rgb8" ||
+        metadata.luminanceByteLength !== luminanceBytes.byteLength ||
+        metadata.luminanceSha256 !== sha256(luminanceBytes) ||
+        metadata.recoveredPreparedSampleCount !== 495_339 ||
+        metadata.sourceSolvedMissingSampleCount !== 23_061 ||
+        ![metadata.particleOrders, metadata.particleRadiusIndices,
+          metadata.particlePhaseFrameIndices, metadata.particlePeriodicOrbitCounts]
+          .every((values) => Array.isArray(values) && values.length === sourcePointCount) ||
+        coordinateBytes.byteLength !== 3 * 2 * 16 * 5_400 * 2 * 2 ||
+        luminanceBytes.byteLength !== 3 * 2 * 16 * 5_400) return null;
+    return Object.freeze({
+      metadata,
+      coordinates: new Uint16Array(
+        coordinateBytes.buffer, coordinateBytes.byteOffset, coordinateBytes.byteLength / 2),
+      luminances: new Uint8Array(
+        luminanceBytes.buffer, luminanceBytes.byteOffset, luminanceBytes.byteLength),
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function runRailPreparation() {
+  const fullCoordinatePath = resolve(
+    repositoryRoot, ".local/cache/cssblackhole-luminet-coordinates.bin");
+  const fullLuminancePath = resolve(
+    repositoryRoot, ".local/cache/cssblackhole-luminet-luminance.bin");
+  const fullStatePath = resolve(
+    repositoryRoot, ".local/cache/cssblackhole-luminet-state.json");
+  if (!await exists(fullCoordinatePath) || !await exists(fullLuminancePath) ||
+      !await exists(fullStatePath)) {
+    throw new Error("Full prepared Luminet cache is required to factor source rails");
+  }
+  await new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(pythonPath, [
+      resolve(import.meta.dirname, "prepare-luminet-rail-cache.py"),
+      "--preparation", resolve(import.meta.dirname, "prepare-luminet-state.py"),
+      "--source-root", sourceRoot,
+      "--source-commit", sourceLock.commit,
+      "--state", fullStatePath,
+      "--coordinates", fullCoordinatePath,
+      "--luminances", fullLuminancePath,
+      "--coordinate-output", railCoordinatePath,
+      "--luminance-output", railLuminancePath,
+      "--metadata-output", railMetadataPath,
+    ], { stdio: "inherit" });
+    child.once("error", rejectPromise);
+    child.once("exit", (code, signal) => code === 0 ? resolvePromise() :
+      rejectPromise(new Error(`Luminet rail preparation failed: code=${code} signal=${signal}`)));
+  });
+}
+
 async function exists(path) {
   try { await access(path); return true; } catch { return false; }
 }
 
 function sha256(value) {
   return createHash("sha256").update(value).digest("hex");
+}
+
+function compressPreparedBytes(decoded) {
+  return brotliCompressSync(decoded, {
+    params: {
+      [zlibConstants.BROTLI_PARAM_QUALITY]: 11,
+      [zlibConstants.BROTLI_PARAM_MODE]: zlibConstants.BROTLI_MODE_GENERIC,
+      [zlibConstants.BROTLI_PARAM_SIZE_HINT]: decoded.byteLength,
+    },
+  });
 }
 
 function selectSourceFrames(
@@ -705,4 +891,41 @@ function selectSourcePoints(source, frameCount, sourceCount, valuesPerPoint, poi
     }
   }
   return selected;
+}
+
+function selectSourcePointFrames(
+  source, startFrame, frameCount, sourcePointCount, pointIndices, sourceFrameCount,
+) {
+  const selected = new Int32Array(frameCount * pointIndices.length * 2);
+  for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
+    const sourceFrameIndex = (startFrame + frameIndex) % sourceFrameCount;
+    for (let selectedIndex = 0; selectedIndex < pointIndices.length; selectedIndex += 1) {
+      const sourcePointIndex = pointIndices[selectedIndex];
+      const sourceOffset = (sourceFrameIndex * sourcePointCount + sourcePointIndex) * 2;
+      const selectedOffset = (frameIndex * pointIndices.length + selectedIndex) * 2;
+      selected[selectedOffset] = source[sourceOffset];
+      selected[selectedOffset + 1] = source[sourceOffset + 1];
+    }
+  }
+  return selected;
+}
+
+function requiredSourceConfigurationIndices(startFrameIndex, frameCount, configurationSequence) {
+  const required = new Set();
+  for (let frameOffset = 0; frameOffset < frameCount; frameOffset += 1) {
+    const sequenceFrameIndex = (startFrameIndex + frameOffset) %
+      configurationSequence.presentationSequenceFrameCount;
+    const presentationIndex = configurationSequence.presentationSlots.findIndex((slot) =>
+      sequenceFrameIndex >= slot.startFrameIndex &&
+      sequenceFrameIndex < slot.startFrameIndex + slot.frameCount);
+    const slot = configurationSequence.presentationSlots[presentationIndex];
+    if (!slot) throw new Error("Luminet transport bank presentation slot drifted");
+    required.add(slot.stateIndex);
+    if (sequenceFrameIndex - slot.startFrameIndex >= slot.transitionStartFrameIndex) {
+      const nextSlot = configurationSequence.presentationSlots[
+        (presentationIndex + 1) % configurationSequence.presentationSlots.length];
+      required.add(nextSlot.stateIndex);
+    }
+  }
+  return Object.freeze([...required].sort((left, right) => left - right));
 }

--- a/src/adapters/blackhole/tools/prepare-luminet-rail-cache.py
+++ b/src/adapters/blackhole/tools/prepare-luminet-rail-cache.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Factor the exact prepared Luminet cache into reusable source phase rails."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import math
+import pathlib
+import sys
+
+import numpy as np
+from matplotlib import colormaps
+from matplotlib.colors import PowerNorm
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    preparation = load_preparation_module(pathlib.Path(arguments.preparation))
+    source_root = pathlib.Path(arguments.source_root).resolve()
+    sys.path.insert(0, str(source_root))
+    from luminet import black_hole_math as bhmath
+    from luminet.spatial import polar_to_cartesian
+
+    state_path = pathlib.Path(arguments.state)
+    state = json.loads(state_path.read_text())
+    if state.get("schema") != "cssblackhole-luminet-prepared-state@9" or \
+            state.get("sourceCommit") != arguments.source_commit or \
+            state.get("frameCount") != 10_800 or state.get("pointCount") != 3_000:
+        raise RuntimeError("Exact full Luminet prepared cache is required")
+
+    particles = preparation.create_particles()
+    orders = np.array([particle["order"] for particle in particles], dtype=np.intp)
+    radius_indices = np.array(
+        [particle["radiusIndex"] for particle in particles], dtype=np.intp)
+    phase_indices = np.array(
+        [particle["phaseFrameIndex"] for particle in particles], dtype=np.int64)
+    turns = np.array([particle["turns"] for particle in particles], dtype=np.int64)
+    if len(particles) != preparation.POINT_COUNT:
+        raise RuntimeError("Luminet particle identity count drifted")
+
+    prepared_coordinates = np.memmap(
+        arguments.coordinates,
+        dtype="<i4",
+        mode="r",
+        shape=(state["frameCount"], preparation.POINT_COUNT, 2),
+    )
+    prepared_luminances = np.memmap(
+        arguments.luminances,
+        dtype=np.uint8,
+        mode="r",
+        shape=(state["frameCount"], preparation.POINT_COUNT),
+    )
+    shape = (
+        preparation.SOURCE_CONFIGURATION_COUNT,
+        2,
+        preparation.PERIODIC_RADIUS_COUNT,
+        preparation.SOURCE_LOOP_FRAME_COUNT,
+    )
+    rail_coordinates = np.zeros((*shape, 2), dtype="<i4")
+    rail_luminances = np.zeros(shape, dtype=np.uint8)
+    seen = np.zeros(shape, dtype=bool)
+    sequence = state["configurationSequence"]
+
+    for global_frame_index in range(state["frameCount"]):
+        sequence_frame_index = global_frame_index % \
+            sequence["presentationSequenceFrameCount"]
+        presentation_index = next(
+            index
+            for index, start_frame_index in
+            enumerate(sequence["presentationSlotStartFrameIndices"])
+            if sequence_frame_index <
+            start_frame_index + sequence["presentationSlotFrameCounts"][index]
+        )
+        local_frame_index = sequence_frame_index - \
+            sequence["presentationSlotStartFrameIndices"][presentation_index]
+        if local_frame_index >= \
+                sequence["transitionStartFrameIndices"][presentation_index]:
+            continue
+        configuration_index = \
+            sequence["presentationStateIndices"][presentation_index]
+        source_frame_index = global_frame_index % preparation.SOURCE_LOOP_FRAME_COUNT
+        particle_phase_indices = (
+            phase_indices + turns * source_frame_index
+        ) % preparation.SOURCE_LOOP_FRAME_COUNT
+        key = (
+            np.full(preparation.POINT_COUNT, configuration_index, dtype=np.intp),
+            orders,
+            radius_indices,
+            particle_phase_indices,
+        )
+        rail_coordinates[key] = prepared_coordinates[global_frame_index]
+        rail_luminances[key] = prepared_luminances[global_frame_index]
+        seen[key] = True
+
+    recovered_sample_count = int(np.count_nonzero(seen))
+    solve_missing_rail_samples(
+        preparation,
+        bhmath,
+        polar_to_cartesian,
+        state,
+        rail_coordinates,
+        rail_luminances,
+        seen,
+    )
+    if not np.all(seen):
+        raise RuntimeError("Luminet rail recovery retained missing samples")
+
+    verify_exact_presentation(
+        preparation,
+        state,
+        prepared_coordinates,
+        prepared_luminances,
+        rail_coordinates,
+        rail_luminances,
+        orders,
+        radius_indices,
+        phase_indices,
+        turns,
+    )
+    if int(np.min(rail_coordinates)) < 0 or int(np.max(rail_coordinates)) > 0xffff:
+        raise RuntimeError("Luminet rail coordinate exceeded unsigned 16-bit transport")
+
+    coordinate_output = pathlib.Path(arguments.coordinate_output)
+    luminance_output = pathlib.Path(arguments.luminance_output)
+    metadata_output = pathlib.Path(arguments.metadata_output)
+    for path in (coordinate_output, luminance_output, metadata_output):
+        path.parent.mkdir(parents=True, exist_ok=True)
+    np.ascontiguousarray(rail_coordinates, dtype="<u2").tofile(coordinate_output)
+    np.ascontiguousarray(rail_luminances, dtype=np.uint8).tofile(luminance_output)
+    coordinate_bytes = coordinate_output.read_bytes()
+    luminance_bytes = luminance_output.read_bytes()
+    metadata = {
+        "schema": "cssblackhole-luminet-source-rail-cache@1",
+        "sourceCommit": arguments.source_commit,
+        "configurationCount": preparation.SOURCE_CONFIGURATION_COUNT,
+        "imageOrderCount": 2,
+        "radiusCount": preparation.PERIODIC_RADIUS_COUNT,
+        "sourceFrameCount": preparation.SOURCE_LOOP_FRAME_COUNT,
+        "coordinateEncoding": "configuration-order-radius-phase-xy-u16le-decimal1",
+        "coordinateByteLength": len(coordinate_bytes),
+        "coordinateSha256": hashlib.sha256(coordinate_bytes).hexdigest(),
+        "luminanceEncoding": "configuration-order-radius-phase-u8-rgb8",
+        "luminanceByteLength": len(luminance_bytes),
+        "luminanceSha256": hashlib.sha256(luminance_bytes).hexdigest(),
+        "recoveredPreparedSampleCount": recovered_sample_count,
+        "sourceSolvedMissingSampleCount": int(seen.size - recovered_sample_count),
+        "particleCount": preparation.POINT_COUNT,
+        "particleOrders": orders.tolist(),
+        "particleRadiusIndices": radius_indices.tolist(),
+        "particlePhaseFrameIndices": phase_indices.tolist(),
+        "particlePeriodicOrbitCounts": turns.tolist(),
+    }
+    metadata_output.write_text(json.dumps(metadata, separators=(",", ":")) + "\n")
+    print(json.dumps({
+        "status": "ready",
+        "coordinateByteLength": len(coordinate_bytes),
+        "luminanceByteLength": len(luminance_bytes),
+        "recoveredPreparedSampleCount": recovered_sample_count,
+        "sourceSolvedMissingSampleCount": int(seen.size - recovered_sample_count),
+        "exactPresentationFrameCount": state["frameCount"],
+    }, indent=2), flush=True)
+
+
+def solve_missing_rail_samples(
+        preparation,
+        bhmath,
+        polar_to_cartesian,
+        state: dict[str, object],
+        rail_coordinates: np.ndarray,
+        rail_luminances: np.ndarray,
+        seen: np.ndarray,
+) -> None:
+    _, radii = preparation.periodic_orbits()
+    normalizer = PowerNorm(
+        gamma=state["photometry"]["displayPowerGamma"],
+        vmin=0.0,
+        vmax=state["photometry"]["maximumObservedFlux"],
+        clip=True,
+    )
+    for configuration_index, configuration in enumerate(preparation.CONFIGURATIONS):
+        inclination = math.radians(configuration["inclinationDegrees"])
+        for order in range(2):
+            for radius_index, radius in enumerate(radii):
+                missing_phase_indices = np.flatnonzero(
+                    ~seen[configuration_index, order, radius_index]
+                )
+                if missing_phase_indices.size == 0:
+                    continue
+                phase_angles = missing_phase_indices.astype(np.float64) * \
+                    (2 * math.pi / preparation.SOURCE_LOOP_FRAME_COUNT)
+                impact_parameters = np.array([
+                    bhmath.solve_for_impact_parameter(
+                        float(radius), inclination, float(alpha), preparation.MASS, order)
+                    for alpha in phase_angles
+                ], dtype=np.float64)
+                if not np.all(np.isfinite(impact_parameters)) or \
+                        np.any(impact_parameters <= 0):
+                    raise RuntimeError("Luminet missing rail solve returned invalid impact parameter")
+                x, y = polar_to_cartesian(
+                    phase_angles, impact_parameters, rotation=math.pi / 2
+                )
+                redshift_factors = bhmath.calc_redshift_factor(
+                    float(radius), phase_angles, inclination,
+                    preparation.MASS, impact_parameters,
+                )
+                flux = np.asarray(bhmath.calc_flux_observed(
+                    float(radius), 1.0, preparation.MASS, redshift_factors
+                ), dtype=np.float64)
+                visible_flux = preparation.DISPLAY_OPACITY_FLOOR + \
+                    (1 - preparation.DISPLAY_OPACITY_FLOOR) * normalizer(flux)
+                luminance = colormaps[preparation.COLORMAP](
+                    visible_flux, bytes=True
+                )[..., 0]
+                rail_coordinates[
+                    configuration_index, order, radius_index, missing_phase_indices, 0
+                ] = np.rint(
+                    (preparation.CENTER_X + x * preparation.PIXELS_PER_IMPACT_PARAMETER) * 10
+                ).astype("<i4")
+                rail_coordinates[
+                    configuration_index, order, radius_index, missing_phase_indices, 1
+                ] = np.rint(
+                    (preparation.CENTER_Y - y * preparation.PIXELS_PER_IMPACT_PARAMETER) * 10
+                ).astype("<i4")
+                rail_luminances[
+                    configuration_index, order, radius_index, missing_phase_indices
+                ] = luminance
+                seen[configuration_index, order, radius_index, missing_phase_indices] = True
+
+
+def verify_exact_presentation(
+        preparation,
+        state: dict[str, object],
+        prepared_coordinates: np.ndarray,
+        prepared_luminances: np.ndarray,
+        rail_coordinates: np.ndarray,
+        rail_luminances: np.ndarray,
+        orders: np.ndarray,
+        radius_indices: np.ndarray,
+        phase_indices: np.ndarray,
+        turns: np.ndarray,
+) -> None:
+    sequence = state["configurationSequence"]
+    for global_frame_index in range(state["frameCount"]):
+        source_frame_index = global_frame_index % preparation.SOURCE_LOOP_FRAME_COUNT
+        particle_phase_indices = (
+            phase_indices + turns * source_frame_index
+        ) % preparation.SOURCE_LOOP_FRAME_COUNT
+        sequence_frame_index = global_frame_index % \
+            sequence["presentationSequenceFrameCount"]
+        presentation_index = next(
+            index
+            for index, start_frame_index in
+            enumerate(sequence["presentationSlotStartFrameIndices"])
+            if sequence_frame_index <
+            start_frame_index + sequence["presentationSlotFrameCounts"][index]
+        )
+        configuration_index = \
+            sequence["presentationStateIndices"][presentation_index]
+        current_coordinates = rail_coordinates[
+            configuration_index, orders, radius_indices, particle_phase_indices
+        ]
+        current_luminances = rail_luminances[
+            configuration_index, orders, radius_indices, particle_phase_indices
+        ]
+        local_frame_index = sequence_frame_index - \
+            sequence["presentationSlotStartFrameIndices"][presentation_index]
+        transition_start_frame_index = \
+            sequence["transitionStartFrameIndices"][presentation_index]
+        if local_frame_index < transition_start_frame_index:
+            expected_coordinates = current_coordinates
+            expected_luminances = current_luminances
+        else:
+            next_presentation_index = \
+                (presentation_index + 1) % sequence["presentationConfigurationCount"]
+            next_configuration_index = \
+                sequence["presentationStateIndices"][next_presentation_index]
+            next_coordinates = rail_coordinates[
+                next_configuration_index, orders, radius_indices, particle_phase_indices
+            ]
+            next_luminances = rail_luminances[
+                next_configuration_index, orders, radius_indices, particle_phase_indices
+            ]
+            progress = (
+                local_frame_index - transition_start_frame_index + 1
+            ) / preparation.TRANSITION_FRAME_COUNT
+            eased = progress * progress * (3 - 2 * progress)
+            expected_coordinates = np.rint(
+                current_coordinates * (1 - eased) + next_coordinates * eased
+            ).astype("<i4")
+            expected_luminances = np.rint(
+                current_luminances * (1 - eased) + next_luminances * eased
+            ).astype(np.uint8)
+        if not np.array_equal(expected_coordinates, prepared_coordinates[global_frame_index]):
+            raise RuntimeError(
+                f"Luminet rail coordinates diverged at frame {global_frame_index}"
+            )
+        if not np.array_equal(expected_luminances, prepared_luminances[global_frame_index]):
+            raise RuntimeError(
+                f"Luminet rail luminance diverged at frame {global_frame_index}"
+            )
+
+
+def load_preparation_module(path: pathlib.Path):
+    specification = importlib.util.spec_from_file_location(
+        "cssblackhole_luminet_preparation", path.resolve()
+    )
+    if specification is None or specification.loader is None:
+        raise RuntimeError("Could not load Luminet preparation module")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--preparation", required=True)
+    parser.add_argument("--source-root", required=True)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--state", required=True)
+    parser.add_argument("--coordinates", required=True)
+    parser.add_argument("--luminances", required=True)
+    parser.add_argument("--coordinate-output", required=True)
+    parser.add_argument("--luminance-output", required=True)
+    parser.add_argument("--metadata-output", required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/adapters/blackhole/vite.config.mjs
+++ b/src/adapters/blackhole/vite.config.mjs
@@ -15,7 +15,7 @@ function createBlackHolePreparedBrotliPlugin() {
     server.middlewares.use(async (request, response, next) => {
       if (!request.url || !["GET", "HEAD"].includes(request.method ?? "GET")) return next();
       const pathname = new URL(request.url, "http://css.graphics").pathname;
-      if (!/^\/cssblackhole(?:-side-tilt)?\/banks\/bank-\d{2}-[a-f0-9]{64}\.bin\.br$/u
+      if (!/^\/cssblackhole(?:-side-tilt)?\/(?:banks\/bank-\d{2}|rails\/rails-\d)-[a-f0-9]{64}\.bin\.br$/u
         .test(pathname)) {
         return next();
       }


### PR DESCRIPTION
## Summary
- replace the 9.72 MB exploded Luminet coordinate stream with prepared source phase rails and sparse collision-repair banks
- split rails by view so first-ready transport is 196 KB and the full 180-second loop is 761 KB
- preserve the exact 1979-dot, 60 Hz presentation and local side-tilt mode
- serve immutable Brotli rail assets in Vite and Netlify

## Verification
- pnpm test:luminet
- pnpm build:luminet
- pnpm test:luminet:browser
- CSSBLACKHOLE_DEPLOY_BUILD=1 pnpm build:luminet
- pnpm test:luminet:deploy
- exact 10,800-frame rail reconstruction and 303,464 prepared collision repairs
- headless desktop, 27-inch, mobile, and DPR2 smoke profiles at 60 Hz