### PR TITLE
fix(cityflow): share renderer stylesheet across banks

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -124,6 +124,11 @@
     Cache-Control = "public, max-age=31536000, immutable"
 
 [[headers]]
+  for = "/csscityflow/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
   for = "/csscityflow/*"
   [headers.values]
     Cache-Control = "no-cache"

--- a/src/adapters/cityflow/src/csscityflow/client.mjs
+++ b/src/adapters/cityflow/src/csscityflow/client.mjs
@@ -53,11 +53,17 @@ export function mountCityflow(host) {
       height: host.clientHeight || innerHeight,
     });
     const modelId = CSSCITYFLOW_PREPARED_BANKS[bankId].modelId;
-    const [metadata, loaded, playback] = await Promise.all([
-      fetchPreparedMetadata("/csscityflow/prepared.json"),
-      loadPolyMorphPackage("/csscityflow/", { modelId }),
-      loadCityflowPreparedPlayback(`/csscityflow/${modelId}.playback.json`),
-      loadPreparedStylesheet(`/csscityflow/${modelId}.css`),
+    const metadataPromise = fetchPreparedMetadata("/csscityflow/prepared.json");
+    const loadedPromise = loadPolyMorphPackage("/csscityflow/", { modelId });
+    const playbackPromise = loadCityflowPreparedPlayback(
+      `/csscityflow/${modelId}.playback.json`,
+    );
+    const metadata = await metadataPromise;
+    const stylesheetAssetUrl = preparedStylesheetAssetUrl(metadata);
+    const [loaded, playback] = await Promise.all([
+      loadedPromise,
+      playbackPromise,
+      loadPreparedStylesheet(stylesheetAssetUrl),
     ]);
     assertPreparedMetadata(metadata, playback, bankId, modelId);
     if (destroyed) return;
@@ -115,7 +121,7 @@ async function fetchPreparedMetadata(url) {
 
 function assertPreparedMetadata(metadata, playback, bankId, modelId) {
   const bank = metadata?.banks?.find((candidate) => candidate.id === bankId);
-  if (metadata?.schema !== "csscityflow-prepared-product@2" || metadata.status !== "ready" ||
+  if (metadata?.schema !== "csscityflow-prepared-product@3" || metadata.status !== "ready" ||
       metadata.defaultBank !== "desktop" ||
       metadata.profileSelection?.mobileBreakpointWidth !== 600 ||
       metadata.profileSelection?.mobileCapabilityQuery !== "(hover: none) and (pointer: coarse)" ||
@@ -188,6 +194,24 @@ function assertPreparedMetadata(metadata, playback, bankId, modelId) {
         "periodic-zero-sum-twelve-frame-direction-run-folded-adaptive-smooth-sine-eased-sample-cycle") {
     throw new Error("Cityflow prepared metadata drifted");
   }
+}
+
+function preparedStylesheetAssetUrl(metadata) {
+  const stylesheet = metadata?.stylesheet;
+  const match = /^\/csscityflow\/assets\/presentation-([a-f0-9]{64})\.css$/u
+    .exec(stylesheet?.assetUrl ?? "");
+  if (metadata?.schema !== "csscityflow-prepared-product@3" ||
+      stylesheet?.schema !== "csscityflow-prepared-stylesheet@1" ||
+      stylesheet?.policy !== "one-content-addressed-rendering-contract-shared-by-all-banks" ||
+      match?.[1] !== stylesheet.sha256 ||
+      !Number.isSafeInteger(stylesheet.byteLength) || stylesheet.byteLength <= 0 ||
+      JSON.stringify(stylesheet.compatibilityAssetUrls) !== JSON.stringify([
+        "/csscityflow/cityflow.css",
+        "/csscityflow/cityflow-mobile.css",
+      ])) {
+    throw new Error("Cityflow prepared stylesheet metadata drifted");
+  }
+  return stylesheet.assetUrl;
 }
 
 function waitForPaint() {

--- a/src/adapters/cityflow/src/prepare/csscityflow/model.mjs
+++ b/src/adapters/cityflow/src/prepare/csscityflow/model.mjs
@@ -209,10 +209,11 @@ function rotateZ([x, y, z], degrees) {
 export function buildCityflowPreparedCss(state) {
   return [
     `:root{--csscityflow-background:${paletteColor(state.palette[0])}}`,
-    `.polycss-scene>div>b{position:absolute;display:block!important;width:1px;height:1px;` +
+    `.polycss-scene>div>b,.csscityflow-box>b{position:absolute;display:block!important;` +
+      `width:1px;height:1px;` +
       `margin:0;padding:0;border:0;transform-style:preserve-3d;transform-origin:0 0;` +
       `backface-visibility:hidden;-webkit-backface-visibility:hidden}`,
-    `.polycss-scene>div>b:nth-child(1){backface-visibility:visible;` +
+    `.polycss-scene>div>b:nth-child(1),.csscityflow-box>b:nth-child(1){backface-visibility:visible;` +
       `-webkit-backface-visibility:visible}`,
   ].join("");
 }

--- a/src/adapters/cityflow/test/csscityflow-assets.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-assets.test.mjs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: HPND
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import test from "node:test";
@@ -9,20 +10,23 @@ const repositoryRoot = resolve(import.meta.dirname, "../../../..");
 const productRoot = resolve(repositoryRoot, "build/generated/public/csscityflow");
 
 test("prepared Cityflow product binds source, topology, playback, and bounded transfer", async () => {
-  const [metadataText, catalogText, manifestText, modelText, playbackText, css,
-    mobileManifestText, mobileModelText, mobilePlaybackText, mobileCss] = await Promise.all([
-    readFile(resolve(productRoot, "prepared.json"), "utf8"),
+  const metadataText = await readFile(resolve(productRoot, "prepared.json"), "utf8");
+  const metadata = JSON.parse(metadataText);
+  const stylesheetPath = metadata.stylesheet.assetUrl.replace(/^\/csscityflow\//u, "");
+  const [catalogText, manifestText, modelText, playbackText, css,
+    mobileManifestText, mobileModelText, mobilePlaybackText, desktopAliasCss,
+    mobileAliasCss] = await Promise.all([
     readFile(resolve(productRoot, "catalog.json"), "utf8"),
     readFile(resolve(productRoot, "cityflow/manifest.json"), "utf8"),
     readFile(resolve(productRoot, "cityflow/model.json"), "utf8"),
     readFile(resolve(productRoot, "cityflow.playback.json"), "utf8"),
-    readFile(resolve(productRoot, "cityflow.css"), "utf8"),
+    readFile(resolve(productRoot, stylesheetPath), "utf8"),
     readFile(resolve(productRoot, "cityflow-mobile/manifest.json"), "utf8"),
     readFile(resolve(productRoot, "cityflow-mobile/model.json"), "utf8"),
     readFile(resolve(productRoot, "cityflow-mobile.playback.json"), "utf8"),
+    readFile(resolve(productRoot, "cityflow.css"), "utf8"),
     readFile(resolve(productRoot, "cityflow-mobile.css"), "utf8"),
   ]);
-  const metadata = JSON.parse(metadataText);
   const catalog = JSON.parse(catalogText);
   const manifest = JSON.parse(manifestText);
   const model = JSON.parse(modelText);
@@ -32,7 +36,7 @@ test("prepared Cityflow product binds source, topology, playback, and bounded tr
   const mobilePlayback = JSON.parse(mobilePlaybackText);
   const bank = metadata.banks.find(({ id }) => id === "desktop");
   const mobileBank = metadata.banks.find(({ id }) => id === "mobile");
-  assert.equal(metadata.schema, "csscityflow-prepared-product@2");
+  assert.equal(metadata.schema, "csscityflow-prepared-product@3");
   assert.equal(metadata.status, "ready");
   assert.equal(metadata.defaultBank, "desktop");
   assert.equal(metadata.profileSelection.mobileBreakpointWidth, 600);
@@ -43,6 +47,22 @@ test("prepared Cityflow product binds source, topology, playback, and bounded tr
   assert.equal(metadata.source.files.length, 14);
   assert.ok(metadata.source.files.every(({ path, sha256 }) =>
     !path.startsWith("/") && /^[a-f0-9]{64}$/u.test(sha256)));
+  assert.equal(metadata.stylesheet.schema, "csscityflow-prepared-stylesheet@1");
+  assert.equal(metadata.stylesheet.policy,
+    "one-content-addressed-rendering-contract-shared-by-all-banks");
+  assert.match(metadata.stylesheet.assetUrl,
+    /^\/csscityflow\/assets\/presentation-[a-f0-9]{64}\.css$/u);
+  assert.equal(createHash("sha256").update(css).digest("hex"), metadata.stylesheet.sha256);
+  assert.equal(metadata.stylesheet.assetUrl,
+    `/csscityflow/assets/presentation-${metadata.stylesheet.sha256}.css`);
+  assert.equal(Buffer.byteLength(css), metadata.stylesheet.byteLength);
+  assert.deepEqual(metadata.stylesheet.compatibilityAssetUrls, [
+    "/csscityflow/cityflow.css",
+    "/csscityflow/cityflow-mobile.css",
+  ]);
+  assert.equal(desktopAliasCss, css);
+  assert.equal(mobileAliasCss, css);
+  assert.match(css, /\.polycss-scene>div>b,\.csscityflow-box>b/u);
   assert.equal(bank.boxCount, 200);
   assert.equal(bank.leafCount, 600);
   assert.equal(bank.frameCount, 301);
@@ -176,7 +196,7 @@ test("prepared Cityflow product binds source, topology, playback, and bounded tr
     "mobile prepared wire payload must not send expanded matrix strings");
   assert.ok(Buffer.byteLength(mobilePlaybackText) < 800_000,
     `Mobile prepared playback raw transfer grew to ${Buffer.byteLength(mobilePlaybackText)} bytes`);
-  assert.doesNotMatch(mobileCss, /will-change|attr\(|::before|::after/u);
+  assert.doesNotMatch(css, /will-change|attr\(|::before|::after/u);
   assert.doesNotMatch(
     `${metadataText}\n${catalogText}\n${manifestText}\n${modelText}\n${playbackText}\n${mobileManifestText}\n${mobileModelText}\n${mobilePlaybackText}`,
     /\/Users\/|[A-Z]:\\/u,

--- a/src/adapters/cityflow/test/csscityflow-deploy.deploy.mjs
+++ b/src/adapters/cityflow/test/csscityflow-deploy.deploy.mjs
@@ -57,6 +57,8 @@ test("public Cityflow attribution, previews, preparation, and cache contracts ar
   assert.match(packageJson, /"build:cityflow:deploy": "CSSCITYFLOW_DEPLOY_BUILD=1 pnpm build:cityflow"/u);
   assert.match(packageJson, /pnpm prepare:cityflow[^\n]+node scripts\/copy-deploy-products\.mjs/u);
   assert.match(astroConfig, /"\.css": "text\/css; charset=utf-8"/u);
+  assert.match(netlify,
+    /for = "\/csscityflow\/assets\/\*"[\s\S]*?Cache-Control = "public, max-age=31536000, immutable"/u);
   assert.match(netlify, /for = "\/csscityflow\/\*"[\s\S]*?Cache-Control = "no-cache"/u);
   assert.match(sourceAuthority, /https:\/\/raw\.githubusercontent\.com\/\$\{segments\[0\]\}\/\$\{segments\[1\]\}/u);
   assert.match(notice, /Permission to use, copy, modify, distribute, and sell this software/u);

--- a/src/adapters/cityflow/test/csscityflow-model.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-model.test.mjs
@@ -197,10 +197,12 @@ test("prepares DOMFORMAT-precedented exact states and C2 reconstructed presentat
   assert.doesNotMatch(css, /::before/u);
   assert.doesNotMatch(css, /attr\(|::after/u);
   assert.doesNotMatch(css, /--z|@property/u);
-  assert.match(css, /\.polycss-scene>div>b\{[^}]*width:1px;[^}]*height:1px;/u);
-  assert.match(css, /\.polycss-scene>div>b\{[^}]*backface-visibility:hidden;/u);
-  assert.match(css, /\.polycss-scene>div>b:nth-child\(1\)\{backface-visibility:visible;/u);
-  assert.doesNotMatch(css, /csscityflow-box/u);
+  assert.match(css,
+    /\.polycss-scene>div>b,\.csscityflow-box>b\{[^}]*width:1px;[^}]*height:1px;/u);
+  assert.match(css,
+    /\.polycss-scene>div>b,\.csscityflow-box>b\{[^}]*backface-visibility:hidden;/u);
+  assert.match(css,
+    /\.polycss-scene>div>b:nth-child\(1\),\.csscityflow-box>b:nth-child\(1\)\{backface-visibility:visible;/u);
   assert.equal((css.match(/hypot\(/gu) ?? []).length, 0);
   assert.doesNotMatch(css, /filter|clip-path|mask|linear-gradient|radial-gradient/u);
 

--- a/src/adapters/cityflow/test/csscityflow-runtime-surface.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-runtime-surface.test.mjs
@@ -37,11 +37,13 @@ test("publishes every prepared box automatically with a fixed source camera", as
   assert.match(dom, /runtimeDomMutationCount/u);
   assert.match(client, /selectCityflowPreparedBank/u);
   assert.ok(client.indexOf("selectCityflowPreparedBank({") <
-    client.indexOf("await Promise.all(["), "prepared bank selection must precede all bank fetches");
+    client.indexOf("const metadataPromise"), "prepared bank selection must precede all bank fetches");
   assert.match(client, /loadPolyMorphPackage\("\/csscityflow\/", \{ modelId \}\)/u);
   assert.match(client,
-    /loadCityflowPreparedPlayback\(`\/csscityflow\/\$\{modelId\}\.playback\.json`\)/u);
-  assert.match(client, /loadPreparedStylesheet\(`\/csscityflow\/\$\{modelId\}\.css`\)/u);
+    /loadCityflowPreparedPlayback\([\s\S]*?`\/csscityflow\/\$\{modelId\}\.playback\.json`,?[\s\S]*?\)/u);
+  assert.match(client, /const stylesheetAssetUrl = preparedStylesheetAssetUrl\(metadata\)/u);
+  assert.match(client, /loadPreparedStylesheet\(stylesheetAssetUrl\)/u);
+  assert.doesNotMatch(client, /loadPreparedStylesheet\(`\/csscityflow\/\$\{modelId\}/u);
   assert.doesNotMatch(client,
     /addEventListener\([^\n]*resize[^\n]*selectCityflowPreparedBank/u);
   assert.match(profileSelection, /width < CSSCITYFLOW_MOBILE_BREAKPOINT_WIDTH/u);

--- a/src/adapters/cityflow/tools/prepare-csscityflow.mjs
+++ b/src/adapters/cityflow/tools/prepare-csscityflow.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: HPND
+import { createHash } from "node:crypto";
 import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,6 +22,7 @@ await rm(stagingRoot, { recursive: true, force: true });
 await mkdir(stagingRoot, { recursive: true });
 const packages = [];
 const preparedBanks = [];
+let sharedStylesheetBytes = null;
 for (const bankId of Object.keys(CITYFLOW_BANKS)) {
   const { state, model } = buildCityflowMorphModel({ bankId });
   const built = await buildPolyMorphPackage(model);
@@ -34,10 +36,11 @@ for (const bankId of Object.keys(CITYFLOW_BANKS)) {
     manifestSha256: built.manifestSha256,
   });
   const playback = buildCityflowPreparedPlayback(state);
-  await writeFile(
-    join(stagingRoot, `${model.identity.id}.css`),
-    `${buildCityflowPreparedCss(state)}\n`,
-  );
+  const stylesheetBytes = Buffer.from(`${buildCityflowPreparedCss(state)}\n`);
+  if (sharedStylesheetBytes === null) sharedStylesheetBytes = stylesheetBytes;
+  else if (!sharedStylesheetBytes.equals(stylesheetBytes)) {
+    throw new Error(`Cityflow ${bankId} introduced a bank-specific rendering stylesheet`);
+  }
   await writeFile(
     join(stagingRoot, `${model.identity.id}.playback.json`),
     `${JSON.stringify(playback)}\n`,
@@ -74,10 +77,22 @@ for (const bankId of Object.keys(CITYFLOW_BANKS)) {
     }),
   }));
 }
+if (sharedStylesheetBytes === null) throw new Error("Cityflow prepared no stylesheet");
+const stylesheetSha256 = createHash("sha256").update(sharedStylesheetBytes).digest("hex");
+const stylesheetAssetUrl = `/csscityflow/assets/presentation-${stylesheetSha256}.css`;
+await writeBytes(
+  join(stagingRoot, stylesheetAssetUrl.replace(/^\/csscityflow\//u, "")),
+  sharedStylesheetBytes,
+);
+// Compatibility aliases keep already-cached pre-content-addressed clients valid
+// across the migration. New clients never select a stylesheet by bank.
+for (const { manifest } of packages) {
+  await writeBytes(join(stagingRoot, `${manifest.identity.id}.css`), sharedStylesheetBytes);
+}
 const catalog = await buildPolyMorphCatalog("cityflow", packages);
 await writeBytes(join(stagingRoot, "catalog.json"), catalog.bytes);
 await writeFile(join(stagingRoot, "prepared.json"), `${JSON.stringify({
-  schema: "csscityflow-prepared-product@2",
+  schema: "csscityflow-prepared-product@3",
   status: "ready",
   defaultBank: "desktop",
   profileSelection: {
@@ -96,6 +111,17 @@ await writeFile(join(stagingRoot, "prepared.json"), `${JSON.stringify({
     runtimeGeometry: false,
     runtimeRasterization: false,
     runtimeDomGrowth: false,
+  },
+  stylesheet: {
+    schema: "csscityflow-prepared-stylesheet@1",
+    policy: "one-content-addressed-rendering-contract-shared-by-all-banks",
+    assetUrl: stylesheetAssetUrl,
+    sha256: stylesheetSha256,
+    byteLength: sharedStylesheetBytes.byteLength,
+    compatibilityAssetUrls: [
+      "/csscityflow/cityflow.css",
+      "/csscityflow/cityflow-mobile.css",
+    ],
   },
   banks: preparedBanks,
 }, null, 2)}\n`);

--- a/src/adapters/cityflow/tools/smoke-browser.mjs
+++ b/src/adapters/cityflow/tools/smoke-browser.mjs
@@ -63,8 +63,25 @@ try {
     maximumShapeWrites: 100, maximumColorWrites: 159,
     sideDepthDefault: 0.28, sideDepthMaximum: 0.28, sideDepthOverrides: 0, url: route,
   });
+  const requestedStylesheets = [desktop, wide, mobile].map(({ preparedRequests }) =>
+    preparedRequests.filter((path) => path.endsWith(".css")));
+  if (requestedStylesheets.some((paths) => paths.length !== 1) ||
+      new Set(requestedStylesheets.flat()).size !== 1) {
+    throw new Error(`Cityflow banks did not share one rendering stylesheet: ${JSON.stringify(
+      requestedStylesheets,
+    )}`);
+  }
   const home = deploy ? await captureHome({ width: 1280, height: 720, url: `${origin}/` }) : null;
-  const report = { schema: "csscityflow-browser-smoke@4", route, deploy, desktop, wide, mobile, home };
+  const report = {
+    schema: "csscityflow-browser-smoke@5",
+    route,
+    deploy,
+    sharedStylesheet: requestedStylesheets[0][0],
+    desktop,
+    wide,
+    mobile,
+    home,
+  };
   await writeFile(resolve(outputRoot, "report.json"), `${JSON.stringify(report, null, 2)}\n`);
   console.log(JSON.stringify(report, null, 2));
 } finally {
@@ -319,7 +336,7 @@ async function capture({
     "https://css.graphics/cityflow/";
   const preparedRequests = requests.filter((path) => path.startsWith("/csscityflow/"));
   const preparedStylesheet = preparedResponses.find(({ path }) =>
-    path === `/csscityflow/${modelId}.css`);
+    path === before.metadata?.stylesheet?.assetUrl);
   if (errors.length || failedResponses.length || before.errors.length || before.status !== "ready" || !before.ready ||
       before.canonical !== expectedCanonical ||
       before.bankId !== bankId || !before.stable || before.shapeCount !== boxes ||
@@ -401,7 +418,10 @@ async function capture({
       before.player?.visibilityCullingPolicy !==
         "prepared-viewport-independent-whole-box-direct-leaf-visibility-no-face-culling" ||
       before.transformAnimationCount !== 0 ||
-      before.metadata?.schema !== "csscityflow-prepared-product@2" ||
+      before.metadata?.schema !== "csscityflow-prepared-product@3" ||
+      !/^\/csscityflow\/assets\/presentation-[a-f0-9]{64}\.css$/u.test(
+        before.metadata?.stylesheet?.assetUrl ?? "") ||
+      preparedRequests.includes(`/csscityflow/${modelId}.css`) ||
       after.player?.timerCallbackCount !== 0 ||
       after.player?.animationFrameCallbackCount <= before.player.animationFrameCallbackCount ||
       after.player?.frameIndex === before.player.frameIndex ||


### PR DESCRIPTION
## Summary

- load one content-addressed rendering stylesheet for desktop and mobile
- keep bank selection limited to prepared model and playback payloads
- fail preparation if bank rendering CSS diverges
- retain compatible stable aliases for cached older clients

## Verification

- `pnpm test:cityflow`
- `pnpm prepare:cityflow:check`
- `pnpm test:cityflow:browser`
- `pnpm build:cityflow:deploy`
- `pnpm test:cityflow:deploy`