### PR TITLE
fix(cityflow): rebuild mobile without changing desktop

### DIFF
--- a/src/adapters/cityflow/AGENTS.md
+++ b/src/adapters/cityflow/AGENTS.md
@@ -1,5 +1,23 @@
 # Cityflow adapter contract
 
+## Mobile replacement, 2026-09-04
+
+- Desktop is frozen against `main` at `0f8727544a30d0a742f43d60f3ef969b823abeb1` for this release.
+  Preserve its renderer, source preparation, camera, cadence, and generated assets.
+- The user permits a different authored mobile scene: 72 touching towers, 216
+  ordinary 2D faces, full sides, fixed painter order, and 360 prepared states.
+  Heights span 36–124 scene units. No gaps, CSS 3D, runtime geometry, culling,
+  dynamic colors, or full-matrix playback transport. Expand scalar heights once.
+- Keep the existing selection policy and freeze its result before lazy loading
+  the selected client. Mobile assets and CSS are loaded only by the mobile client.
+- Legacy mobile assets remain for cached clients; new mobile clients never fetch them.
+- Validate mobile face coverage and lifecycle in available browsers; the user's
+  phone is not required. Do not label browser evidence as physical-device proof.
+- The older source/native mobile requirements below describe the legacy bank,
+  not the replacement. Desktop requirements remain unchanged.
+
+## Desktop and legacy bank contract
+
 - Read `notes/provenance-bible.md` before changing source simulation, box geometry, colors, lighting, camera, timing, or parity claims.
 - Preserve the XScreenSaver simulation contract: six waves, 25 wave speed, 256 radius, 12-degree skew, 20 ms cadence, the source-supported `count` control set to 200 for desktop and 100 for mobile, and only the source-emitted top, front, and right faces. The source default remains 800; do not describe either prepared count as that default.
 - Preserve the seeded initialization, wave equation, palette, lighting, camera, and cadence independently in both prepared banks. Select `desktop` or `mobile` once, before fetching or mounting any bank asset, using the established `<600px`, coarse-pointer, and mobile-UA profile policy. Do not fetch both banks, switch banks after mount, or rebuild a bank at runtime. Responsive projection updates are not bank selection.

--- a/src/adapters/cityflow/NOTICE.md
+++ b/src/adapters/cityflow/NOTICE.md
@@ -25,6 +25,11 @@ not claim that the continuously advancing source has an exact finite loop.
 
 ## Upstream attribution and permission notice
 
+The replacement mobile product is an authored isometric adaptation with 72
+touching towers, static face colors, and a six-second prepared height loop. It
+does not reproduce native depth-buffer rendering or source wave simulation.
+The 100-box mobile bank described above remains only for cached-client compatibility.
+
 The following notice is reproduced from the pinned `hacks/glx/cityflow.c`
 source:
 

--- a/src/adapters/cityflow/README.md
+++ b/src/adapters/cityflow/README.md
@@ -1,9 +1,32 @@
 # css.graphics/cityflow
 
