### PR TITLE
fix(chaos): version prepared DOM snapshot

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -136,7 +136,7 @@
     Cache-Control = "no-cache"
 
 [[headers]]
-  for = "/csschaos/snapshot.html"
+  for = "/csschaos/snapshot-*.html"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
 

--- a/site/test/landing.test.mjs
+++ b/site/test/landing.test.mjs
@@ -307,6 +307,9 @@ test("deployment serves only the current public products through the Astro shell
   assert.doesNotMatch(deployCommand, /playwright install/u);
   assert.match(deployCommand, /pnpm prepare:luminet/u);
   assert.match(deployCommand, /pnpm prepare:chaos/u);
+  assert.match(netlify,
+    /for = "\/csschaos\/snapshot-\*\.html"[\s\S]*?Cache-Control = "public, max-age=31536000, immutable"/u);
+  assert.doesNotMatch(netlify, /for = "\/csschaos\/snapshot\.html"/u);
   assert.match(deployCommand, /node scripts\/copy-deploy-products\.mjs && CSSGRAPHICS_DEPLOY_BUILD=1 pnpm build:site$/u);
   for (const [projectId] of expectedProjects) {
     const productDirectory = projectId === "pipes" ? "csspipes" :

--- a/src/adapters/dysts-lab/src/cssdysts/client.mjs
+++ b/src/adapters/dysts-lab/src/cssdysts/client.mjs
@@ -72,7 +72,7 @@ export function mountChaosClient(host) {
     state.currentIndex = state.playbackOrder[0];
     const currentDescriptor = metadata.sequence[state.currentIndex];
     const nextIndex = peekNextPlaybackIndex();
-    const snapshotPromise = fetchText(`${ASSET_ROOT}/snapshot.html`);
+    const snapshotPromise = fetchText(`${ASSET_ROOT}/${metadata.snapshot.asset}`);
     const currentPromise = loadPrepared(state.currentIndex);
     if (!singleSystem) void loadPrepared(nextIndex);
     const snapshotHtml = await snapshotPromise;
@@ -271,9 +271,13 @@ function createPreparedAssetMaterializer(state) {
 }
 
 function validateMetadata(metadata) {
-  if (metadata?.schema !== "csschaos-prepared-sequence@14" ||
+  if (metadata?.schema !== "csschaos-prepared-sequence@15" ||
       metadata.status !== "ready" || metadata.adapterId !== "chaos" ||
       metadata.starCount !== 2000 || metadata.framesPerSecond !== 60 ||
+      !/^snapshot-[a-f0-9]{64}\.html$/u.test(metadata.snapshot?.asset) ||
+      metadata.snapshot.sha256 !== metadata.snapshot.asset.slice(9, -5) ||
+      !Number.isSafeInteger(metadata.snapshot.byteLength) ||
+      metadata.snapshot.byteLength < 1 ||
       metadata.preparedRevealSeconds !== 3 ||
       metadata.preparedHandoffSeconds !== 2 ||
       metadata.preparedHoldSeconds !== 3 ||

--- a/src/adapters/dysts-lab/test/cssdysts-assets.test.mjs
+++ b/src/adapters/dysts-lab/test/cssdysts-assets.test.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { resolve } from "node:path";
 import test from "node:test";
 import { brotliDecompressSync } from "node:zlib";
@@ -12,16 +12,23 @@ const repositoryRoot = resolve(import.meta.dirname, "../../../..");
 const generatedRoot = resolve(repositoryRoot, "build/generated/public/csschaos");
 
 test("Chaos prepared bank is complete, compact, and source-locked", async () => {
-  const [prepared, snapshot, sourceLock] = await Promise.all([
+  const [prepared, sourceLock] = await Promise.all([
     readJson(resolve(generatedRoot, "prepared.json")),
-    readFile(resolve(generatedRoot, "snapshot.html"), "utf8"),
     readJson(resolve(import.meta.dirname, "../notes/references/source-lock.json")),
   ]);
-  assert.equal(prepared.schema, "csschaos-prepared-sequence@14");
+  const snapshot = await readFile(resolve(generatedRoot, prepared.snapshot.asset), "utf8");
+  assert.equal(prepared.schema, "csschaos-prepared-sequence@15");
   assert.equal(prepared.status, "ready");
   assert.equal(prepared.adapterId, "chaos");
   assert.equal(prepared.source.commit, sourceLock.upstream.commit);
   assert.equal(prepared.starCount, 2000);
+  assert.match(prepared.snapshot.asset, /^snapshot-[a-f0-9]{64}\.html$/u);
+  assert.equal(prepared.snapshot.sha256, sha256(snapshot));
+  assert.equal(prepared.snapshot.asset, `snapshot-${prepared.snapshot.sha256}.html`);
+  assert.equal(prepared.snapshot.byteLength, Buffer.byteLength(snapshot));
+  await assert.rejects(readFile(resolve(generatedRoot, "snapshot.html")), { code: "ENOENT" });
+  assert.deepEqual((await readdir(generatedRoot)).filter((name) =>
+    /^snapshot-.*\.html$/u.test(name)).sort(), [prepared.snapshot.asset]);
   assert.equal(prepared.sampleCount, 5760);
   assert.equal(prepared.sourceFrameStep, 2);
   assert.equal(prepared.source.integrationSampleCount, 2880);

--- a/src/adapters/dysts-lab/tools/audit-chaos-dot-requirements.py
+++ b/src/adapters/dysts-lab/tools/audit-chaos-dot-requirements.py
@@ -140,7 +140,7 @@ def main() -> None:
 
 
 def validate_inputs(metadata: dict, phase_audit: dict) -> None:
-    if metadata.get("schema") != "csschaos-prepared-sequence@14" or \
+    if metadata.get("schema") != "csschaos-prepared-sequence@15" or \
             metadata.get("starCount") != CURRENT_DOT_COUNT or \
             metadata.get("sampleCount") != PREPARED_SAMPLE_COUNT or \
             metadata.get("sourceFrameStep") != 2 or \

--- a/src/adapters/dysts-lab/tools/audit-chaos-motion.py
+++ b/src/adapters/dysts-lab/tools/audit-chaos-motion.py
@@ -86,7 +86,7 @@ def read_bank(bank: Path) -> tuple[dict, np.ndarray, np.ndarray, list[dict]]:
     metadata_bytes = metadata_path.read_bytes()
     metadata = json.loads(metadata_bytes)
     colors = metadata.get("leafColors", ())
-    if metadata.get("schema") != "csschaos-prepared-sequence@14" or \
+    if metadata.get("schema") != "csschaos-prepared-sequence@15" or \
             metadata.get("starCount") != POINT_COUNT or len(colors) != POINT_COUNT:
         raise RuntimeError("Motion audit requires the prepared 2,000-dot bank")
     parsed_colors = [COLOR_PATTERN.fullmatch(color) for color in colors]

--- a/src/adapters/dysts-lab/tools/audit-chaos-similarity.py
+++ b/src/adapters/dysts-lab/tools/audit-chaos-similarity.py
@@ -47,7 +47,7 @@ LAVENDER_ACCENT_STRIDE = 13
 def main() -> None:
     metadata = json.loads(METADATA_PATH.read_text())
     sequence = metadata.get("sequence", ())
-    if metadata.get("schema") != "csschaos-prepared-sequence@14" or \
+    if metadata.get("schema") != "csschaos-prepared-sequence@15" or \
             metadata.get("starCount") != POINT_COUNT or len(sequence) < 2 or \
             len(sequence) != metadata.get("audition", {}).get("candidateCount"):
         raise RuntimeError("Chaos similarity audit requires the complete prepared shortlist")

--- a/src/adapters/dysts-lab/tools/audit-chaos-spacing.py
+++ b/src/adapters/dysts-lab/tools/audit-chaos-spacing.py
@@ -105,7 +105,7 @@ def main() -> None:
 
 
 def validate_metadata(metadata: dict) -> None:
-    if metadata.get("schema") != "csschaos-prepared-sequence@14" or \
+    if metadata.get("schema") != "csschaos-prepared-sequence@15" or \
             metadata.get("starCount") != POINT_COUNT or \
             metadata.get("sampleCount") != SAMPLE_COUNT or \
             metadata.get("sourceFrameStep") != SOURCE_FRAME_STEP or \

--- a/src/adapters/dysts-lab/tools/prepare-chaos-assets.py
+++ b/src/adapters/dysts-lab/tools/prepare-chaos-assets.py
@@ -312,8 +312,11 @@ def main() -> None:
         print(f"{system_index + 1:02d}/{len(route)} {name}: {len(encoded) / 1024:.1f} KiB")
 
     leaf_colors = [format_leaf_color(index) for index in range(STAR_COUNT)]
+    snapshot_html = prepare_snapshot()
+    snapshot_sha256 = hashlib.sha256(snapshot_html.encode()).hexdigest()
+    snapshot_asset = f"snapshot-{snapshot_sha256}.html"
     metadata = {
-        "schema": "csschaos-prepared-sequence@14",
+        "schema": "csschaos-prepared-sequence@15",
         "status": "ready",
         "adapterId": "chaos",
         "title": "Chaos",
@@ -373,6 +376,11 @@ def main() -> None:
         "viewport": {"width": VIEWPORT_WIDTH, "height": VIEWPORT_HEIGHT,
                      "depth": VIEWPORT_DEPTH, "perspective": PERSPECTIVE_DISTANCE},
         "starCount": STAR_COUNT,
+        "snapshot": {
+            "asset": snapshot_asset,
+            "sha256": snapshot_sha256,
+            "byteLength": len(snapshot_html.encode()),
+        },
         "sampleCount": SAMPLE_COUNT,
         "sourceFrameStep": SOURCE_FRAME_STEP,
         "framesPerSecond": FRAMES_PER_SECOND,
@@ -421,7 +429,11 @@ def main() -> None:
     }
     (output_root / "prepared.json").write_text(
         json.dumps(metadata, separators=(",", ":")) + "\n")
-    (output_root / "snapshot.html").write_text(prepare_snapshot())
+    (output_root / "snapshot.html").unlink(missing_ok=True)
+    for stale_snapshot in output_root.glob("snapshot-*.html"):
+        if stale_snapshot.name != snapshot_asset:
+            stale_snapshot.unlink()
+    (output_root / snapshot_asset).write_text(snapshot_html)
     write_phase_distribution_audit(route, phase_distribution)
     print("route=" + " -> ".join(route))
     print(f"sequence={len(route)} advance=automatic-shuffled-handoff")

--- a/src/adapters/dysts-lab/tools/smoke-browser.mjs
+++ b/src/adapters/dysts-lab/tools/smoke-browser.mjs
@@ -192,7 +192,8 @@ function assertSmoke(report) {
       report.final.paused !== true ||
       report.final.pausedFrame !== report.final.pausedFrameAfterWait ||
       assetRequests.filter((path) => path.endsWith("prepared.json")).length !== 1 ||
-      assetRequests.filter((path) => path.endsWith("snapshot.html")).length !== 1 ||
+      assetRequests.filter((path) =>
+        /\/snapshot-[a-f0-9]{64}\.html$/u.test(path)).length !== 1 ||
       assetRequests.filter((path) => path.endsWith(".bin.br")).length < 2 ||
       report.pageErrors.length || report.consoleErrors.length || report.failedResponses.length) {
     throw new Error(`Chaos ${report.id} browser smoke failed:\n${JSON.stringify(report, null, 2)}`);


### PR DESCRIPTION
## Summary
- content-address the prepared Chaos DOM snapshot
- remove the stale unversioned snapshot from generated output
- cache only hash-named snapshots as immutable
- validate the snapshot identity in metadata, tests, and browser smoke

## Root cause
The previous release cached `/csschaos/snapshot.html` for one year while `/csschaos/prepared.json` and the client could update. Returning browsers could therefore mount an older retained DOM snapshot against the new prepared bank and fail with `Chaos prepared retained point graph is incomplete`.

## Verification
- `pnpm prepare:chaos`
- `pnpm test:chaos`
- `pnpm test:site`
- `pnpm build:deploy`
- `pnpm test:chaos:deploy` (isolated headless Chromium: desktop, mobile, and home; 2,000 leaves; zero source-frame drops)
- seeded a persistent headless Chrome profile with the currently published stale immutable `/csschaos/snapshot.html` for post-deploy returning-user verification