### PR TITLE
fix(cityflow): clean retained DOM projection

### DIFF
--- a/src/adapters/cityflow/src/csscityflow/client.mjs
+++ b/src/adapters/cityflow/src/csscityflow/client.mjs
@@ -5,10 +5,8 @@ import {
   createCityflowPreparedPlayer,
   loadCityflowPreparedPlayback,
 } from "./preparedPlayback.mjs";
-import {
-  bindCityflowSourceProjection,
-  cityflowSourceProjection,
-} from "./sourceProjection.mjs";
+import { cleanCityflowPreparedDom } from "./preparedDom.mjs";
+import { cityflowSourceProjection } from "./sourceProjection.mjs";
 import {
   CSSCITYFLOW_PREPARED_BANKS,
   selectCityflowPreparedBank,
@@ -16,12 +14,12 @@ import {
 
 export function mountCityflow(host) {
   let destroyed = false;
-  let unbindProjection = () => {};
   const state = {
     ready: false,
     errors: [],
     metadata: null,
     bankId: null,
+    dom: null,
     mounted: null,
     player: null,
   };
@@ -35,8 +33,8 @@ export function mountCityflow(host) {
     destroy() {
       if (destroyed) return;
       destroyed = true;
-      unbindProjection();
       state.player?.destroy();
+      state.dom?.destroy();
       state.mounted?.destroy();
       state.ready = false;
       if (globalThis.__csscityflow === state) delete globalThis.__csscityflow;
@@ -64,7 +62,8 @@ export function mountCityflow(host) {
     assertPreparedMetadata(metadata, playback, bankId, modelId);
     if (destroyed) return;
     const perspective = cityflowSourceProjection(host.clientWidth, host.clientHeight).perspective;
-    const mounted = mountPolyMorphModel(host, loaded.model, {
+    const stagingHost = host.ownerDocument.createElement("div");
+    const mounted = mountPolyMorphModel(stagingHost, loaded.model, {
       resources: loaded.resources,
       camera: createPolyPerspectiveCamera({
         perspective,
@@ -75,34 +74,28 @@ export function mountCityflow(host) {
         distance: -perspective,
       }),
     });
-    const shapeElements = [];
-    for (const box of loaded.model.render.shapes) {
-      const element = mounted.shapeElements.get(box.id);
-      if (!element) throw new Error(`Missing retained Cityflow box ${box.id}`);
-      element.classList.add("csscityflow-box");
-      shapeElements.push(element);
-    }
-    const player = createCityflowPreparedPlayer({ playback, mounted, shapeElements });
-    const cameraElement = host.querySelector(":scope > .polycss-camera");
-    unbindProjection = bindCityflowSourceProjection(host, cameraElement, (projection) => {
-      mounted.camera.update({ distance: -projection.perspective });
-      mounted.updateCamera();
-    });
+    const dom = cleanCityflowPreparedDom(mounted, loaded.model.render.shapes.length);
+    const player = createCityflowPreparedPlayer({ playback, dom });
+    const cameraElement = dom.cameraElement;
+    host.append(cameraElement);
     if (destroyed) {
       player.destroy();
+      dom.destroy();
       mounted.destroy();
       return;
     }
     state.metadata = metadata;
     state.bankId = bankId;
+    state.dom = dom;
     state.mounted = mounted;
     state.player = player;
+    player.resume();
     await waitForPaint();
     if (destroyed) return;
+    dom.finalizePreparedTarget();
     state.ready = true;
     document.body.classList.replace("loading", "ready");
     performance.mark("csscityflow-ready");
-    player.resume();
   }
 
   function fail(error) {

--- a/src/adapters/cityflow/src/csscityflow/preparedDom.mjs
+++ b/src/adapters/cityflow/src/csscityflow/preparedDom.mjs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: HPND
+
+const FACES_PER_BOX = 3;
+const STYLESHEET_MODEL_TRANSFORM =
+  "matrix3d(29.6, 6.484, 8.604, 0, -10.774, 17.814, 23.64, 0, 0, 25.157, -18.957, 0, -2.7, -2.7, -30, 1)";
+
+export function cleanCityflowPreparedDom(mounted, expectedBoxCount) {
+  const cameraElement = mounted?.cameraElement;
+  const sceneElement = mounted?.sceneElement;
+  const modelElement = mounted?.modelElement;
+  const shapeElements = [...(mounted?.shapeElements?.values?.() ?? [])];
+  if (!(cameraElement instanceof HTMLElement) || !(sceneElement instanceof HTMLElement) ||
+      !(modelElement instanceof HTMLElement) || !Number.isSafeInteger(expectedBoxCount) ||
+      expectedBoxCount < 1 || shapeElements.length !== expectedBoxCount ||
+      cameraElement.children.length !== 1 || cameraElement.firstElementChild !== sceneElement ||
+      sceneElement.children.length !== 1 || sceneElement.firstElementChild !== modelElement ||
+      shapeElements.some((element) => !(element instanceof HTMLElement) ||
+        element.parentElement !== modelElement || element.children.length !== FACES_PER_BOX ||
+        [...element.children].some((leaf) => leaf.localName !== "b"))) {
+    throw new Error("Cityflow prepared Morph graph cannot be cleaned safely");
+  }
+
+  const leafElements = shapeElements.map((element) => [...element.children]);
+  const modelTransform = modelElement.style.transform;
+  if (modelTransform !== STYLESHEET_MODEL_TRANSFORM) {
+    throw new Error("Cityflow stylesheet-owned model transform drifted");
+  }
+
+  cameraElement.className = "polycss-camera";
+  cleanCameraMetadata();
+  cameraElement.style.removeProperty("perspective");
+  sceneElement.className = "polycss-scene";
+  sceneElement.removeAttribute("aria-hidden");
+  sceneElement.style.removeProperty("transform");
+  removeEmptyRootStyleAttributes();
+
+  for (const element of shapeElements) {
+    element.removeAttribute("class");
+    element.removeAttribute("data-poly-morph-shape");
+  }
+  for (const leaves of leafElements) {
+    for (const leaf of leaves) {
+      leaf.removeAttribute("class");
+      leaf.removeAttribute("data-poly-morph-leaf");
+      leaf.removeAttribute("data-poly-morph-strategy");
+      leaf.removeAttribute("data-poly-morph-resolved-strategy");
+      leaf.style.removeProperty("backface-visibility");
+      leaf.style.removeProperty("background-repeat");
+      leaf.style.removeProperty("color");
+      leaf.style.removeProperty("height");
+      leaf.style.removeProperty("opacity");
+      leaf.style.removeProperty("transform-origin");
+      leaf.style.removeProperty("visibility");
+      leaf.style.removeProperty("width");
+    }
+  }
+
+  for (const element of shapeElements) sceneElement.append(element);
+  if (modelElement.childElementCount !== 0) {
+    throw new Error("Cityflow prepared model wrapper contains unexpected retained nodes");
+  }
+  modelElement.remove();
+
+  const stableNodes = Object.freeze([
+    cameraElement,
+    sceneElement,
+    ...shapeElements,
+    ...leafElements.flat(),
+  ]);
+  let runtimeDomCreationCount = 0;
+  let runtimeDomRemovalCount = 0;
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      runtimeDomCreationCount += record.addedNodes.length;
+      runtimeDomRemovalCount += record.removedNodes.length;
+    }
+  });
+  observer.observe(cameraElement, { childList: true, subtree: true });
+
+  function cleanCameraMetadata() {
+    cameraElement.removeAttribute("data-polycss-camera-projection");
+    cameraElement.removeAttribute("data-polycss-camera-perspective");
+  }
+
+  function removeEmptyRootStyleAttributes() {
+    if (cameraElement.style.length !== 0 || sceneElement.style.length !== 0) {
+      throw new Error("Cityflow prepared roots contain unexpected inline presentation");
+    }
+    cameraElement.removeAttribute("style");
+    sceneElement.removeAttribute("style");
+  }
+
+  function assertStableDomIdentity() {
+    const currentNodes = [
+      cameraElement,
+      sceneElement,
+      ...sceneElement.children,
+      ...shapeElements.flatMap((element) => [...element.children]),
+    ];
+    if (cameraElement.children.length !== 1 || cameraElement.firstElementChild !== sceneElement ||
+        sceneElement.children.length !== shapeElements.length ||
+        shapeElements.some((element, index) =>
+          sceneElement.children[index] !== element || element.children.length !== FACES_PER_BOX) ||
+        currentNodes.length !== stableNodes.length ||
+        currentNodes.some((node, index) => node !== stableNodes[index])) {
+      throw new Error("Cityflow cleaned retained DOM identity changed");
+    }
+    return true;
+  }
+
+  return Object.freeze({
+    cameraElement,
+    sceneElement,
+    shapeElements: Object.freeze(shapeElements),
+    leafElements: Object.freeze(leafElements.map((leaves) => Object.freeze(leaves))),
+    modelTransform,
+    finalizePreparedTarget() {
+      removeEmptyRootStyleAttributes();
+      return assertStableDomIdentity();
+    },
+    assertStableDomIdentity,
+    stats() {
+      assertStableDomIdentity();
+      const renderNodes = stableNodes;
+      return Object.freeze({
+        retainedCameraRootCount: 1,
+        retainedSceneRootCount: 1,
+        retainedModelRootCount: 0,
+        retainedBoxRootCount: shapeElements.length,
+        retainedFaceLeafCount: leafElements.length * FACES_PER_BOX,
+        retainedDomClassAttributeCount:
+          renderNodes.filter((element) => element.hasAttribute("class")).length,
+        retainedDomDataAttributeCount: renderNodes.reduce((count, element) => count +
+          [...element.attributes].filter(({ name }) => name.startsWith("data-")).length, 0),
+        retainedDomAriaAttributeCount: renderNodes.reduce((count, element) => count +
+          [...element.attributes].filter(({ name }) => name.startsWith("aria-")).length, 0),
+        retainedCameraInlineStyleAttributeCount: cameraElement.hasAttribute("style") ? 1 : 0,
+        retainedSceneInlineStyleAttributeCount: sceneElement.hasAttribute("style") ? 1 : 0,
+        retainedSceneInlineTransformCount: sceneElement.style.transform === "" ? 0 : 1,
+        retainedBackfaceInlineStyleCount: leafElements.flat().filter((leaf) =>
+          leaf.style.backfaceVisibility !== "" ||
+          leaf.style.webkitBackfaceVisibility !== "").length,
+        runtimeDomCreationCount,
+        runtimeDomRemovalCount,
+        runtimeDomMutationCount: runtimeDomCreationCount + runtimeDomRemovalCount,
+        runtimeDomGrowth: false,
+      });
+    },
+    destroy() {
+      observer.disconnect();
+    },
+  });
+}

--- a/src/adapters/cityflow/src/csscityflow/preparedPlayback.mjs
+++ b/src/adapters/cityflow/src/csscityflow/preparedPlayback.mjs
@@ -8,11 +8,11 @@ const decodedPackets = new WeakMap();
 
 export function createCityflowPreparedPlayer({
   playback,
-  mounted,
-  shapeElements,
+  dom,
   ...overrides
 }) {
-  const decoded = validatePlayback(playback, mounted, shapeElements);
+  const decoded = validatePlayback(playback, dom);
+  const shapeElements = dom.shapeElements;
   const frameCount = playback.frameCount;
   const boxCount = playback.boxCount;
   const facesPerBox = playback.facesPerBox;
@@ -33,12 +33,8 @@ export function createCityflowPreparedPlayer({
   const materials = playback.colors.materials;
   const target = createPolyMorphPreparedDomTarget({
     model: {
-      element: mounted.modelElement,
-      writeTransform(transform) {
-        if (mounted.modelElement.style.transform === transform) return false;
-        mounted.modelElement.style.transform = transform;
-        return true;
-      },
+      element: dom.sceneElement,
+      writeTransform() { return false; },
     },
     shapes: shapeElements.map((element) => ({ element })),
     leaves: [],
@@ -249,7 +245,8 @@ export function createCityflowPreparedPlayer({
   function snapshot() {
     const schedulerStats = scheduler.stats();
     target.assertStableDomIdentity();
-    mounted.assertStableDomIdentity();
+    dom.assertStableDomIdentity();
+    const domStats = dom.stats();
     return Object.freeze({
       schema: "csscityflow-prepared-player-stats@7",
       ready: true,
@@ -330,6 +327,15 @@ export function createCityflowPreparedPlayer({
       identityStable: true,
       runtimeGeometryCalculationCount: 0,
       runtimeAtlasRasterizationCount: 0,
+      retainedModelRootCount: domStats.retainedModelRootCount,
+      retainedDomClassAttributeCount: domStats.retainedDomClassAttributeCount,
+      retainedDomDataAttributeCount: domStats.retainedDomDataAttributeCount,
+      retainedDomAriaAttributeCount: domStats.retainedDomAriaAttributeCount,
+      retainedCameraInlineStyleAttributeCount: domStats.retainedCameraInlineStyleAttributeCount,
+      retainedSceneInlineStyleAttributeCount: domStats.retainedSceneInlineStyleAttributeCount,
+      retainedSceneInlineTransformCount: domStats.retainedSceneInlineTransformCount,
+      retainedBackfaceInlineStyleCount: domStats.retainedBackfaceInlineStyleCount,
+      runtimeDomMutationCount: domStats.runtimeDomMutationCount,
       runtimeDomGrowth: false,
     });
   }
@@ -381,7 +387,7 @@ export function createCityflowPreparedPlayer({
     },
     assertStableDomIdentity() {
       target.assertStableDomIdentity();
-      mounted.assertStableDomIdentity();
+      dom.assertStableDomIdentity();
       return true;
     },
     stats: snapshot,
@@ -400,11 +406,12 @@ export async function loadCityflowPreparedPlayback(url, fetchImpl = globalThis.f
   return playback;
 }
 
-function validatePlayback(playback, mounted, shapeElements) {
+function validatePlayback(playback, dom) {
   const decoded = validatePacket(playback);
-  if (!mounted?.modelElement || typeof mounted.assertStableDomIdentity !== "function" ||
-      !Array.isArray(shapeElements) || shapeElements.length !== playback.boxCount ||
-      shapeElements.some((element) => !(element instanceof HTMLElement))) {
+  if (!(dom?.sceneElement instanceof HTMLElement) ||
+      typeof dom.assertStableDomIdentity !== "function" ||
+      !Array.isArray(dom.shapeElements) || dom.shapeElements.length !== playback.boxCount ||
+      dom.shapeElements.some((element) => !(element instanceof HTMLElement))) {
     throw new Error("Cityflow retained playback targets drifted");
   }
   return decoded;

--- a/src/adapters/cityflow/src/csscityflow/sourceProjection.mjs
+++ b/src/adapters/cityflow/src/csscityflow/sourceProjection.mjs
@@ -15,20 +15,3 @@ export function cityflowSourceProjection(width, height) {
     usesWideSourceViewport,
   });
 }
-
-export function bindCityflowSourceProjection(host, cameraElement, onProjection = () => {}) {
-  if (!(host instanceof HTMLElement) || !(cameraElement instanceof HTMLElement)) {
-    throw new TypeError("Cityflow projection binding requires retained host and camera elements");
-  }
-  const apply = () => {
-    const projection = cityflowSourceProjection(host.clientWidth, host.clientHeight);
-    cameraElement.style.setProperty("--csscityflow-camera-height", `${projection.viewportHeight}px`);
-    cameraElement.style.setProperty("--csscityflow-camera-top", `${projection.viewportTop}px`);
-    cameraElement.style.setProperty("--csscityflow-perspective", `${projection.perspective}px`);
-    onProjection(projection);
-  };
-  apply();
-  const observer = new ResizeObserver(apply);
-  observer.observe(host);
-  return () => observer.disconnect();
-}

--- a/src/adapters/cityflow/src/csscityflow/styles.css
+++ b/src/adapters/cityflow/src/csscityflow/styles.css
@@ -25,6 +25,7 @@ body {
 }
 
 .example-stage {
+  container-type: size;
   overflow: hidden;
   background: #000;
 }
@@ -32,19 +33,38 @@ body {
 .example-stage > .polycss-camera {
   position: absolute;
   inset: auto 0 auto 0;
-  top: var(--csscityflow-camera-top, 0px);
+  top: 0;
   width: 100%;
-  height: var(--csscityflow-camera-height, 100%);
+  height: 100cqh;
   overflow: hidden;
   contain: layout paint size style;
-  perspective: var(--csscityflow-perspective) !important;
+  perspective: 186.60254037844388cqh !important;
   perspective-origin: 50% 50%;
 }
 
-.polycss-mesh {
+.example-stage > .polycss-camera > .polycss-scene,
+.example-stage > .polycss-camera > .polycss-scene > div {
   position: absolute;
   transform-style: preserve-3d;
   transform-origin: 0 0 0;
+}
+
+.example-stage > .polycss-camera > .polycss-scene {
+  transform: translateZ(186.60254037844388cqh)
+    matrix3d(29.6, 6.484, 8.604, 0, -10.774, 17.814, 23.64, 0, 0, 25.157, -18.957, 0, -2.7, -2.7, -30, 1);
+}
+
+@container (min-aspect-ratio: 2 / 1) {
+  .example-stage > .polycss-camera {
+    top: calc(100cqh - 50cqw);
+    height: 100cqw;
+    perspective: 186.60254037844388cqw !important;
+  }
+
+  .example-stage > .polycss-camera > .polycss-scene {
+    transform: translateZ(186.60254037844388cqw)
+      matrix3d(29.6, 6.484, 8.604, 0, -10.774, 17.814, 23.64, 0, 0, 25.157, -18.957, 0, -2.7, -2.7, -30, 1);
+  }
 }
 
 body.loading .example-stage > .polycss-camera {

--- a/src/adapters/cityflow/src/prepare/csscityflow/model.mjs
+++ b/src/adapters/cityflow/src/prepare/csscityflow/model.mjs
@@ -209,8 +209,11 @@ function rotateZ([x, y, z], degrees) {
 export function buildCityflowPreparedCss(state) {
   return [
     `:root{--csscityflow-background:${paletteColor(state.palette[0])}}`,
-    `.csscityflow-box>b{display:block!important;backface-visibility:hidden}`,
-    `.csscityflow-box>b:nth-child(1){backface-visibility:visible}`,
+    `.polycss-scene>div>b{position:absolute;display:block!important;width:1px;height:1px;` +
+      `margin:0;padding:0;border:0;transform-style:preserve-3d;transform-origin:0 0;` +
+      `backface-visibility:hidden;-webkit-backface-visibility:hidden}`,
+    `.polycss-scene>div>b:nth-child(1){backface-visibility:visible;` +
+      `-webkit-backface-visibility:visible}`,
   ].join("");
 }
 

--- a/src/adapters/cityflow/test/csscityflow-model.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-model.test.mjs
@@ -197,7 +197,10 @@ test("prepares DOMFORMAT-precedented exact states and C2 reconstructed presentat
   assert.doesNotMatch(css, /::before/u);
   assert.doesNotMatch(css, /attr\(|::after/u);
   assert.doesNotMatch(css, /--z|@property/u);
-  assert.doesNotMatch(css, /\.csscityflow-box[^}]*transform:/u);
+  assert.match(css, /\.polycss-scene>div>b\{[^}]*width:1px;[^}]*height:1px;/u);
+  assert.match(css, /\.polycss-scene>div>b\{[^}]*backface-visibility:hidden;/u);
+  assert.match(css, /\.polycss-scene>div>b:nth-child\(1\)\{backface-visibility:visible;/u);
+  assert.doesNotMatch(css, /csscityflow-box/u);
   assert.equal((css.match(/hypot\(/gu) ?? []).length, 0);
   assert.doesNotMatch(css, /filter|clip-path|mask|linear-gradient|radial-gradient/u);
 

--- a/src/adapters/cityflow/test/csscityflow-runtime-surface.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-runtime-surface.test.mjs
@@ -5,8 +5,9 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 test("publishes every prepared box automatically with a fixed source camera", async () => {
-  const [client, player, profileSelection, projection, styles, scheduler, tracePerformance] = await Promise.all([
+  const [client, dom, player, profileSelection, projection, styles, scheduler, tracePerformance] = await Promise.all([
     readFile(new URL("../src/csscityflow/client.mjs", import.meta.url), "utf8"),
+    readFile(new URL("../src/csscityflow/preparedDom.mjs", import.meta.url), "utf8"),
     readFile(new URL("../src/csscityflow/preparedPlayback.mjs", import.meta.url), "utf8"),
     readFile(new URL("../src/csscityflow/profileSelection.mjs", import.meta.url), "utf8"),
     readFile(new URL("../src/csscityflow/sourceProjection.mjs", import.meta.url), "utf8"),
@@ -15,6 +16,25 @@ test("publishes every prepared box automatically with a fixed source camera", as
     readFile(new URL("../tools/trace-performance.mjs", import.meta.url), "utf8"),
   ]);
   assert.match(client, /mountPolyMorphModel/u);
+  assert.match(client, /const stagingHost = host\.ownerDocument\.createElement\("div"\)/u);
+  assert.match(client, /mountPolyMorphModel\(stagingHost,/u);
+  assert.match(client, /host\.append\(cameraElement\)/u);
+  assert.match(client, /cleanCityflowPreparedDom/u);
+  assert.match(client, /createCityflowPreparedPlayer\(\{ playback, dom \}\)/u);
+  assert.doesNotMatch(client, /classList\.add\("csscityflow-box"\)/u);
+  assert.match(dom, /modelElement\.remove\(\)/u);
+  assert.match(dom, /cameraElement\.className = "polycss-camera"/u);
+  assert.match(dom, /sceneElement\.className = "polycss-scene"/u);
+  assert.match(dom, /element\.removeAttribute\("data-poly-morph-shape"\)/u);
+  assert.match(dom, /leaf\.removeAttribute\("data-poly-morph-leaf"\)/u);
+  assert.match(dom, /leaf\.style\.removeProperty\("backface-visibility"\)/u);
+  assert.match(dom, /leaf\.style\.removeProperty\("width"\)/u);
+  assert.match(dom, /retainedModelRootCount:\s*0/u);
+  assert.match(dom, /retainedDomAriaAttributeCount/u);
+  assert.match(dom, /retainedCameraInlineStyleAttributeCount/u);
+  assert.match(dom, /retainedSceneInlineStyleAttributeCount/u);
+  assert.match(dom, /retainedSceneInlineTransformCount/u);
+  assert.match(dom, /runtimeDomMutationCount/u);
   assert.match(client, /selectCityflowPreparedBank/u);
   assert.ok(client.indexOf("selectCityflowPreparedBank({") <
     client.indexOf("await Promise.all(["), "prepared bank selection must precede all bank fetches");
@@ -26,21 +46,30 @@ test("publishes every prepared box automatically with a fixed source camera", as
     /addEventListener\([^\n]*resize[^\n]*selectCityflowPreparedBank/u);
   assert.match(profileSelection, /width < CSSCITYFLOW_MOBILE_BREAKPOINT_WIDTH/u);
   assert.match(profileSelection, /\(hover: none\) and \(pointer: coarse\)/u);
-  assert.match(client, /bindCityflowSourceProjection/u);
+  assert.doesNotMatch(client, /bindCityflowSourceProjection|ResizeObserver|style\.setProperty/u);
   assert.match(client, /resume\(\)\s*\{\s*if \(!destroyed\) return state\.player\?\.resume\(\)/u);
-  assert.match(client, /performance\.mark\("csscityflow-ready"\);\s*player\.resume\(\)/u);
+  assert.match(client,
+    /player\.resume\(\);\s*await waitForPaint\(\);[\s\S]*dom\.finalizePreparedTarget\(\);[\s\S]*performance\.mark\("csscityflow-ready"\)/u);
   assert.doesNotMatch(client, /orbitControls|bindCityflowOrbitControls|state\.orbit|animationFrozen/u);
-  assert.match(client, /mounted\.camera\.update\(\{ distance: -projection\.perspective \}\)/u);
+  assert.doesNotMatch(client, /mounted\.updateCamera\(\)/u);
+  assert.match(dom, /sceneElement\.removeAttribute\("aria-hidden"\)/u);
+  assert.match(dom, /sceneElement\.style\.removeProperty\("transform"\)/u);
+  assert.match(dom, /cameraElement\.removeAttribute\("style"\)/u);
+  assert.match(dom, /sceneElement\.removeAttribute\("style"\)/u);
+  assert.match(client, /dom\.finalizePreparedTarget\(\)/u);
+  assert.match(dom, /stylesheet-owned model transform drifted/u);
+  assert.match(styles, /container-type:\s*size/u);
+  assert.match(styles, /perspective:\s*186\.60254037844388cqh/u);
+  assert.match(styles, /transform: translateZ\(186\.60254037844388cqh\)[\s\S]*matrix3d\(/u);
+  assert.match(styles, /@container \(min-aspect-ratio:\s*2 \/ 1\)/u);
+  assert.match(styles, /top:\s*calc\(100cqh - 50cqw\)/u);
+  assert.match(styles, /perspective:\s*186\.60254037844388cqw/u);
   assert.match(client, /rotX:\s*0,\s*rotY:\s*0,\s*zoom:\s*50,/u);
   assert.match(projection, /width > height \* 2/u);
   assert.match(projection, /height - viewportHeight \/ 2/u);
-  assert.match(projection, /ResizeObserver/u);
-  assert.match(styles, /--csscityflow-camera-top/u);
-  assert.match(styles, /--csscityflow-camera-height/u);
-  assert.match(styles, /--csscityflow-perspective/u);
+  assert.doesNotMatch(`${client}\n${projection}\n${styles}`, /--csscityflow-camera-|ResizeObserver/u);
   assert.doesNotMatch(styles,
     /data-csscityflow-(?:orbit|dragging)|cursor:\s*(?:grab|grabbing)|touch-action|pointer-events:\s*auto|transform-origin:\s*0 0 -30px/u);
-  assert.doesNotMatch(styles, /\.polycss-scene\s*\{[^}]*transform:/su);
   assert.match(player, /domformat@0\/polycss-playback@0@cc8da736/u);
   assert.match(player,
     /shapeElements\[boxIndex\]\.style\.transform\s*=\s*[\s\S]*transforms\[transformOffsets\[boxIndex\] \+ transformIndex\]/u);
@@ -98,6 +127,7 @@ test("publishes every prepared box automatically with a fixed source camera", as
   assert.doesNotMatch(tracePerformance, /color-mix|data-csscityflow-|PERF_EXPERIMENT/u);
   assert.doesNotMatch(tracePerformance, /presentationCadenceP95: draw\.p95Ms/u);
   assert.doesNotMatch(`${client}\n${player}\n${scheduler}`, /setTimeout|setInterval|canvas|getContext/u);
+  assert.doesNotMatch(`${client}\n${dom}\n${player}`, /csscityflow-box/u);
 });
 
 test("owns project 12 and the shared css.graphics route shell", async () => {

--- a/src/adapters/cityflow/tools/audit-sparse-color-publication.mjs
+++ b/src/adapters/cityflow/tools/audit-sparse-color-publication.mjs
@@ -70,7 +70,7 @@ async function auditViewport(viewport) {
         reference.evaluate((index) => {
           const state = globalThis.__csscityflowFullColorReference;
           globalThis.__csscityflow.player.seekFrame(index);
-          const roots = document.querySelectorAll(".csscityflow-box");
+          const roots = document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div");
           for (let boxIndex = 0; boxIndex < state.playback.boxCount; boxIndex += 1) {
             const material = state.playback.colors.materials[
               state.materialIndices[index * state.playback.boxCount + boxIndex]

--- a/src/adapters/cityflow/tools/oracle/ablate-visibility-diff-faces.mjs
+++ b/src/adapters/cityflow/tools/oracle/ablate-visibility-diff-faces.mjs
@@ -39,7 +39,7 @@ try {
     };
     const transformIndices = decodeUint16(playback.transformIndices.presentationBase64);
     const materialIndices = decodeUint16(playback.colors.presentationMaterialIndicesBase64);
-    const roots = [...document.querySelectorAll(".csscityflow-box")];
+    const roots = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")];
     const leaves = roots.flatMap((root) => [...root.children]);
     for (let boxIndex = 0; boxIndex < playback.boxCount; boxIndex += 1) {
       roots[boxIndex].style.transform = player.preparedTransformAt(
@@ -71,7 +71,7 @@ try {
   const ranked = [];
   for (const faceIndex of hiddenFaceIndices) {
     await page.evaluate((nextFaceIndex) => {
-      document.querySelectorAll(".csscityflow-box>b")[nextFaceIndex]
+      document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b")[nextFaceIndex]
         .style.visibility = "";
     }, faceIndex);
     const restoredDiff = diff(reference, await rawRgb(await page.screenshot()));
@@ -82,7 +82,7 @@ try {
       maximumChannelDelta: restoredDiff.maximumChannelDelta,
     });
     await page.evaluate((nextFaceIndex) => {
-      document.querySelectorAll(".csscityflow-box>b")[nextFaceIndex]
+      document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b")[nextFaceIndex]
         .style.visibility = "hidden";
     }, faceIndex);
   }

--- a/src/adapters/cityflow/tools/oracle/audit-static-suppression.mjs
+++ b/src/adapters/cityflow/tools/oracle/audit-static-suppression.mjs
@@ -50,7 +50,7 @@ try {
     await page.evaluate((nextFrameIndex) => {
       const { playback, transformIndices, materialIndices } = globalThis.__csscityflowStaticAudit;
       globalThis.__csscityflow.player.seekFrame(nextFrameIndex);
-      const roots = [...document.querySelectorAll(".csscityflow-box")];
+      const roots = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")];
       for (const boxIndex of playback.staticVisibility.hiddenBoxIndices) {
         const root = roots[boxIndex];
         root.style.setProperty("display", "block", "important");
@@ -74,12 +74,12 @@ try {
     )).removeAlpha().raw().toBuffer();
     for (const boxIndex of hiddenBoxIndices) {
       await page.evaluate((nextBoxIndex) => {
-        document.querySelectorAll(".csscityflow-box")[nextBoxIndex]
+        document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")[nextBoxIndex]
           .style.setProperty("display", "none", "important");
       }, boxIndex);
       const candidate = await sharp(await page.screenshot()).removeAlpha().raw().toBuffer();
       await page.evaluate((nextBoxIndex) => {
-        document.querySelectorAll(".csscityflow-box")[nextBoxIndex]
+        document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")[nextBoxIndex]
           .style.setProperty("display", "block", "important");
       }, boxIndex);
       let changedPixelCount = 0;

--- a/src/adapters/cityflow/tools/oracle/capture-motion-face-audit.mjs
+++ b/src/adapters/cityflow/tools/oracle/capture-motion-face-audit.mjs
@@ -122,7 +122,7 @@ async function captureLiveVideo(browserHandle) {
     return {
       durationMilliseconds,
       callbackCount: samples.length,
-      transformAnimationCount: [...document.querySelectorAll(".csscityflow-box")].reduce(
+      transformAnimationCount: [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")].reduce(
         (sum, root) => sum + root.getAnimations().length,
         0,
       ),
@@ -428,15 +428,15 @@ async function openReadyScene(page) {
 async function installGeometryAuditStyles(page, unculled) {
   await page.addStyleTag({ content: `
     :root, body, .example-stage { background: #000 !important; }
-    .csscityflow-box > b:first-child,
-    .csscityflow-box::before,
-    .csscityflow-box::after,
-    .csscityflow-box.csscityflow-side-1-hidden::before,
-    .csscityflow-box.csscityflow-side-2-hidden::after {
+    .example-stage>.polycss-camera>.polycss-scene>div>b:first-child,
+    .example-stage>.polycss-camera>.polycss-scene>div::before,
+    .example-stage>.polycss-camera>.polycss-scene>div::after,
+    .example-stage>.polycss-camera>.polycss-scene>div.csscityflow-side-1-hidden::before,
+    .example-stage>.polycss-camera>.polycss-scene>div.csscityflow-side-2-hidden::after {
       background: #fff !important;
       ${unculled ? "visibility: visible !important;" : ""}
     }
-    .csscityflow-box > b {
+    .example-stage>.polycss-camera>.polycss-scene>div>b {
       ${unculled ? "visibility: visible !important;" : ""}
     }
   ` });
@@ -448,7 +448,7 @@ async function setAuditTime(page, presentationTimeMilliseconds, publishAllShapes
     const stats = player.seekPresentationTime(nextPresentationTime);
     if (!publishAll) return;
     const playback = globalThis.__csscityflowAuditPlayback;
-    const boxes = [...document.querySelectorAll(".csscityflow-box")];
+    const boxes = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")];
     if (playback?.presentationShapeStyles?.length !== stats.frameCount * stats.boxCount ||
         boxes.length !== stats.boxCount) {
       throw new Error("Cityflow unculled audit playback binding drifted");

--- a/src/adapters/cityflow/tools/oracle/capture-presentation-sequence.mjs
+++ b/src/adapters/cityflow/tools/oracle/capture-presentation-sequence.mjs
@@ -54,7 +54,7 @@ try {
         const { playback, transformIndices, materialIndices } =
           globalThis.__csscityflowUnculledCapture;
         const frameIndex = index % playback.frameCount;
-        const roots = [...document.querySelectorAll(".csscityflow-box")];
+        const roots = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")];
         for (let boxIndex = 0; boxIndex < playback.boxCount; boxIndex += 1) {
           const root = roots[boxIndex];
           root.style.setProperty("display", "block", "important");
@@ -78,8 +78,8 @@ try {
   }
   const audit = await page.evaluate(() => ({
     player: globalThis.__csscityflow.player.stats(),
-    roots: document.querySelectorAll(".csscityflow-box").length,
-    leaves: document.querySelectorAll(".csscityflow-box>b").length,
+    roots: document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div").length,
+    leaves: document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b").length,
   }));
   if (errors.length) throw new Error(`Cityflow presentation capture failed: ${JSON.stringify(errors)}`);
   const report = {

--- a/src/adapters/cityflow/tools/oracle/discover-browser-visible-faces.mjs
+++ b/src/adapters/cityflow/tools/oracle/discover-browser-visible-faces.mjs
@@ -28,7 +28,7 @@ try {
     const response = await fetch("/csscityflow/cityflow.playback.json", { cache: "no-store" });
     if (!response.ok) throw new Error(`Cityflow face-ID playback failed: ${response.status}`);
     const playback = await response.json();
-    const boxes = [...document.querySelectorAll(".csscityflow-box")];
+    const boxes = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")];
     const leaves = boxes.flatMap((box) => [...box.children]);
     if (boxes.length !== playback.boxCount || leaves.length !== playback.boxCount * playback.facesPerBox) {
       throw new Error("Cityflow face-ID retained binding drifted");
@@ -55,7 +55,7 @@ try {
   for (let frameIndex = 0; frameIndex < setup.frameCount; frameIndex += 1) {
     await page.evaluate((nextFrameIndex) => {
       globalThis.__csscityflow.player.seekFrame(nextFrameIndex);
-      const leaves = [...document.querySelectorAll(".csscityflow-box > b")];
+      const leaves = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b")];
       leaves.forEach((leaf, faceIndex) => {
         const [red, green, blue] = globalThis.__csscityflowFaceIdColors[faceIndex];
         leaf.style.setProperty("display", "block", "important");

--- a/src/adapters/cityflow/tools/oracle/identify-culled-diff-faces.mjs
+++ b/src/adapters/cityflow/tools/oracle/identify-culled-diff-faces.mjs
@@ -41,7 +41,7 @@ try {
   await page.addStyleTag({ content: `
     .examples-sidebar, .example-info { display: none !important; }
     .example-stage { position: fixed !important; inset: 0 !important; }
-    .csscityflow-box>b { pointer-events: auto !important; }
+    .example-stage>.polycss-camera>.polycss-scene>div>b { pointer-events: auto !important; }
   ` });
   const hits = await page.evaluate(async ({ frameIndex: nextFrameIndex, samples: points }) => {
     const player = globalThis.__csscityflow.player;
@@ -56,7 +56,7 @@ try {
         view.getUint16(index * 2, true));
     };
     const transformIndices = decodeUint16(playback.transformIndices.presentationBase64);
-    const roots = [...document.querySelectorAll(".csscityflow-box")];
+    const roots = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")];
     const leaves = roots.flatMap((root) => [...root.children]);
     for (let boxIndex = 0; boxIndex < playback.boxCount; boxIndex += 1) {
       roots[boxIndex].style.transform = player.preparedTransformAt(
@@ -68,7 +68,7 @@ try {
     return points.map((point) => ({
       ...point,
       hits: document.elementsFromPoint(point.x, point.y)
-        .filter((element) => element.matches?.(".csscityflow-box>b"))
+        .filter((element) => element.matches?.(".example-stage>.polycss-camera>.polycss-scene>div>b"))
         .map((element) => ({
           faceIndex: leaves.indexOf(element),
           opacity: getComputedStyle(element).opacity,

--- a/src/adapters/cityflow/tools/oracle/run-visual-oracle.mjs
+++ b/src/adapters/cityflow/tools/oracle/run-visual-oracle.mjs
@@ -228,8 +228,8 @@ async function captureBrowserRun(browser, url, runRoot) {
       .example-stage { position: fixed !important; inset: 0 !important; }
     ` });
     const initial = await page.evaluate(async () => {
-      const roots = [...document.querySelectorAll(".csscityflow-box")];
-      const leaves = [...document.querySelectorAll(".csscityflow-box>b")];
+      const roots = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")];
+      const leaves = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b")];
       globalThis.__csscityflowOracleIdentity = { roots, leaves };
       globalThis.__csscityflow.player.pause();
       globalThis.__csscityflow.player.seekSourceFrame(1);
@@ -257,8 +257,8 @@ async function captureBrowserRun(browser, url, runRoot) {
     }
     const audit = await page.evaluate(() => {
       const expected = globalThis.__csscityflowOracleIdentity;
-      const roots = [...document.querySelectorAll(".csscityflow-box")];
-      const leaves = [...document.querySelectorAll(".csscityflow-box>b")];
+      const roots = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")];
+      const leaves = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b")];
       return {
         stableRootIdentity: roots.every((element, index) => element === expected.roots[index]),
         stableLeafIdentity: leaves.every((element, index) => element === expected.leaves[index]),

--- a/src/adapters/cityflow/tools/smoke-browser.mjs
+++ b/src/adapters/cityflow/tools/smoke-browser.mjs
@@ -47,6 +47,14 @@ try {
     maximumShapeWrites: 187, maximumColorWrites: 271,
     sideDepthMaximum: 0.28, sideDepthOverrides: 19, url: route,
   });
+  const wide = await capture({
+    profile: "wide", width: 3200, height: 900, bankId: "desktop", modelId: "cityflow",
+    boxes: 200, leaves: 600, visibleBoxRange: [166, 187], visibleFaceRange: [498, 561],
+    initialVisibleBoxes: 170, initialVisibleFaces: 510, initialVisibilityWrites: 90,
+    staticSuppressedBoxes: 5, staticSuppressedFaces: 15,
+    maximumShapeWrites: 187, maximumColorWrites: 271,
+    sideDepthMaximum: 0.28, sideDepthOverrides: 19, url: route,
+  });
   const mobile = await capture({
     profile: "mobile", width: 390, height: 844, bankId: "mobile", modelId: "cityflow-mobile",
     boxes: 100, leaves: 300, visibleBoxRange: [100, 100], visibleFaceRange: [300, 300],
@@ -56,7 +64,7 @@ try {
     sideDepthDefault: 0.28, sideDepthMaximum: 0.28, sideDepthOverrides: 0, url: route,
   });
   const home = deploy ? await captureHome({ width: 1280, height: 720, url: `${origin}/` }) : null;
-  const report = { schema: "csscityflow-browser-smoke@3", route, deploy, desktop, mobile, home };
+  const report = { schema: "csscityflow-browser-smoke@4", route, deploy, desktop, wide, mobile, home };
   await writeFile(resolve(outputRoot, "report.json"), `${JSON.stringify(report, null, 2)}\n`);
   console.log(JSON.stringify(report, null, 2));
 } finally {
@@ -112,10 +120,25 @@ async function capture({
     globalThis.__csscityflow?.errors?.length, null, { timeout: 30_000 });
   const before = await page.evaluate(() => {
     const state = globalThis.__csscityflow;
-    const shapes = [...document.querySelectorAll(".csscityflow-box")];
-    const leaves = [...document.querySelectorAll(".csscityflow-box > b")];
+    const shapes = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")];
+    const leaves = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b")];
+    const camera = document.querySelector(".example-stage>.polycss-camera");
+    const stage = document.querySelector(".example-stage");
+    const renderNodes = camera ? [camera, ...camera.querySelectorAll("*")] : [];
+    const stageBounds = stage?.getBoundingClientRect();
+    const cameraStyle = camera ? getComputedStyle(camera) : null;
+    const wideProjection = stageBounds ? stageBounds.width > stageBounds.height * 2 : false;
+    const expectedCameraHeight = stageBounds ?
+      (wideProjection ? stageBounds.width : stageBounds.height) : null;
+    const expectedCameraTop = stageBounds ?
+      (wideProjection ? stageBounds.height - stageBounds.width / 2 : 0) : null;
+    const expectedPerspective = expectedCameraHeight === null ? null :
+      expectedCameraHeight / (2 * Math.tan(Math.PI / 12));
+    const actualCameraHeight = cameraStyle ? Number.parseFloat(cameraStyle.height) : null;
+    const actualCameraTop = cameraStyle ? Number.parseFloat(cameraStyle.top) : null;
+    const actualPerspective = cameraStyle ? Number.parseFloat(cameraStyle.perspective) : null;
     let stable = true;
-    try { state?.mounted?.assertStableDomIdentity(); } catch { stable = false; }
+    try { state?.dom?.assertStableDomIdentity(); } catch { stable = false; }
     return {
       status: document.body.className,
       canonical: document.querySelector('link[rel="canonical"]')?.href ?? null,
@@ -125,6 +148,43 @@ async function capture({
       stable,
       shapeCount: shapes.length,
       leafCount: leaves.length,
+      renderNodeCount: renderNodes.length,
+      classAttributeCount: renderNodes.filter((element) => element.hasAttribute("class")).length,
+      dataAttributeCount: renderNodes.reduce((count, element) => count +
+        [...element.attributes].filter(({ name }) => name.startsWith("data-")).length, 0),
+      ariaAttributeCount: renderNodes.reduce((count, element) => count +
+        [...element.attributes].filter(({ name }) => name.startsWith("aria-")).length, 0),
+      cameraInlineStyleAttributeCount: camera?.hasAttribute("style") ? 1 : 0,
+      cameraInlineCustomPropertyCount: camera ? [...camera.style]
+        .filter((name) => name.startsWith("--")).length : 0,
+      sceneInlineStyleAttributeCount: camera?.firstElementChild?.hasAttribute("style") ? 1 : 0,
+      sceneInlineTransformCount: camera?.firstElementChild?.style.transform === "" ? 0 : 1,
+      morphClassCount: renderNodes.filter((element) =>
+        [...element.classList].some((name) => name.startsWith("polycss-morph") ||
+          name === "polycss-mesh")).length,
+      modelRootCount: document.querySelectorAll(
+        ".example-stage>.polycss-camera>.polycss-scene>.polycss-morph-model",
+      ).length,
+      projection: {
+        wide: wideProjection,
+        expectedCameraHeight,
+        expectedCameraTop,
+        expectedPerspective,
+        actualCameraHeight,
+        actualCameraTop,
+        actualPerspective,
+        matches: expectedCameraHeight !== null &&
+          Math.abs(actualCameraHeight - expectedCameraHeight) < 0.02 &&
+          Math.abs(actualCameraTop - expectedCameraTop) < 0.02 &&
+          Math.abs(actualPerspective - expectedPerspective) < 0.02,
+      },
+      backfaceInlineStyleCount: leaves.filter((leaf) =>
+        leaf.style.backfaceVisibility !== "" || leaf.style.webkitBackfaceVisibility !== "").length,
+      topBackfaceVisibleCount: shapes.filter((shape) =>
+        getComputedStyle(shape.children[0]).backfaceVisibility === "visible").length,
+      sideBackfaceHiddenCount: shapes.reduce((count, shape) => count +
+        [...shape.children].slice(1).filter((leaf) =>
+          getComputedStyle(leaf).backfaceVisibility === "hidden").length, 0),
       hiddenShapeCount: shapes.filter((shape) => getComputedStyle(shape).visibility === "hidden").length,
       hiddenLeafCount: leaves.filter((leaf) => getComputedStyle(leaf).visibility === "hidden").length,
       displayNoneShapeCount: shapes.filter((shape) => getComputedStyle(shape).display === "none").length,
@@ -152,7 +212,7 @@ async function capture({
   });
   await page.waitForTimeout(250);
   const after = await page.evaluate(() => {
-    const shapes = [...document.querySelectorAll(".csscityflow-box")];
+    const shapes = [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")];
     return {
       transforms: shapes.slice(0, 40).map((shape) => getComputedStyle(shape).transform),
       player: globalThis.__csscityflow?.player?.stats(),
@@ -217,8 +277,8 @@ async function capture({
     orbitStatePresent: Object.hasOwn(globalThis.__csscityflow ?? {}, "orbit"),
     orbitDataset: document.querySelector(".example-stage")?.dataset.csscityflowOrbit ?? null,
     draggingDataset: document.querySelector(".example-stage")?.dataset.csscityflowDragging ?? null,
-    shapeCount: document.querySelectorAll(".csscityflow-box").length,
-    leafCount: document.querySelectorAll(".csscityflow-box > b").length,
+    shapeCount: document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div").length,
+    leafCount: document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b").length,
   }));
   const sourceRoundTrip = await page.evaluate(async () => {
     const player = globalThis.__csscityflow?.player;
@@ -227,30 +287,30 @@ async function capture({
     await new Promise((resolveFrame) => requestAnimationFrame(resolveFrame));
     const source = {
       player: sourcePlayer,
-      hiddenShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      hiddenShapeCount: [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")]
         .filter((shape) => getComputedStyle(shape).visibility === "hidden").length,
-      hiddenLeafCount: [...document.querySelectorAll(".csscityflow-box>b")]
+      hiddenLeafCount: [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b")]
         .filter((leaf) => getComputedStyle(leaf).visibility === "hidden").length,
-      displayNoneShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      displayNoneShapeCount: [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")]
         .filter((shape) => getComputedStyle(shape).display === "none").length,
-      zeroOpacityShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      zeroOpacityShapeCount: [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")]
         .filter((shape) => getComputedStyle(shape).opacity === "0").length,
-      zeroOpacityLeafCount: [...document.querySelectorAll(".csscityflow-box>b")]
+      zeroOpacityLeafCount: [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b")]
         .filter((leaf) => getComputedStyle(leaf).opacity === "0").length,
     };
     const presentationPlayer = player.seekFrame(0);
     await new Promise((resolveFrame) => requestAnimationFrame(resolveFrame));
     const presentation = {
       player: presentationPlayer,
-      hiddenShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      hiddenShapeCount: [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")]
         .filter((shape) => getComputedStyle(shape).visibility === "hidden").length,
-      hiddenLeafCount: [...document.querySelectorAll(".csscityflow-box>b")]
+      hiddenLeafCount: [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b")]
         .filter((leaf) => getComputedStyle(leaf).visibility === "hidden").length,
-      displayNoneShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      displayNoneShapeCount: [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")]
         .filter((shape) => getComputedStyle(shape).display === "none").length,
-      zeroOpacityShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      zeroOpacityShapeCount: [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div")]
         .filter((shape) => getComputedStyle(shape).opacity === "0").length,
-      zeroOpacityLeafCount: [...document.querySelectorAll(".csscityflow-box>b")]
+      zeroOpacityLeafCount: [...document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div>b")]
         .filter((leaf) => getComputedStyle(leaf).opacity === "0").length,
     };
     return { source, presentation, resumed: player.resume() };
@@ -263,7 +323,16 @@ async function capture({
   if (errors.length || failedResponses.length || before.errors.length || before.status !== "ready" || !before.ready ||
       before.canonical !== expectedCanonical ||
       before.bankId !== bankId || !before.stable || before.shapeCount !== boxes ||
-      before.leafCount !== leaves || before.canvasCount !== 0 || before.svgSceneCount !== 0 ||
+      before.leafCount !== leaves || before.renderNodeCount !== boxes + leaves + 2 ||
+      before.classAttributeCount !== 2 || before.dataAttributeCount !== 0 ||
+      before.ariaAttributeCount !== 0 || before.cameraInlineStyleAttributeCount !== 0 ||
+      before.cameraInlineCustomPropertyCount !== 0 ||
+      before.sceneInlineStyleAttributeCount !== 0 || before.sceneInlineTransformCount !== 0 ||
+      !before.projection.matches || before.projection.wide !== (profile === "wide") ||
+      before.morphClassCount !== 0 || before.modelRootCount !== 0 ||
+      before.backfaceInlineStyleCount !== 0 || before.topBackfaceVisibleCount !== boxes ||
+      before.sideBackfaceHiddenCount !== boxes * 2 ||
+      before.canvasCount !== 0 || before.svgSceneCount !== 0 ||
       !before.firstLeafColor || before.whiteLeafCount === leaves ||
       !preparedStylesheet?.contentType?.startsWith("text/css") ||
       before.animationName !== "none" ||
@@ -286,6 +355,15 @@ async function capture({
         "prepared-packed-transform-components-expanded-once-plus-sparse-final-face-color-and-whole-box-leaf-visibility-publication" ||
       before.player?.preparedTransformAnimationCount !== 0 ||
       before.player?.preparedTransformStateCount !== 301 ||
+      before.player?.retainedModelRootCount !== 0 ||
+      before.player?.retainedDomClassAttributeCount !== 2 ||
+      before.player?.retainedDomDataAttributeCount !== 0 ||
+      before.player?.retainedDomAriaAttributeCount !== 0 ||
+      before.player?.retainedCameraInlineStyleAttributeCount !== 0 ||
+      before.player?.retainedSceneInlineStyleAttributeCount !== 0 ||
+      before.player?.retainedSceneInlineTransformCount !== 0 ||
+      before.player?.retainedBackfaceInlineStyleCount !== 0 ||
+      before.player?.runtimeDomMutationCount !== 0 ||
       before.player?.runtimeShapeStyleWriteUpperBound !== maximumShapeWrites ||
       before.player?.runtimeLeafColorStyleWriteUpperBound !== maximumColorWrites ||
       !Number.isSafeInteger(before.player?.runtimeLeafColorStyleWrites) ||
@@ -391,7 +469,7 @@ async function captureHome({ width, height, url }) {
       title: card?.querySelector(".project-title")?.textContent?.trim() ?? null,
       number: card?.querySelector(".project-number")?.textContent?.trim() ?? null,
       image: card?.querySelector("img")?.getAttribute("src") ?? null,
-      sceneCount: document.querySelectorAll(".csscityflow-box").length,
+      sceneCount: document.querySelectorAll(".example-stage>.polycss-camera>.polycss-scene>div").length,
     };
   });
   if (errors.length || failedResponses.length || result.canonical !== "https://css.graphics/" ||


### PR DESCRIPTION
## Summary

- flatten the prepared Morph wrapper into the Pipes-style camera > scene > box > face graph
- remove runtime camera custom properties and resize projection binding
- move fixed source projection and model transform ownership into static responsive CSS
- strengthen browser gates for DOM attributes, projection math, and extreme-wide presentation

## Validation

- pnpm test:cityflow
- pnpm typecheck
- pnpm prepare:cityflow:check
- pnpm oracle:cityflow:visual:full
- pnpm test:cityflow:sparse-publication
- pnpm build:cityflow
- pnpm build:cityflow:deploy
- pnpm test:cityflow:deploy
- pnpm perf:cityflow:trace

The full 251-frame native/browser oracle is aligned. The 302-state sparse-publication audit is pixel-exact at normal and wide viewports. The fresh Chrome 152 trace reports presented-frame p95/max 17.633/24.000 ms, no gaps above 33.3 ms, and no smoothness-affecting pipeline drops. RasterTask was not captured and remains unknown.