-Source-backed XScreenSaver Cityflow rendered as retained PolyCSS Morph boxes.
-The desktop and mobile prepared banks use the source's own `count` control at
-200 and 100 boxes respectively; the XScreenSaver default is 800. Every box
-retains the source-emitted top, front, and right faces.
+Desktop renders 200 source-backed XScreenSaver Cityflow boxes; the source
+default is 800. Its renderer and prepared assets are unchanged by the mobile
+replacement. Mobile uses an authored city of 72 touching towers and 216 ordinary
+2D faces, without CSS 3D depth sorting. It deliberately differs from native.
+
+## Mobile
+
+The 72 irregular footprints tile edge-to-edge, with complete sides down to the
+ground. Heights span 36–124 scene units over 360 prepared states at 60 Hz. The
+packet carries fixed-point scalar heights, a fixed 2x height scale, and footprint
+dimensions—not matrix strings. The loader expands transforms once. Playback
+uses the existing adjacent-state scheduler, cached transforms, and stable DOM,
+without runtime geometry, culling, or color changes.
+
+The existing width/device policy selects one client before loading its assets.
+Rotation keeps the same bank. Legacy mobile assets remain available to cached
+clients but are not fetched by the new client.
+
+`node src/adapters/cityflow/tools/smoke-mobile.mjs --all-frames` checks every
+state across five viewport/DPR combinations for gaps and missing face interiors,
+plus pause and stable DOM after rotation. This is installed Chrome headless
+evidence, not physical Android proof or native parity.
+
+## Desktop and legacy bank details
+
+The details below describe the unchanged desktop and legacy 100-box mobile bank.
+They do not qualify the new mobile composition.
 
 ```bash
 pnpm prepare:cityflow

--- a/src/adapters/cityflow/src/csscityflow/client.mjs
+++ b/src/adapters/cityflow/src/csscityflow/client.mjs
@@ -11,7 +11,7 @@ import {
   selectCityflowPreparedBank,
 } from "./profileSelection.mjs";
 
-export function mountCityflow(host) {
+export function mountCityflow(host, selectedBankId) {
   let destroyed = false;
   const state = {
     ready: false,
@@ -45,7 +45,7 @@ export function mountCityflow(host) {
   return controller;
 
   async function main() {
-    const bankId = selectCityflowPreparedBank({
+    const bankId = selectedBankId ?? selectCityflowPreparedBank({
       width: host.clientWidth || innerWidth,
       height: host.clientHeight || innerHeight,
     });

--- a/src/adapters/cityflow/src/csscityflow/mobileClient.mjs
+++ b/src/adapters/cityflow/src/csscityflow/mobileClient.mjs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: HPND
+import { mountCityflowPreparedSnapshot } from "./preparedDom.mjs";
+import { createCityflowMobilePlayer, preparedMobileBank } from "./mobilePlayback.mjs";
+
+export function mountCityflow(host) {
+  let destroyed = false;
+  const state = { ready: false, errors: [], metadata: null, bankId: "mobile",
+    dom: null, player: null, stylesheetElement: null };
+  const controller = Object.freeze({
+    pause() { return state.player?.pause(); },
+    resume() { if (!destroyed) return state.player?.resume(); },
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      cleanup();
+      if (globalThis.__csscityflow === state) delete globalThis.__csscityflow;
+    },
+  });
+  Object.defineProperty(globalThis, "__csscityflow", { configurable: true, value: state });
+  main().catch((error) => {
+    if (destroyed) return;
+    cleanup();
+    state.errors.push(String(error?.stack || error));
+    document.body.classList.remove("loading");
+    document.body.classList.add("error");
+    console.error(error);
+  });
+  return controller;
+
+  function cleanup() {
+    state.player?.destroy();
+    state.dom?.destroy();
+    state.stylesheetElement?.remove();
+    state.ready = false;
+  }
+
+  async function main() {
+    const metadata = await fetchAsset("/csscityflow/prepared.json", "json", "no-store");
+    if (destroyed) return;
+    const bank = preparedMobileBank(metadata);
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = bank.stylesheet.assetUrl;
+    state.stylesheetElement = link;
+    const stylesheet = new Promise((done, reject) => {
+      link.addEventListener("load", done, { once: true });
+      link.addEventListener("error", () => reject(new Error("Cityflow mobile stylesheet failed")), { once: true });
+    });
+    document.head.append(link);
+    const [snapshotHtml, playback] = await Promise.all([
+      fetchAsset(bank.snapshot.assetUrl, "text"),
+      fetchAsset(bank.playback.assetUrl, "json"),
+      stylesheet,
+    ]);
+    if (destroyed) return;
+    state.metadata = metadata;
+    state.dom = mountCityflowPreparedSnapshot({ host, snapshotHtml, expectedBoxCount: bank.boxCount });
+    state.player = createCityflowMobilePlayer({ playback, dom: state.dom });
+    await new Promise((done) => requestAnimationFrame(() => requestAnimationFrame(done)));
+    if (destroyed) return;
+    state.ready = true;
+    document.body.classList.replace("loading", "ready");
+    performance.mark("csscityflow-ready");
+    state.player.resume();
+  }
+}
+
+async function fetchAsset(url, type, cache = "force-cache") {
+  const response = await fetch(url, { cache });
+  if (!response.ok) throw new Error(`Cityflow mobile asset failed: ${response.status} ${url}`);
+  return response[type]();
+}

--- a/src/adapters/cityflow/src/csscityflow/mobilePlayback.mjs
+++ b/src/adapters/cityflow/src/csscityflow/mobilePlayback.mjs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: HPND
+import { createCityflowDeadlineScheduler } from "./deadlineScheduler.mjs";
+import { decodeMobileHeights, mobileFaceTransforms } from "./mobileTransforms.mjs";
+
+export function preparedMobileBank(metadata) {
+  const bank = metadata?.mobile;
+  if (bank?.schema !== "csscityflow-mobile-product@1" || bank.id !== "mobile" ||
+      bank.modelId !== "cityflow-mobile" || !Number.isSafeInteger(bank.boxCount) ||
+      bank.boxCount < 1 || bank.boxCount > 100 || bank.leafCount !== bank.boxCount * 3) {
+    throw new Error("Cityflow mobile product is incomplete; run prepare:cityflow");
+  }
+  for (const [kind, extension] of [["snapshot", "html"], ["stylesheet", "css"], ["playback", "json"]]) {
+    const asset = bank[kind];
+    if (!asset || !/^[a-f0-9]{64}$/u.test(asset.sha256) ||
+        asset.assetUrl !== `/csscityflow/assets/mobile-${kind}-${asset.sha256}.${extension}` ||
+        !Number.isSafeInteger(asset.byteLength) || asset.byteLength <= 0) {
+      throw new Error(`Cityflow mobile ${kind} metadata drifted`);
+    }
+  }
+  return bank;
+}
+
+export async function loadCityflowMobilePlayback(url) {
+  const response = await fetch(url, { cache: "force-cache" });
+  if (!response.ok) throw new Error(`Cityflow mobile playback failed: ${response.status}`);
+  return response.json();
+}
+
+export function createCityflowMobilePlayer({ playback, dom, ...overrides }) {
+  const heights = decodeMobileHeights(playback);
+  if (dom.shapeElements.length !== playback.boxCount ||
+      dom.leafElements.some((leaves) => leaves.length !== 3)) {
+    throw new Error("Cityflow mobile face binding drifted");
+  }
+  const dictionary = new Map();
+  const states = Array.from(heights, (height, index) => {
+    const [width, depth] = playback.footprints[index % playback.boxCount];
+    const key = `${width},${depth},${height}`;
+    if (!dictionary.has(key)) dictionary.set(key, mobileFaceTransforms(height, width, depth, playback.heightScale));
+    return dictionary.get(key);
+  });
+  let frameIndex = 0;
+  let publicationCount = 0;
+  let runtimeTransformWrites = 0;
+  let destroyed = false;
+  const lastPublication = { frameIndex: 0, faceTransformWrites: 0 };
+  const scheduler = createCityflowDeadlineScheduler({
+    ...overrides,
+    frameMilliseconds: 1000 / playback.framesPerSecond,
+    publishDue(tick) { publishFrame(tick % playback.frameCount); },
+  });
+
+  function publishFrame(frame) {
+    const offset = frame * playback.boxCount;
+    let writes = 0;
+    for (let box = 0; box < playback.boxCount; box += 1) {
+      const transforms = states[offset + box];
+      if (transforms === states[frameIndex * playback.boxCount + box]) continue;
+      const leaves = dom.leafElements[box];
+      for (let face = 0; face < 3; face += 1) leaves[face].style.transform = transforms[face];
+      writes += 3;
+    }
+    frameIndex = frame;
+    publicationCount += 1;
+    runtimeTransformWrites += writes;
+    lastPublication.frameIndex = frame;
+    lastPublication.faceTransformWrites = writes;
+  }
+
+  function stats() {
+    return {
+      ...dom.stats(), ...scheduler.stats(),
+      bankId: "mobile", modelId: "cityflow-mobile", frameIndex,
+      frameCount: playback.frameCount, publicationCount, runtimeTransformWrites,
+      lastPublication: { ...lastPublication }, retainedBoxCount: playback.boxCount,
+      retainedFaceCount: playback.boxCount * 3,
+      runtimeGeometry: false, runtimeFormatting: false, runtimeCulling: false,
+      runtimeColorWrites: 0, css3d: false,
+    };
+  }
+
+  return Object.freeze({
+    stats,
+    pause() { scheduler.pause(); return stats(); },
+    resume() { if (!destroyed) scheduler.resume(); return stats(); },
+    seekFrame(frame) {
+      if (!Number.isSafeInteger(frame) || frame < 0 || frame >= playback.frameCount) {
+        throw new RangeError("Cityflow mobile frame is out of range");
+      }
+      publishFrame(frame);
+      scheduler.seekTick(frame);
+      return stats();
+    },
+    destroy() { destroyed = true; scheduler.destroy(); },
+  });
+}

--- a/src/adapters/cityflow/src/csscityflow/mobileTransforms.mjs
+++ b/src/adapters/cityflow/src/csscityflow/mobileTransforms.mjs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: HPND
+// Expanded only during preparation or loading, never in the animation callback.
+export function mobileFaceTransforms(heightUnits, width, depth, heightScale) {
+  const height = heightUnits * heightScale / 1000;
+  return [
+    `matrix(${width},${width * 0.22},${-depth * 0.36},${depth * 0.6},0,${-height})`,
+    `matrix(${width},${width * 0.22},0,${height},${-depth * 0.36},${depth * 0.6 - height})`,
+    `matrix(${depth * 0.36},${-depth * 0.6},0,${height},${width - depth * 0.36},${width * 0.22 + depth * 0.6 - height})`,
+  ];
+}
+
+export function decodeMobileHeights(playback) {
+  if (playback?.schema !== "csscityflow-mobile-playback@1" ||
+      !Number.isSafeInteger(playback.boxCount) || playback.boxCount < 1 || playback.boxCount > 100 ||
+      playback.footprints?.length !== playback.boxCount || playback.facesPerBox !== 3 ||
+      playback.frameCount !== 360 || playback.framesPerSecond !== 60 ||
+      !Number.isFinite(playback.heightScale) || playback.heightScale <= 0 || playback.heightScale > 2 ||
+      playback.heightEncoding !== "uint16-le-millipixels-base64" ||
+      typeof playback.heightsBase64 !== "string") {
+    throw new Error("Cityflow mobile playback contract drifted");
+  }
+  for (const footprint of playback.footprints) {
+    if (!Array.isArray(footprint) || footprint.length !== 2 ||
+        footprint.some((value) => !Number.isFinite(value) || value < 28 || value > 120)) {
+      throw new Error("Cityflow mobile footprint is out of bounds");
+    }
+  }
+  const bytes = Uint8Array.from(atob(playback.heightsBase64), (char) => char.charCodeAt(0));
+  if (bytes.length !== playback.boxCount * playback.frameCount * 2) {
+    throw new Error("Cityflow mobile height stream is incomplete");
+  }
+  const view = new DataView(bytes.buffer);
+  const heights = new Uint16Array(bytes.length / 2);
+  for (let index = 0; index < heights.length; index += 1) {
+    const value = view.getUint16(index * 2, true);
+    if (value < 18000 || value > 62000) throw new Error("Cityflow mobile height is out of bounds");
+    heights[index] = value;
+  }
+  return heights;
+}

--- a/src/adapters/cityflow/src/csscityflow/preparedDom.mjs
+++ b/src/adapters/cityflow/src/csscityflow/preparedDom.mjs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: HPND
+
+const FACES_PER_BOX = 3;
+
+export function mountCityflowPreparedSnapshot({ host, snapshotHtml, expectedBoxCount }) {
+  if (!(host instanceof HTMLElement) || typeof snapshotHtml !== "string" ||
+      !Number.isSafeInteger(expectedBoxCount) || expectedBoxCount < 1) {
+    throw new Error("Cityflow requires a prepared retained-DOM snapshot");
+  }
+  const parsed = new DOMParser().parseFromString(snapshotHtml, "text/html");
+  const camera = parsed.body.querySelector(":scope > .polycss-camera");
+  const scene = camera?.querySelector(":scope > .polycss-scene");
+  const shapeElements = [...(scene?.children ?? [])];
+  if (parsed.querySelector("script,style,canvas,svg") || !(camera instanceof HTMLElement) ||
+      camera.localName !== "main" || !(scene instanceof HTMLElement) ||
+      camera.children.length !== 1 || camera.firstElementChild !== scene ||
+      shapeElements.length !== expectedBoxCount ||
+      shapeElements.some((shape) => shape.localName !== "div" ||
+        shape.children.length !== FACES_PER_BOX ||
+        [...shape.children].some((leaf) => leaf.localName !== "b" || leaf.children.length !== 0) ||
+        hasDiagnosticAttributes(shape) || [...shape.children].some(hasDiagnosticAttributes))) {
+    throw new Error("Cityflow prepared retained-DOM snapshot is incomplete");
+  }
+
+  const mountedCamera = document.importNode(camera, true);
+  host.replaceChildren(mountedCamera);
+  const mountedScene = mountedCamera.querySelector(":scope > .polycss-scene");
+  const mountedShapes = [...(mountedScene?.children ?? [])];
+  const leafElements = mountedShapes.map((shape) => [...shape.children]);
+  if (!(mountedScene instanceof HTMLElement) || mountedCamera.children.length !== 1 ||
+      mountedShapes.length !== expectedBoxCount ||
+      leafElements.some((leaves) => leaves.length !== FACES_PER_BOX)) {
+    throw new Error("Mounted Cityflow retained-DOM snapshot drifted");
+  }
+
+  const stableNodes = Object.freeze([
+    mountedCamera,
+    mountedScene,
+    ...mountedShapes,
+    ...leafElements.flat(),
+  ]);
+  let runtimeDomCreationCount = 0;
+  let runtimeDomRemovalCount = 0;
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      runtimeDomCreationCount += record.addedNodes.length;
+      runtimeDomRemovalCount += record.removedNodes.length;
+    }
+  });
+  observer.observe(mountedCamera, { childList: true, subtree: true });
+
+  function assertStableDomIdentity() {
+    const currentNodes = [
+      host.querySelector(":scope > .polycss-camera"),
+      host.querySelector(":scope > .polycss-camera > .polycss-scene"),
+      ...host.querySelectorAll(":scope > .polycss-camera > .polycss-scene > div"),
+      ...host.querySelectorAll(":scope > .polycss-camera > .polycss-scene > div > b"),
+    ];
+    if (currentNodes.length !== stableNodes.length ||
+        currentNodes.some((node, index) => node !== stableNodes[index])) {
+      throw new Error("Cityflow prepared retained-DOM identity changed");
+    }
+    return true;
+  }
+
+  return Object.freeze({
+    cameraElement: mountedCamera,
+    sceneElement: mountedScene,
+    shapeElements: Object.freeze(mountedShapes),
+    leafElements: Object.freeze(leafElements.map((leaves) => Object.freeze(leaves))),
+    assertStableDomIdentity,
+    stats() {
+      assertStableDomIdentity();
+      return Object.freeze({
+        retainedDomMode: "prepared-flat-polycss-snapshot",
+        retainedCameraRootCount: 1,
+        retainedSceneRootCount: 1,
+        retainedModelRootCount: 0,
+        retainedBoxRootCount: mountedShapes.length,
+        retainedFaceLeafCount: leafElements.length * FACES_PER_BOX,
+        runtimeDomCreationCount,
+        runtimeDomRemovalCount,
+        runtimeDomMutationCount: runtimeDomCreationCount + runtimeDomRemovalCount,
+        runtimeDomGrowth: false,
+      });
+    },
+    destroy() {
+      observer.disconnect();
+      mountedCamera.remove();
+    },
+  });
+}
+
+function hasDiagnosticAttributes(element) {
+  return element.id || element.className ||
+    [...element.attributes].some((attribute) => attribute.name.startsWith("data-"));
+}

--- a/src/adapters/cityflow/src/main.mjs
+++ b/src/adapters/cityflow/src/main.mjs
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: HPND
 import "./csscityflow/styles.css";
 import { requireExamplesStage } from "../../../../site/examples-shell-client.mjs";
-import { mountCityflow } from "./csscityflow/client.mjs";
+import { selectCityflowPreparedBank } from "./csscityflow/profileSelection.mjs";
 
-mountCityflow(requireExamplesStage());
+const host = requireExamplesStage();
+const bankId = selectCityflowPreparedBank({
+  width: host.clientWidth || innerWidth,
+  height: host.clientHeight || innerHeight,
+});
+const { mountCityflow } = bankId === "mobile"
+  ? await import("./csscityflow/mobileClient.mjs")
+  : await import("./csscityflow/client.mjs");
+mountCityflow(host, bankId);

--- a/src/adapters/cityflow/src/prepare/csscityflow/mobileModel.mjs
+++ b/src/adapters/cityflow/src/prepare/csscityflow/mobileModel.mjs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: HPND
+import { mobileFaceTransforms } from "../../csscityflow/mobileTransforms.mjs";
+
+// Authored mobile composition, not a native Cityflow reconstruction.
+// Disjoint ground footprints and this fixed isometric view have a fixed painter order.
+export function buildCityflowMobileProduct() {
+  const boxes = [];
+  // Stretch heights, not footprints or the camera. Keep compact base samples;
+  // the loader applies this fixed scale while expanding the prepared states.
+  const heightScale = 2;
+  const rowDepths = [44, 72, 48, 60, 36, 80, 54, 66, 40, 100].map((value) => value * 1.2);
+  const columnWidths = [72, 44, 84, 52, 64, 36, 76, 48, 60, 64].map((value) => value * 1.2);
+  let worldY = -360;
+  for (let row = 0; row < 10; row += 1) {
+    const depth = rowDepths[row];
+    let worldX = -360;
+    for (let column = 0; column < 10; column += 1) {
+      const width = columnWidths[(column + row * 3) % columnWidths.length];
+      const x = worldX - worldY * 0.36;
+      const y = worldX * 0.22 + worldY * 0.6;
+      // All viewports crop inside this fixed camera. Omit plots that can never
+      // touch its bounds at any height; no runtime visibility work is needed.
+      if (!(x + width < -256 || x - depth * 0.36 > 256 ||
+          y + width * 0.22 + depth * 0.6 < -170 || y - 62 * heightScale > 170)) {
+        boxes.push({ row, column, x, y, width, depth, worldX, worldY });
+      }
+      worldX += width;
+    }
+    worldY += depth;
+  }
+  // Contiguous row bands are painted far-to-near, then left-to-right within
+  // each band. This order remains correct at every independently moving height.
+  const heights = new Uint16Array(360 * boxes.length);
+  const bytes = Buffer.alloc(heights.length * 2);
+  for (let frame = 0; frame < 360; frame += 1) {
+    for (let box = 0; box < boxes.length; box += 1) {
+      const { row, column } = boxes[box];
+      const phase = (row + column) * 0.56 + (column - row) * 0.19;
+      const time = frame * 2 * Math.PI / 360;
+      const height = Math.round((40 + 18 * Math.sin(time - phase) +
+        4 * Math.sin(time * 2 - row * 0.9 + column * 0.4)) * 1000);
+      heights[frame * boxes.length + box] = height;
+      bytes.writeUInt16LE(height, (frame * boxes.length + box) * 2);
+    }
+  }
+  const colors = [
+    ["#608519", "#304810", "#1d340a"],
+    ["#578c1a", "#294811", "#16320b"],
+    ["#6e8b1a", "#3b4b10", "#253409"],
+    ["#45931b", "#244a12", "#13310c"],
+  ];
+  const snapshotHtml = `<main class="polycss-camera cityflow-mobile"><div class="polycss-scene">${boxes.map((box, index) => {
+    const transforms = mobileFaceTransforms(heights[index], box.width, box.depth, heightScale);
+    const palette = colors[(box.row * 3 + box.column) % colors.length];
+    return `<div style="transform:translate(${box.x}px,${box.y}px)">${transforms.map((transform, face) =>
+      `<b style="transform:${transform};background-color:${palette[face]}"></b>`).join("")}</div>`;
+  }).join("")}</div></main>`;
+  const css = `/* Authored Cityflow mobile: ordinary 2D faces, no depth sorting. */
+.example-stage>.polycss-camera.cityflow-mobile{
+  position:absolute;left:50%;top:50%;width:512px;height:340px;
+  overflow:hidden;contain:layout paint style;perspective:none!important;
+  transform:scale(max(calc(100cqw / 512px),calc(100cqh / 340px))) translate(-50%,-50%);
+  transform-origin:0 0;
+}
+.example-stage>.polycss-camera.cityflow-mobile>.polycss-scene{
+  position:absolute;left:256px;top:170px;width:0;height:0;
+  transform:none!important;transform-style:flat;transform-origin:0 0;
+}
+.example-stage>.polycss-camera.cityflow-mobile>.polycss-scene>div{
+  position:absolute;left:0;top:0;width:0;height:0;
+  transform-style:flat;transform-origin:0 0;
+}
+.example-stage>.polycss-camera.cityflow-mobile>.polycss-scene>div>b{
+  display:block;position:absolute;left:0;top:0;width:1px;height:1px;
+  margin:0;padding:0;border:0;transform-origin:0 0;transform-style:flat;
+  backface-visibility:visible;
+}
+`;
+  return {
+    boxes, snapshotHtml, css,
+    playback: {
+      schema: "csscityflow-mobile-playback@1", bankId: "mobile", modelId: "cityflow-mobile",
+      provenance: "authored-isometric-mobile-composition-not-native-parity",
+      boxCount: boxes.length, facesPerBox: 3, frameCount: 360, framesPerSecond: 60,
+      heightScale,
+      footprints: boxes.map(({ width, depth }) => [width, depth]),
+      heightEncoding: "uint16-le-millipixels-base64", heightsBase64: bytes.toString("base64"),
+    },
+  };
+}

--- a/src/adapters/cityflow/test/csscityflow-desktop-preservation.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-desktop-preservation.test.mjs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: HPND
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { preparedMobileBank } from "../src/csscityflow/mobilePlayback.mjs";
+import { decodeMobileHeights } from "../src/csscityflow/mobileTransforms.mjs";
+
+const root = new URL("../../../../build/generated/public/csscityflow/", import.meta.url);
+// Main 0f872754: the mobile replacement must not change desktop's bytes.
+test("mobile replacement preserves the main desktop prepared product byte-for-byte", async () => {
+  for (const [path, expected] of [
+    ["cityflow.playback.json", "aa05e854b3b4241869cf05cc069fcec10da68944c7c77de8c9eeb8ecd15ed231"],
+    ["cityflow.css", "9ab06aa5e1680d5e4f31bfb4097fa4fc6171fa2532b7cbc7720ddd8af234dfd4"],
+    ["cityflow/model.json", "2324022d137aabe5cb37e56b2d6c7c4ba1e5ad5996d8007fb71b9774fea63642"],
+    ["cityflow/manifest.json", "9bb0740dd8bad387a2d347450d7cbbf591b93e7cab5916ae8b28a132153d1d19"],
+  ]) {
+    assert.equal(createHash("sha256").update(await readFile(new URL(path, root))).digest("hex"), expected, path);
+  }
+});
+
+test("new mobile assets are content-addressed and carry scalars rather than matrices", async () => {
+  const metadata = JSON.parse(await readFile(new URL("prepared.json", root), "utf8"));
+  const bank = preparedMobileBank(metadata);
+  for (const kind of ["snapshot", "stylesheet", "playback"]) {
+    const asset = bank[kind];
+    const bytes = await readFile(new URL(asset.assetUrl.replace("/csscityflow/", ""), root));
+    assert.equal(bytes.length, asset.byteLength);
+    assert.equal(createHash("sha256").update(bytes).digest("hex"), asset.sha256);
+    assert.doesNotMatch(bytes.toString(), /matrix3d|translateZ|preserve-3d|will-change|clip-path|mask/u);
+    if (kind === "playback") {
+      assert.doesNotMatch(bytes.toString(), /matrix\(/u);
+      assert.equal(decodeMobileHeights(JSON.parse(bytes)).length, 360 * 72);
+    }
+  }
+});

--- a/src/adapters/cityflow/test/csscityflow-mobile.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-mobile.test.mjs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: HPND
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCityflowMobileProduct } from "../src/prepare/csscityflow/mobileModel.mjs";
+import { decodeMobileHeights, mobileFaceTransforms } from "../src/csscityflow/mobileTransforms.mjs";
+import { createCityflowMobilePlayer } from "../src/csscityflow/mobilePlayback.mjs";
+import { selectCityflowPreparedBank } from "../src/csscityflow/profileSelection.mjs";
+
+test("mobile selection stays mobile in landscape and leaves desktop alone", () => {
+  const base = { width: 1280, height: 720, mediaMatches: () => false, userAgent: "desktop", userAgentDataMobile: false };
+  assert.equal(selectCityflowPreparedBank(base), "desktop");
+  for (const userAgent of ["Android", "iPhone", "iPad"]) {
+    assert.equal(selectCityflowPreparedBank({ ...base, userAgent }), "mobile");
+  }
+  assert.equal(selectCityflowPreparedBank({ ...base, userAgentDataMobile: true }), "mobile");
+  for (const query of ["(hover: none) and (pointer: coarse)"]) {
+    assert.equal(selectCityflowPreparedBank({ ...base, mediaMatches: (value) => value === query }), "mobile");
+  }
+  assert.equal(selectCityflowPreparedBank({ ...base, width: 599 }), "mobile");
+});
+
+test("mobile is deterministic, compact, 2D, and has a bounded complete loop", () => {
+  const product = buildCityflowMobileProduct();
+  assert.deepEqual(product, buildCityflowMobileProduct());
+  const text = JSON.stringify(product.playback);
+  assert.ok(Buffer.byteLength(text) < 90000);
+  assert.doesNotMatch(text, /matrix\(|matrix3d\(/u);
+  assert.doesNotMatch(product.css + product.snapshotHtml,
+    /matrix3d|preserve-3d|translateZ|will-change|clip-path|mask|gradient|filter|::before|::after/u);
+  const count = product.boxes.length;
+  assert.ok(count >= 60 && count <= 100);
+  assert.equal((product.snapshotHtml.match(/<b\b/gu) ?? []).length, count * 3);
+  const heights = decodeMobileHeights(product.playback);
+  assert.equal(product.playback.heightScale, 2);
+  let maxStep = 0;
+  for (let frame = 0; frame < 360; frame += 1) {
+    let motion = 0;
+    for (let box = 0; box < count; box += 1) {
+      const height = heights[frame * count + box] * product.playback.heightScale / 1000;
+      const step = Math.abs(heights[((frame + 1) % 360) * count + box] * product.playback.heightScale / 1000 - height);
+      maxStep = Math.max(maxStep, step);
+      motion += step;
+      const { x, y, width, depth } = product.boxes[box];
+      assert.ok(Math.abs(x) < 400 && Math.abs(y) < 400);
+      const [top, left, right] = mobileFaceTransforms(heights[frame * count + box], width, depth, product.playback.heightScale)
+        .map((value) => value.slice(7, -1).split(",").map(Number));
+      const point = (matrix, u, v) => [matrix[0] * u + matrix[2] * v + matrix[4],
+        matrix[1] * u + matrix[3] * v + matrix[5]];
+      const near = (a, b) => a.forEach((value, index) => assert.ok(Math.abs(value - b[index]) < 1e-10));
+      near(point(top, 0, 1), point(left, 0, 0));
+      near(point(top, 0, 0), [0, -height]);
+      near(point(top, 1, 1), point(left, 1, 0));
+      near(point(top, 1, 1), point(right, 0, 0));
+      near(point(top, 1, 0), point(right, 1, 0));
+      near(point(left, 1, 1), point(right, 0, 1));
+      near(point(left, 0, 1), [-depth * 0.36, depth * 0.6]);
+      near(point(right, 1, 1), [width, width * 0.22]);
+    }
+    assert.ok(motion > 0, `frame ${frame} must not repeat the preceding image`);
+  }
+  assert.ok(maxStep < 0.91, `including the loop seam: ${maxStep}`);
+  for (let index = 1; index < count; index += 1) {
+    const a = product.boxes[index];
+    const b = product.boxes[index - 1];
+    assert.ok(a.row > b.row || (a.row === b.row && a.column > b.column));
+  }
+  for (let a = 0; a < count; a += 1) for (let b = a + 1; b < count; b += 1) {
+    const first = product.boxes[a];
+    const second = product.boxes[b];
+    const overlapX = Math.min(first.worldX + first.width, second.worldX + second.width) -
+      Math.max(first.worldX, second.worldX);
+    const overlapY = Math.min(first.worldY + first.depth, second.worldY + second.depth) -
+      Math.max(first.worldY, second.worldY);
+    assert.ok(overlapX <= 1e-9 || overlapY <= 1e-9, "ground footprints must never intersect");
+  }
+  // Every point in the camera's ground projection has an owner: no streets,
+  // omitted plots, or invented gaps between the towers.
+  for (let y = -170; y <= 170; y += 5) for (let x = -256; x <= 256; x += 5) {
+    const worldX = (0.6 * x + 0.36 * y) / 0.6792;
+    const worldY = (-0.22 * x + y) / 0.6792;
+    assert.ok(product.boxes.some((box) => worldX >= box.worldX - 1e-9 &&
+      worldX <= box.worldX + box.width + 1e-9 && worldY >= box.worldY - 1e-9 &&
+      worldY <= box.worldY + box.depth + 1e-9), `uncovered ground at ${x},${y}`);
+  }
+  assert.throws(() => decodeMobileHeights({ ...product.playback, heightsBase64: "AA==" }));
+  for (const heightScale of [undefined, 0, -1, Infinity, NaN, 2.01]) {
+    assert.throws(() => decodeMobileHeights({ ...product.playback, heightScale }));
+  }
+});
+
+test("mobile uses the existing adjacent scheduler, cached transforms and stable leaves", () => {
+  const { playback, snapshotHtml } = buildCityflowMobileProduct();
+  const heights = decodeMobileHeights(playback);
+  const count = playback.boxCount;
+  const leaves = Array.from({ length: count }, (_, box) =>
+    mobileFaceTransforms(heights[box], ...playback.footprints[box], playback.heightScale).map((transform) => ({ style: { transform } })));
+  const dom = { shapeElements: Array(count).fill({}), leafElements: leaves, stats: () => ({}) };
+  let now = 0;
+  let callback;
+  const player = createCityflowMobilePlayer({ playback, dom, readNow: () => now,
+    requestFrame: (next) => { callback = next; return 1; }, cancelFrame: () => { callback = null; } });
+  assert.match(snapshotHtml, /cityflow-mobile/u);
+  player.resume();
+  for (let tick = 0; tick < 720; tick += 1) {
+    now += 1000 / 60;
+    callback(now);
+    assert.equal(player.stats().frameIndex, (tick + 1) % 360);
+  }
+  assert.equal(player.stats().preparedStateSkipCount, 0);
+  player.pause();
+  assert.equal(callback, null);
+  player.seekFrame(179);
+  for (let box = 0; box < count; box += 1) {
+    assert.deepEqual(leaves[box].map((leaf) => leaf.style.transform),
+      mobileFaceTransforms(heights[179 * count + box], ...playback.footprints[box], playback.heightScale));
+  }
+  assert.throws(() => player.seekFrame(360));
+  player.destroy();
+  player.resume();
+  assert.equal(callback, null);
+});

--- a/src/adapters/cityflow/test/csscityflow-runtime-surface.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-runtime-surface.test.mjs
@@ -125,7 +125,10 @@ test("owns project 12 and the shared css.graphics route shell", async () => {
   assert.match(html, /<!-- cssgraphics-examples-sidebar -->/u);
   assert.match(html, /<main class="example-stage"/u);
   assert.match(html, /<link rel="stylesheet" href="\/site\.css"/u);
-  assert.match(main, /mountCityflow\(requireExamplesStage\(\)\)/u);
+  assert.match(main, /const host = requireExamplesStage\(\)/u);
+  assert.match(main, /mountCityflow\(host, bankId\)/u);
+  assert.match(main, /await import\("\.\/csscityflow\/mobileClient\.mjs"\)/u);
+  assert.match(main, /await import\("\.\/csscityflow\/client\.mjs"\)/u);
   assert.match(config, /createExamplesShellPlugin\("cityflow"\)/u);
   assert.match(config, /deployBuild \? "\/cityflow\/" : "\/"/u);
   assert.match(sceneRouter, /mountCityflow\(host\)/u);

--- a/src/adapters/cityflow/tools/prepare-csscityflow.mjs
+++ b/src/adapters/cityflow/tools/prepare-csscityflow.mjs
@@ -12,6 +12,7 @@ import {
 } from "../src/prepare/csscityflow/model.mjs";
 import { CITYFLOW_BANKS } from "../src/prepare/csscityflow/sourceModel.mjs";
 import { ensureCityflowSourceTree } from "../src/prepare/csscityflow/sourceAuthority.mjs";
+import { buildCityflowMobileProduct } from "../src/prepare/csscityflow/mobileModel.mjs";
 
 const adapterRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = resolve(adapterRoot, "..", "..", "..");
@@ -91,6 +92,25 @@ for (const { manifest } of packages) {
 }
 const catalog = await buildPolyMorphCatalog("cityflow", packages);
 await writeBytes(join(stagingRoot, "catalog.json"), catalog.bytes);
+// Add the authored mobile product without changing the legacy desktop closure.
+// Keep legacy mobile assets for already-open clients; new clients do not fetch them.
+const mobileProduct = buildCityflowMobileProduct();
+const mobile = {
+  schema: "csscityflow-mobile-product@1", id: "mobile", modelId: "cityflow-mobile",
+  boxCount: mobileProduct.boxes.length, leafCount: mobileProduct.boxes.length * 3,
+  frameCount: 360, provenance: "authored-isometric-mobile-composition-not-native-parity",
+};
+for (const [kind, extension, content] of [
+  ["snapshot", "html", mobileProduct.snapshotHtml],
+  ["stylesheet", "css", mobileProduct.css],
+  ["playback", "json", `${JSON.stringify(mobileProduct.playback)}\n`],
+]) {
+  const bytes = Buffer.from(content);
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  const assetUrl = `/csscityflow/assets/mobile-${kind}-${sha256}.${extension}`;
+  await writeBytes(join(stagingRoot, assetUrl.replace(/^\/csscityflow\//u, "")), bytes);
+  mobile[kind] = { assetUrl, sha256, byteLength: bytes.byteLength };
+}
 await writeFile(join(stagingRoot, "prepared.json"), `${JSON.stringify({
   schema: "csscityflow-prepared-product@3",
   status: "ready",
@@ -124,6 +144,7 @@ await writeFile(join(stagingRoot, "prepared.json"), `${JSON.stringify({
     ],
   },
   banks: preparedBanks,
+  mobile,
 }, null, 2)}\n`);
 await rm(outputRoot, { recursive: true, force: true });
 await mkdir(dirname(outputRoot), { recursive: true });

--- a/src/adapters/cityflow/tools/smoke-browser.mjs
+++ b/src/adapters/cityflow/tools/smoke-browser.mjs
@@ -6,6 +6,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { extname, resolve, sep } from "node:path";
 import { chromium } from "playwright";
+import { captureMobile } from "./smoke-mobile.mjs";
 
 const adapterRoot = resolve(import.meta.dirname, "..");
 const repositoryRoot = resolve(adapterRoot, "..", "..", "..");
@@ -47,15 +48,8 @@ try {
     maximumShapeWrites: 187, maximumColorWrites: 271,
     sideDepthMaximum: 0.28, sideDepthOverrides: 19, url: route,
   });
-  const mobile = await capture({
-    profile: "mobile", width: 390, height: 844, bankId: "mobile", modelId: "cityflow-mobile",
-    boxes: 100, leaves: 300, visibleBoxRange: [100, 100], visibleFaceRange: [300, 300],
-    initialVisibleBoxes: 100, initialVisibleFaces: 300, initialVisibilityWrites: 0,
-    staticSuppressedBoxes: 0, staticSuppressedFaces: 0,
-    maximumShapeWrites: 100, maximumColorWrites: 159,
-    sideDepthDefault: 0.28, sideDepthMaximum: 0.28, sideDepthOverrides: 0, url: route,
-  });
-  const requestedStylesheets = [desktop, mobile].map(({ preparedRequests }) =>
+  const mobile = await captureMobile({ browser, route, width: 390, height: 844, outputRoot });
+  const requestedStylesheets = [desktop].map(({ preparedRequests }) =>
     preparedRequests.filter((path) => path.endsWith(".css")));
   if (requestedStylesheets.some((paths) => paths.length !== 1) ||
       new Set(requestedStylesheets.flat()).size !== 1) {
@@ -68,7 +62,7 @@ try {
     schema: "csscityflow-browser-smoke@5",
     route,
     deploy,
-    sharedStylesheet: requestedStylesheets[0][0],
+    desktopStylesheet: requestedStylesheets[0][0],
     desktop,
     mobile,
     home,

--- a/src/adapters/cityflow/tools/smoke-mobile.mjs
+++ b/src/adapters/cityflow/tools/smoke-mobile.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: HPND
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { chromium } from "playwright";
+import sharp from "sharp";
+import { buildCityflowMobileProduct } from "../src/prepare/csscityflow/mobileModel.mjs";
+import { decodeMobileHeights } from "../src/csscityflow/mobileTransforms.mjs";
+
+// Independent pixel check: construct ordinary isometric polygons directly from
+// the authored grid and scalar heights, not from the browser's CSS matrices.
+const product = buildCityflowMobileProduct();
+const heights = decodeMobileHeights(product.playback);
+const palettes = [[96,133,25,48,72,16,29,52,10], [87,140,26,41,72,17,22,50,11],
+  [110,139,26,59,75,16,37,52,9], [69,147,27,36,74,18,19,49,12]];
+
+export async function captureMobile({ browser, route, width, height,
+  deviceScaleFactor = 2, mobileDevice = true, outputRoot, allFrames = false }) {
+  const label = `mobile-${width}x${height}-dpr${deviceScaleFactor}`;
+  const directory = resolve(outputRoot, label);
+  await mkdir(directory, { recursive: true });
+  const page = await browser.newPage({ viewport: { width, height }, deviceScaleFactor,
+    isMobile: mobileDevice, hasTouch: mobileDevice });
+  const errors = [];
+  const preparedRequests = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname;
+    if (path.startsWith("/csscityflow/")) preparedRequests.push(path);
+  });
+  try {
+    await page.goto(route, { waitUntil: "networkidle" });
+    await page.waitForFunction(() => globalThis.__csscityflow?.ready || globalThis.__csscityflow?.errors.length);
+    const initial = await page.evaluate(() => {
+      const state = globalThis.__csscityflow;
+      if (!state.ready) throw new Error(state.errors.join("\n"));
+      state.player.pause();
+      return { bankId: state.bankId, stats: state.player.stats() };
+    });
+    assert.equal(initial.bankId, "mobile");
+    assert.equal(initial.stats.retainedFaceCount, product.boxes.length * 3);
+    assert.equal(preparedRequests.length, 4);
+    assert.ok(preparedRequests.every((path) => path === "/csscityflow/prepared.json" ||
+      /^\/csscityflow\/assets\/mobile-(snapshot|stylesheet|playback)-[a-f0-9]{64}\.(html|css|json)$/u.test(path)));
+    let checkedInteriorPixels = 0;
+    let checkedGapPixels = 0;
+    const frameNumbers = allFrames ? Array.from({ length: 360 }, (_, index) => index) : [0, 90, 180, 270, 359];
+    const framesDirectory = resolve(directory, "frames");
+    await mkdir(framesDirectory, { recursive: true });
+    let previous;
+    let repeatedImages = 0;
+    for (const frame of frameNumbers) {
+      const layout = await page.evaluate((frameIndex) => {
+        const state = globalThis.__csscityflow;
+        state.player.seekFrame(frameIndex);
+        const camera = state.dom.cameraElement;
+        const scene = state.dom.sceneElement;
+        const stage = camera.parentElement.getBoundingClientRect();
+        const leaves = state.dom.leafElements.flat();
+        for (const element of [camera, scene, ...state.dom.shapeElements, ...leaves]) {
+          const style = getComputedStyle(element);
+          if (style.transformStyle !== "flat" || style.perspective !== "none" ||
+              style.transform.startsWith("matrix3d") || style.visibility !== "visible" ||
+              style.display === "none") throw new Error("Mobile inherited a 3D or hidden surface");
+        }
+        for (const leaf of leaves) {
+          const box = leaf.getBoundingClientRect();
+          if (box.width <= 0 || box.height <= 0 || box.width > stage.width || box.height > stage.height) {
+            throw new Error(`Mobile face has an unbounded raster area at ${frameIndex}`);
+          }
+        }
+        if (getComputedStyle(camera).overflow !== "hidden") throw new Error("Mobile camera lost its paint clip");
+        const info = document.querySelector(".example-info");
+        const hudRange = document.createRange();
+        if (info) hudRange.selectNodeContents(info);
+        return { x: scene.getBoundingClientRect().x, y: scene.getBoundingClientRect().y,
+          scale: camera.getBoundingClientRect().width / 512,
+          stage: stage.toJSON(), hud: info ? hudRange.getBoundingClientRect().toJSON() : null };
+      }, frame);
+      const png = await page.screenshot();
+      const { data, info } = await sharp(png).removeAlpha().raw().toBuffer({ resolveWithObject: true });
+      let blackGapPixels = 0;
+      for (let py = Math.ceil((layout.stage.top + 2) * deviceScaleFactor);
+        py < Math.floor((layout.stage.bottom - 2) * deviceScaleFactor); py += 1) {
+        for (let px = Math.ceil((layout.stage.left + 2) * deviceScaleFactor);
+          px < Math.floor((layout.stage.right - 2) * deviceScaleFactor); px += 1) {
+          const index = (py * info.width + px) * 3;
+          checkedGapPixels += 1;
+          if (data[index] === 0 && data[index + 1] === 0 && data[index + 2] === 0) blackGapPixels += 1;
+        }
+      }
+      if (previous?.equals(data)) repeatedImages += 1;
+      previous = data;
+      const polygons = framePolygons(frame);
+      let badPixels = 0;
+      const failures = [];
+      for (const face of polygons) {
+        for (const u of [0.2, 0.5, 0.8]) for (const v of [0.2, 0.5, 0.8]) {
+          const x = face.x + face.ax * u + face.bx * v;
+          const y = face.y + face.ay * u + face.by * v;
+          const px = Math.floor((layout.x + x * layout.scale) * deviceScaleFactor);
+          const py = Math.floor((layout.y + y * layout.scale) * deviceScaleFactor);
+          if (px < 0 || py < 0 || px >= info.width || py >= info.height) continue;
+          const cssX = (px + 0.5) / deviceScaleFactor;
+          const cssY = (py + 0.5) / deviceScaleFactor;
+          if (cssX < layout.stage.left + 2 || cssX > layout.stage.right - 2 ||
+              cssY < layout.stage.top + 2 || cssY > layout.stage.bottom - 2) continue;
+          if (layout.hud && cssX >= layout.hud.left - 2 && cssX <= layout.hud.right + 2 &&
+              cssY >= layout.hud.top - 2 && cssY <= layout.hud.bottom + 2) continue;
+          const actualX = ((px + 0.5) / deviceScaleFactor - layout.x) / layout.scale;
+          const actualY = ((py + 0.5) / deviceScaleFactor - layout.y) / layout.scale;
+          const owner = pixelOwner(polygons, actualX, actualY, 1.25 / (layout.scale * deviceScaleFactor));
+          if (!owner || owner.edgeDistance < 0.12) continue;
+          checkedInteriorPixels += 1;
+          const index = (py * info.width + px) * 3;
+          if (owner.face.color.some((value, channel) => Math.abs(data[index + channel] - value) > 2)) {
+            badPixels += 1;
+            if (failures.length < 12) failures.push({ px, py, expected: owner.face.color,
+              actual: [...data.subarray(index, index + 3)], edgeDistance: owner.edgeDistance });
+          }
+        }
+      }
+      await writeFile(resolve(framesDirectory, `frame_${String(frame).padStart(4, "0")}.png`), png);
+      assert.equal(blackGapPixels, 0, `${label} frame ${frame} exposed black space between towers`);
+      if (badPixels) console.log(JSON.stringify({ label, frame, layout, failures }));
+      assert.equal(badPixels, 0, `${label} frame ${frame}: missing/wrong interior pixels; see ${framesDirectory}`);
+    }
+    assert.equal(repeatedImages, 0);
+    const lifecycle = await page.evaluate(async ({ width, height }) => {
+      const state = globalThis.__csscityflow;
+      state.player.seekFrame(0);
+      state.player.resume();
+      const samples = [];
+      for (let index = 0; index < 125; index += 1) {
+        await new Promise(requestAnimationFrame);
+        const stats = state.player.stats();
+        samples.push({ frame: stats.frameIndex, time: performance.now(), publications: stats.publicationCount });
+      }
+      state.player.pause();
+      const paused = state.player.stats().frameIndex;
+      await new Promise((done) => setTimeout(done, 80));
+      if (state.player.stats().frameIndex !== paused) throw new Error("Mobile did not pause");
+      return { samples, stats: state.player.stats(), originalViewport: { width, height } };
+    }, { width, height });
+    const advances = lifecycle.samples.slice(1).map((row, index) => ({
+      delta: (row.frame - lifecycle.samples[index].frame + 360) % 360,
+      milliseconds: row.time - lifecycle.samples[index].time,
+    }));
+    assert.ok(advances.every(({ delta }) => delta <= 1), "mobile skipped a prepared state");
+    assert.ok(advances.filter(({ delta }) => delta === 1).length > 60);
+    assert.equal(lifecycle.stats.runtimeDomMutationCount, 0);
+    // Rotation must resize the existing scene, never rebuild or switch banks.
+    await page.setViewportSize({ width: height, height: width });
+    const rotated = await page.evaluate(() => ({ bankId: __csscityflow.bankId,
+      stable: __csscityflow.dom.assertStableDomIdentity(), stats: __csscityflow.player.stats() }));
+    assert.equal(rotated.bankId, "mobile");
+    assert.equal(rotated.stable, true);
+    assert.equal(rotated.stats.runtimeDomMutationCount, 0);
+    assert.deepEqual(errors, []);
+    return { label, width, height, deviceScaleFactor, checkedFrames: frameNumbers.length,
+      checkedInteriorPixels, checkedGapPixels, blackGapPixels: 0,
+      wrongInteriorPixels: 0, repeatedImages, preparedRequests,
+      maximumSampleIntervalMs: Math.max(...advances.map(({ milliseconds }) => milliseconds)),
+      adjacentTransitions: advances.filter(({ delta }) => delta === 1).length,
+      stableAfterRotation: true, framesDirectory };
+  } finally { await page.close(); }
+}
+
+function framePolygons(frame) {
+  return product.boxes.flatMap(({ row, column, x, y, width, depth }, box) => {
+    const h = heights[frame * product.boxes.length + box] * product.playback.heightScale / 1000;
+    const rgb = palettes[(row * 3 + column) % 4];
+    return [
+      { x, y: y - h, ax: width, ay: width * 0.22, bx: -depth * 0.36, by: depth * 0.6, color: rgb.slice(0, 3) },
+      { x: x - depth * 0.36, y: y + depth * 0.6 - h, ax: width, ay: width * 0.22,
+        bx: 0, by: h, color: rgb.slice(3, 6) },
+      { x: x + width - depth * 0.36, y: y + width * 0.22 + depth * 0.6 - h,
+        ax: depth * 0.36, ay: -depth * 0.6, bx: 0, by: h, color: rgb.slice(6, 9) },
+    ];
+  });
+}
+
+function pixelOwner(polygons, x, y, rasterMargin) {
+  for (let index = polygons.length - 1; index >= 0; index -= 1) {
+    const face = polygons[index];
+    const det = face.ax * face.by - face.ay * face.bx;
+    const u = ((x - face.x) * face.by - (y - face.y) * face.bx) / det;
+    const v = (face.ax * (y - face.y) - face.ay * (x - face.x)) / det;
+    // Exclude the 1.25-device-pixel antialias band of ANY nearer face,
+    // including a nearer edge just outside the mathematical polygon.
+    const eu = rasterMargin * Math.hypot(face.bx, face.by) / Math.abs(det);
+    const ev = rasterMargin * Math.hypot(face.ax, face.ay) / Math.abs(det);
+    if (u >= -eu && u <= 1 + eu && v >= -ev && v <= 1 + ev &&
+        (u < eu || u > 1 - eu || v < ev || v > 1 - ev)) return null;
+    if (u >= 0 && u <= 1 && v >= 0 && v <= 1) {
+      return { face, edgeDistance: Math.min(u, v, 1 - u, 1 - v) };
+    }
+  }
+  return null;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const browser = await chromium.launch({ channel: "chrome", headless: true });
+  const outputRoot = resolve(process.env.CSSCITYFLOW_MOBILE_SMOKE_OUT ?? "output/playwright/cityflow-mobile-rebuild/continuous-loop");
+  const route = process.env.CSSCITYFLOW_SMOKE_URL ?? "http://127.0.0.1:4325/cityflow/";
+  try {
+    const reports = [];
+    for (const [width, height, deviceScaleFactor] of [[320,568,1], [390,844,2], [448,827,2.25], [844,390,2], [599,900,1]]) {
+      const report = await captureMobile({ browser, route, width, height, deviceScaleFactor,
+        outputRoot, allFrames: process.argv.includes("--all-frames") });
+      reports.push(report);
+      console.log(JSON.stringify(report));
+    }
+    await writeFile(resolve(outputRoot, "report.json"), JSON.stringify({
+      browser: await browser.version(), target: "installed Chrome, headless; not physical Android",
+      route, reports,
+    }, null, 2));
+  } finally { await browser.close(); }
+}


### PR DESCRIPTION
## Summary

- Replace the mobile renderer with 72 touching towers, 216 ordinary 2D faces, and the taller six-second prepared motion loop approved locally.
- Select and lazy-load the appropriate client once using the existing device/width policy. Mobile never loads the desktop runtime or legacy mobile assets.
- Preserve desktop from main `0f8727544a30d0a742f43d60f3ef969b823abeb1`: no changes to its renderer, stylesheet, projection, scheduler, source model, or prepared motion. The existing client only accepts the already-selected bank.
- Keep legacy assets available to cached clients. Add content-addressed mobile assets and regression tests for desktop hashes, scalar transport, joined faces, and retained lifecycle.

## Validation

- `pnpm test:cityflow`: 29 passing tests.
- `pnpm prepare:cityflow:check`: deterministic 14-file generated closure, SHA-256 `04961cfa46496961c44d994f54d5123854527b6ac3401ddab8b0627b2799263a`.
- `pnpm build:cityflow:deploy` and the two deploy artifact tests pass.
- Every pre-existing generated file matches main byte-for-byte except `prepared.json`, whose only change is the additive mobile descriptor.
- Installed Chrome 152: five mobile viewport/DPR profiles, including every state at 390x844 DPR2, pass face-interior, gap, pause, and rotation checks. These are browser observations, not physical Android proof or native parity.
- Desktop before/after comparison: all 301 states at 1280x720 DPR1, 600x900 DPR2, and 2560x1224 DPR1 have identical retained DOM and identical scene PNGs (903 matched frames). Both players start with the same public source-frame-zero seek, then presentation frame zero. Attribution is hidden on both sides and captures cover the entire Cityflow stage, including the pixels behind attribution; sidebar thumbnails are outside this renderer-only comparison. The initial full-page normal-size 301-frame comparison was also byte-exact.

## Scope and payload

16 Cityflow source/test/documentation files; no unrelated adapter changes, dependencies, generated assets, captures, or experimental desktop work.
Mobile snapshot + stylesheet + scalar playback: 102,373 raw bytes / 56,081 locally Brotli-compressed bytes. Shared metadata, JavaScript, and site assets are additional.
