### PR TITLE
fix(cityflow): use mobile entry in production site

### DIFF
--- a/site/scene-router.mjs
+++ b/site/scene-router.mjs
@@ -43,7 +43,7 @@ function requireSceneLifecycle(mount) {
 async function mountForProject(projectId, host) {
   switch (projectId) {
     case "cityflow": {
-      const { mountCityflow } = await import("../src/adapters/cityflow/src/csscityflow/client.mjs");
+      const { mountCityflow } = await import("../src/adapters/cityflow/src/csscityflow/entry.mjs");
       return mountCityflow(host);
     }
     case "chaos": {

--- a/src/adapters/cityflow/src/csscityflow/entry.mjs
+++ b/src/adapters/cityflow/src/csscityflow/entry.mjs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: HPND
+import { selectCityflowPreparedBank } from "./profileSelection.mjs";
+
+// Both the standalone adapter and the production scene router use this entry.
+export async function mountCityflow(host) {
+  const bankId = selectCityflowPreparedBank({
+    width: host.clientWidth || innerWidth,
+    height: host.clientHeight || innerHeight,
+  });
+  const runtime = bankId === "mobile"
+    ? await import("./mobileClient.mjs")
+    : await import("./client.mjs");
+  return runtime.mountCityflow(host, bankId);
+}

--- a/src/adapters/cityflow/src/main.mjs
+++ b/src/adapters/cityflow/src/main.mjs
@@ -1,14 +1,6 @@
 // SPDX-License-Identifier: HPND
 import "./csscityflow/styles.css";
 import { requireExamplesStage } from "../../../../site/examples-shell-client.mjs";
-import { selectCityflowPreparedBank } from "./csscityflow/profileSelection.mjs";
+import { mountCityflow } from "./csscityflow/entry.mjs";
 
-const host = requireExamplesStage();
-const bankId = selectCityflowPreparedBank({
-  width: host.clientWidth || innerWidth,
-  height: host.clientHeight || innerHeight,
-});
-const { mountCityflow } = bankId === "mobile"
-  ? await import("./csscityflow/mobileClient.mjs")
-  : await import("./csscityflow/client.mjs");
-mountCityflow(host, bankId);
+await mountCityflow(requireExamplesStage());

--- a/src/adapters/cityflow/test/csscityflow-entry.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-entry.test.mjs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: HPND
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("production site and standalone adapter use the same bank-selecting entry", async () => {
+  const [entry, standalone, router] = await Promise.all([
+    readFile(new URL("../src/csscityflow/entry.mjs", import.meta.url), "utf8"),
+    readFile(new URL("../src/main.mjs", import.meta.url), "utf8"),
+    readFile(new URL("../../../../site/scene-router.mjs", import.meta.url), "utf8"),
+  ]);
+  assert.match(entry, /selectCityflowPreparedBank\(/u);
+  assert.match(entry, /await import\("\.\/mobileClient\.mjs"\)/u);
+  assert.match(entry, /await import\("\.\/client\.mjs"\)/u);
+  assert.match(entry, /runtime\.mountCityflow\(host, bankId\)/u);
+  assert.match(standalone, /csscityflow\/entry\.mjs/u);
+  assert.match(router, /cityflow\/src\/csscityflow\/entry\.mjs/u);
+  assert.doesNotMatch(router, /cityflow\/src\/csscityflow\/client\.mjs/u);
+});

--- a/src/adapters/cityflow/test/csscityflow-runtime-surface.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-runtime-surface.test.mjs
@@ -125,10 +125,8 @@ test("owns project 12 and the shared css.graphics route shell", async () => {
   assert.match(html, /<!-- cssgraphics-examples-sidebar -->/u);
   assert.match(html, /<main class="example-stage"/u);
   assert.match(html, /<link rel="stylesheet" href="\/site\.css"/u);
-  assert.match(main, /const host = requireExamplesStage\(\)/u);
-  assert.match(main, /mountCityflow\(host, bankId\)/u);
-  assert.match(main, /await import\("\.\/csscityflow\/mobileClient\.mjs"\)/u);
-  assert.match(main, /await import\("\.\/csscityflow\/client\.mjs"\)/u);
+  assert.match(main, /mountCityflow\(requireExamplesStage\(\)\)/u);
+  assert.match(main, /csscityflow\/entry\.mjs/u);
   assert.match(config, /createExamplesShellPlugin\("cityflow"\)/u);
   assert.match(config, /deployBuild \? "\/cityflow\/" : "\/"/u);
   assert.match(sceneRouter, /mountCityflow\(host\)/u);


### PR DESCRIPTION
## Change

Route the Astro production site and standalone Cityflow build through the same bank-selecting entry. Mobile loads the new 72-tower, 216-face 2D renderer; desktop continues to load the existing renderer.

PR #174 selected the new mobile runtime in the standalone entry, but Astro imported the desktop client directly. Its production build was canceled before publication. This follow-up fixes that wiring and adds a regression test for both entry points.

Five source files, 15,830 total file bytes; 38 insertions and 15 deletions. No renderer, camera, motion, prepared asset, or other adapter changes in this follow-up.

## Checks

- Cityflow: 30 tests passed. Site: 6 tests passed.
- Actual production Astro build: all 13 routes built.
- Production-build desktop comparison: all 301 prepared frames at 1280x720 DPR1, 600x900 DPR2, and 2560x1224 DPR1; 903 exact scene PNG and DOM matches. Both runs hide attribution text only; the entire city scene remains visible. Original main desktop renderer and generated assets are unchanged by #174.
- Production-build mobile: all 360 frames at 390x844 DPR2, plus five keyframes each at 320x568, 448x827 DPR2.25, 844x390, and 599x900. No black gaps or wrong sampled face interiors. Stable retained DOM, pause/resume, and rotation checks passed.
- Evidence is from installed desktop Chrome 152.0.7977.76. This is not physical Android device proof or native visual parity.

Local evidence: `output/playwright/cityflow-release/astro-verification/verification.json` and numbered frame directories (ignored, not included in the PR).

## Deployment

The #174 deploy was canceled before it replaced the user-selected live deployment. Merge this follow-up before publishing the mobile rebuild; verify the resulting production commit and both live renderer selections.
