### PR TITLE
fix(cityflow): keep prepared faces double-sided

### DIFF
--- a/src/adapters/cityflow/src/prepare/csscityflow/model.mjs
+++ b/src/adapters/cityflow/src/prepare/csscityflow/model.mjs
@@ -212,9 +212,7 @@ export function buildCityflowPreparedCss(state) {
     `.polycss-scene>div>b,.csscityflow-box>b{position:absolute;display:block!important;` +
       `width:1px;height:1px;` +
       `margin:0;padding:0;border:0;transform-style:preserve-3d;transform-origin:0 0;` +
-      `backface-visibility:hidden;-webkit-backface-visibility:hidden}`,
-    `.polycss-scene>div>b:nth-child(1),.csscityflow-box>b:nth-child(1){backface-visibility:visible;` +
-      `-webkit-backface-visibility:visible}`,
+      `backface-visibility:visible;-webkit-backface-visibility:visible}`,
   ].join("");
 }
 

--- a/src/adapters/cityflow/test/csscityflow-model.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-model.test.mjs
@@ -200,9 +200,8 @@ test("prepares DOMFORMAT-precedented exact states and C2 reconstructed presentat
   assert.match(css,
     /\.polycss-scene>div>b,\.csscityflow-box>b\{[^}]*width:1px;[^}]*height:1px;/u);
   assert.match(css,
-    /\.polycss-scene>div>b,\.csscityflow-box>b\{[^}]*backface-visibility:hidden;/u);
-  assert.match(css,
-    /\.polycss-scene>div>b:nth-child\(1\),\.csscityflow-box>b:nth-child\(1\)\{backface-visibility:visible;/u);
+    /\.polycss-scene>div>b,\.csscityflow-box>b\{[^}]*backface-visibility:visible;/u);
+  assert.doesNotMatch(css, /backface-visibility:hidden/u);
   assert.equal((css.match(/hypot\(/gu) ?? []).length, 0);
   assert.doesNotMatch(css, /filter|clip-path|mask|linear-gradient|radial-gradient/u);
 

--- a/src/adapters/cityflow/tools/smoke-browser.mjs
+++ b/src/adapters/cityflow/tools/smoke-browser.mjs
@@ -197,11 +197,8 @@ async function capture({
       },
       backfaceInlineStyleCount: leaves.filter((leaf) =>
         leaf.style.backfaceVisibility !== "" || leaf.style.webkitBackfaceVisibility !== "").length,
-      topBackfaceVisibleCount: shapes.filter((shape) =>
-        getComputedStyle(shape.children[0]).backfaceVisibility === "visible").length,
-      sideBackfaceHiddenCount: shapes.reduce((count, shape) => count +
-        [...shape.children].slice(1).filter((leaf) =>
-          getComputedStyle(leaf).backfaceVisibility === "hidden").length, 0),
+      doubleSidedFaceCount: leaves.filter((leaf) =>
+        getComputedStyle(leaf).backfaceVisibility === "visible").length,
       hiddenShapeCount: shapes.filter((shape) => getComputedStyle(shape).visibility === "hidden").length,
       hiddenLeafCount: leaves.filter((leaf) => getComputedStyle(leaf).visibility === "hidden").length,
       displayNoneShapeCount: shapes.filter((shape) => getComputedStyle(shape).display === "none").length,
@@ -347,8 +344,7 @@ async function capture({
       before.sceneInlineStyleAttributeCount !== 0 || before.sceneInlineTransformCount !== 0 ||
       !before.projection.matches || before.projection.wide !== (profile === "wide") ||
       before.morphClassCount !== 0 || before.modelRootCount !== 0 ||
-      before.backfaceInlineStyleCount !== 0 || before.topBackfaceVisibleCount !== boxes ||
-      before.sideBackfaceHiddenCount !== boxes * 2 ||
+      before.backfaceInlineStyleCount !== 0 || before.doubleSidedFaceCount !== leaves ||
       before.canvasCount !== 0 || before.svgSceneCount !== 0 ||
       !before.firstLeafColor || before.whiteLeafCount === leaves ||
       !preparedStylesheet?.contentType?.startsWith("text/css") ||


### PR DESCRIPTION
## Cause

The retained-DOM cleanup removed PolyCSS inline backface visibility and changed the two side faces to `backface-visibility: hidden`. Production therefore publishes 200 mobile side faces as backface-hidden even though the pre-cleanup working renderer kept all three source faces double-sided.

## Fix

- restore `backface-visibility: visible` for every prepared face in the one shared stylesheet
- keep the DOM clean; no inline backface styles are restored
- require all desktop and mobile faces to be double-sided in browser smoke

## Verification

- `pnpm test:cityflow`
- `pnpm prepare:cityflow:check`
- `pnpm test:cityflow:browser`
- `pnpm build:cityflow:deploy`
- `pnpm test:cityflow:deploy`
- matched Pixel 7 frame 100 probe: production 100/300 double-sided, repaired build 300/300