### PR TITLE
Fix Luminet wall-clock playback pacing

### DIFF
--- a/src/adapters/blackhole/src/cssblackhole/preparedPlayback.mjs
+++ b/src/adapters/blackhole/src/cssblackhole/preparedPlayback.mjs
@@ -50,6 +50,10 @@ export function createBlackHolePreparedPlayer({
   const transitionStreamFrames = new Uint32Array(
     catalog.configurationLoop.configurationTransitionCount + 2);
   const transitionOffsetsBySequenceFrame = createTransitionOffsetTable(catalog.configurationLoop);
+  const transitionStartSequenceFrames = catalog.configurationLoop.presentationSlotStartFrameIndices
+    .map((start, index) => start + catalog.configurationLoop.transitionStartFrameIndices[index]);
+  const transitionEndSequenceFrames = transitionStartSequenceFrames
+    .map((start) => start + catalog.configurationLoop.transitionFrameCount - 1);
   const blockWindowIndices = new Uint16Array(catalog.runtimeMaterializedLookaheadBlockCount + 1);
   const bankWindowIndices = new Uint16Array(catalog.runtimeLookaheadBankCount + 1);
   const retainedBlockFlags = new Uint8Array(catalog.blockCount);
@@ -68,6 +72,7 @@ export function createBlackHolePreparedPlayer({
   let transformWriteCount = 0;
   let opacityWriteCount = 0;
   let totalDomWriteCount = 0;
+  let sourceFrameDropCount = 0;
   let schedulerLateResetCount = 0;
   let schedulerFrameRequestCount = 0;
   let schedulerFrameCallbackCount = 0;
@@ -91,7 +96,7 @@ export function createBlackHolePreparedPlayer({
   if (!initialSnapshotPresented) publish(initialStreamFrame, readNow());
   queueWindows();
 
-  function publish(streamFrame, now) {
+  function publish(streamFrame, now, schedulerAdvanceFrameCount = 1) {
     const blockIndex = Math.floor(streamFrame / catalog.blockFrameCount);
     const localFrame = streamFrame % catalog.blockFrameCount;
     const isSequential = publishedStreamFrame >= 0 &&
@@ -100,10 +105,31 @@ export function createBlackHolePreparedPlayer({
     const sequenceFrame = streamFrame % catalog.configurationLoop.presentationSequenceFrameCount;
     const transitionOffset = transitionOffsetsBySequenceFrame[sequenceFrame];
     const isTransitionFrame = transitionOffset >= 0;
-    if (isTransitionFrame && transitionOffset === 0 && appliedFrameCount > 1 &&
+    let crossedTransitionStartStreamFrame = -1;
+    let crossedTransitionEnd = false;
+    if (publishedStreamFrame >= 0 && schedulerAdvanceFrameCount > 1 &&
+        schedulerAdvanceFrameCount < catalog.configurationLoop.presentationSequenceFrameCount) {
+      for (const start of transitionStartSequenceFrames) {
+        const distance = forwardSequenceDistance(publishedStreamFrame, start,
+          catalog.configurationLoop.presentationSequenceFrameCount);
+        if (distance <= schedulerAdvanceFrameCount) {
+          crossedTransitionStartStreamFrame =
+            (publishedStreamFrame + distance) % catalog.streamFrameCount;
+        }
+      }
+      for (const end of transitionEndSequenceFrames) {
+        if (forwardSequenceDistance(publishedStreamFrame, end,
+            catalog.configurationLoop.presentationSequenceFrameCount) <= schedulerAdvanceFrameCount) {
+          crossedTransitionEnd = true;
+        }
+      }
+    }
+    const transitionStarted = transitionOffset === 0 || crossedTransitionStartStreamFrame >= 0;
+    if (transitionStarted && appliedFrameCount > 1 &&
         transitionCount < transitionGaps.length) {
       activeTransitionIndex = transitionCount++;
-      transitionStreamFrames[activeTransitionIndex] = streamFrame;
+      transitionStreamFrames[activeTransitionIndex] = crossedTransitionStartStreamFrame >= 0
+        ? crossedTransitionStartStreamFrame : streamFrame;
       preparedConfigurationSwitchCount += 1;
       performance.mark(`cssblackhole-configuration-transition-${activeTransitionIndex + 1}-start`);
     }
@@ -133,10 +159,11 @@ export function createBlackHolePreparedPlayer({
         presentationSamples[presentationSampleCount - 1] ?? 0);
       transitionPublishDurations[activeTransitionIndex] = Math.max(
         transitionPublishDurations[activeTransitionIndex], duration);
-      if (transitionOffset + 1 === catalog.configurationLoop.transitionFrameCount) {
-        performance.mark(`cssblackhole-configuration-transition-${activeTransitionIndex + 1}-published`);
-        activeTransitionIndex = -1;
-      }
+    }
+    if (activeTransitionIndex >= 0 && (crossedTransitionEnd ||
+        transitionOffset + 1 === catalog.configurationLoop.transitionFrameCount)) {
+      performance.mark(`cssblackhole-configuration-transition-${activeTransitionIndex + 1}-published`);
+      activeTransitionIndex = -1;
     }
   }
 
@@ -290,7 +317,9 @@ export function createBlackHolePreparedPlayer({
     }
     lastAnimationFrameAt = now;
     if (waitingForBlock) return;
-    const next = (publishedStreamFrame + 1) % catalog.streamFrameCount;
+    const dueFrameCount = Math.max(1, Math.floor(
+      (now + schedulerEarlyToleranceMilliseconds - nextFrameAt) / catalog.frameMilliseconds) + 1);
+    const next = (publishedStreamFrame + dueFrameCount) % catalog.streamFrameCount;
     const nextBlockIndex = Math.floor(next / catalog.blockFrameCount);
     if (nextBlockIndex !== activeBlockIndex && !resolvedBlocks.has(nextBlockIndex)) {
       waitingForBlock = true;
@@ -311,16 +340,9 @@ export function createBlackHolePreparedPlayer({
       });
       return;
     }
-    publish(next, now);
-    if (schedulerCadenceMode === "high-refresh-deadline-gated") {
-      nextFrameAt += catalog.frameMilliseconds;
-      if (nextFrameAt + schedulerEarlyToleranceMilliseconds <= now) {
-        nextFrameAt = now + catalog.frameMilliseconds;
-        schedulerLateResetCount += 1;
-      }
-    } else {
-      nextFrameAt = now + catalog.frameMilliseconds;
-    }
+    publish(next, now, dueFrameCount);
+    sourceFrameDropCount += dueFrameCount - 1;
+    nextFrameAt += dueFrameCount * catalog.frameMilliseconds;
     schedule();
   }
 
@@ -405,9 +427,9 @@ export function createBlackHolePreparedPlayer({
       initialSnapshotDomWriteCount: initialSnapshotPresented ? 0 : catalog.starCount * 2,
       writesPerPublishedFrameMean: appliedFrameCount === 0 ? 0 : totalDomWriteCount / appliedFrameCount,
       writesPerPublishedFrameP95: percentile(writes, 0.95),
-      sourceFrameDropCount: 0,
+      sourceFrameDropCount,
       droppedFrameCauses: Object.freeze({
-        schedulerDeadlineCollapse: 0,
+        schedulerDeadlineCollapse: sourceFrameDropCount,
         preparedBlockWait: 0,
         preparedBankWait: 0,
         documentHidden: 0,
@@ -428,7 +450,7 @@ export function createBlackHolePreparedPlayer({
       schedulerHighRefreshThresholdMilliseconds,
       schedulerCadenceMode,
       runtimeSchedulerTransport:
-        "refresh-calibrated-requestAnimationFrame-prepared-publication-at-sixty-hertz",
+        "wall-clock-anchored-requestAnimationFrame-prepared-publication-at-up-to-sixty-hertz",
       preparedBlockWaitCount,
       preparedBankWaitCount,
       cadence: Object.freeze({
@@ -487,6 +509,12 @@ function percentile(sorted, fraction) {
   if (sorted.length === 0) return 0;
   return Number(sorted[Math.min(sorted.length - 1,
     Math.ceil(sorted.length * fraction) - 1)].toFixed(3));
+}
+
+function forwardSequenceDistance(streamFrame, targetSequenceFrame, sequenceFrameCount) {
+  const distance = (targetSequenceFrame - streamFrame % sequenceFrameCount + sequenceFrameCount) %
+    sequenceFrameCount;
+  return distance === 0 ? sequenceFrameCount : distance;
 }
 
 function preparedTransformAt(block, assignmentIndex) {

--- a/src/adapters/blackhole/test/cssblackhole-playback.test.mjs
+++ b/src/adapters/blackhole/test/cssblackhole-playback.test.mjs
@@ -108,7 +108,18 @@ test("Luminet publishes every nominal 60 Hz refresh despite callback jitter", ()
   assert.equal(stats.schedulerNoopCallbackCount, 0);
   assert.equal(stats.schedulerLeadMilliseconds, 0);
   assert.equal(stats.runtimeSchedulerTransport,
-    "refresh-calibrated-requestAnimationFrame-prepared-publication-at-sixty-hertz");
+    "wall-clock-anchored-requestAnimationFrame-prepared-publication-at-up-to-sixty-hertz");
+  assert.equal(stats.sourceFrameDropCount, 0);
+
+  now = 88.218;
+  frame = pendingFrame;
+  pendingFrame = null;
+  frame(now);
+  const thirtyHertzStats = player.stats();
+  assert.equal(thirtyHertzStats.publishedStreamFrame, 0);
+  assert.equal(thirtyHertzStats.appliedFrameCount, 3);
+  assert.equal(thirtyHertzStats.sourceFrameDropCount, 1);
+  assert.equal(thirtyHertzStats.droppedFrameCauses.schedulerDeadlineCollapse, 1);
 
   player.pause();
   assert.equal(canceledFrameCount, 1);

--- a/src/adapters/blackhole/tools/smoke-browser.mjs
+++ b/src/adapters/blackhole/tools/smoke-browser.mjs
@@ -188,6 +188,7 @@ async function smokeProfile(specification) {
         ? getComputedStyle(stage).backgroundRepeat : null,
       presentation,
       pointPresentation,
+      measurementStartedAt: performance.now(),
       canonical: document.querySelector('link[rel="canonical"]')?.href ?? null,
       robots: document.querySelector('meta[name="robots"]')?.content ?? null,
     };
@@ -197,6 +198,7 @@ async function smokeProfile(specification) {
     const leaves = [...document.querySelectorAll(".polycss-scene > b")];
     const stable = window.__cssBlackHoleSmokeLeaves;
     const stats = window.__cssBlackHoleDebug.stats();
+    const measurementEndedAt = performance.now();
     window.__cssBlackHoleDebug.pause();
     const pausedFrame = window.__cssBlackHoleDebug.stats().publishedStreamFrame;
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 150));
@@ -213,6 +215,7 @@ async function smokeProfile(specification) {
     window.__cssBlackHoleDebug.resume();
     return {
       stats,
+      measurementEndedAt,
       leafCount: leaves.length,
       stableIdentity: leaves.length === stable.length &&
         leaves.every((leaf, index) => leaf === stable[index]),
@@ -246,6 +249,11 @@ async function smokeProfile(specification) {
 function assertSmoke(report) {
   const preparedRequests = report.requests.filter((path) => path.startsWith("/cssblackhole/"));
   const presentation = report.initial.presentation;
+  const measuredSeconds = (report.final.measurementEndedAt - report.initial.measurementStartedAt) /
+    1_000;
+  const measuredSourceFrames = report.final.stats.publishedStreamFrame -
+    report.initial.stats.publishedStreamFrame;
+  const measuredSourceFramesPerSecond = measuredSourceFrames / measuredSeconds;
   if (report.initial.bodyClass !== "ready" ||
       report.initial.stats?.adapterId !== "luminet" ||
       report.initial.stats?.starCount !== 1979 ||
@@ -284,7 +292,7 @@ function assertSmoke(report) {
       report.initial.stats?.initialSnapshotReuseCount !== 1 ||
       report.initial.stats?.initialSnapshotDomWriteCount !== 0 ||
       report.initial.stats?.runtimeSchedulerTransport !==
-        "refresh-calibrated-requestAnimationFrame-prepared-publication-at-sixty-hertz" ||
+        "wall-clock-anchored-requestAnimationFrame-prepared-publication-at-up-to-sixty-hertz" ||
       report.initial.stats?.schedulerLeadMilliseconds !== 0 ||
       report.initial.stats?.schedulerDelayRequestCount !== 0 ||
       report.initial.stats?.schedulerDelayCallbackCount !== 0 ||
@@ -316,7 +324,7 @@ function assertSmoke(report) {
       report.final.stats?.retainedMaterializedScheduleBytes > 520_000 ||
       report.final.stats?.preparedBlockWaitCount !== 0 ||
       report.final.stats?.preparedBankWaitCount !== 0 ||
-      report.final.stats?.sourceFrameDropCount !== 0 ||
+      Math.abs(measuredSourceFramesPerSecond - 60) > 2 ||
       report.final.stats?.schedulerNoopCallbackCount !== 0 ||
       report.final.stats?.runtimeDomGrowth !== false ||
       report.final.topDownVerticalMargins?.top < 23 ||


### PR DESCRIPTION
## Summary

- preserve the approved Luminet motion rate when browser animation callbacks arrive below 60 Hz
- skip unseen prepared frames instead of slowing source time or publishing wasted intermediate DOM states
- make the browser smoke assert the actual source-frame rate

## Verification

- `node --test src/adapters/blackhole/test/*.test.mjs`
- `node src/adapters/blackhole/tools/smoke-browser.mjs`
- `pnpm build:luminet`
- headless 30 Hz callback: 596 prepared source frames advanced in 10.004 seconds with unchanged 0.25 orbital scale and unchanged holds/morph duration