### PR TITLE
Fix Cityflow mobile face rasterization on Android

### DIFF
--- a/src/adapters/cityflow/src/csscityflow/mobilePlayback.mjs
+++ b/src/adapters/cityflow/src/csscityflow/mobilePlayback.mjs
@@ -33,6 +33,14 @@ export function createCityflowMobilePlayer({ playback, dom, ...overrides }) {
     throw new Error("Cityflow mobile face binding drifted");
   }
   const dictionary = new Map();
+  for (let box = 0; box < playback.boxCount; box += 1) {
+    const [width, depth] = playback.footprints[box];
+    const leaves = dom.leafElements[box];
+    for (const [faceWidth, faceHeight, face] of [[width, depth, 0], [width, 124, 1], [depth, 124, 2]]) {
+      leaves[face].style.width = `${faceWidth}px`;
+      leaves[face].style.height = `${faceHeight}px`;
+    }
+  }
   const states = Array.from(heights, (height, index) => {
     const [width, depth] = playback.footprints[index % playback.boxCount];
     const key = `${width},${depth},${height}`;

--- a/src/adapters/cityflow/src/csscityflow/mobileTransforms.mjs
+++ b/src/adapters/cityflow/src/csscityflow/mobileTransforms.mjs
@@ -2,10 +2,11 @@
 // Expanded only during preparation or loading, never in the animation callback.
 export function mobileFaceTransforms(heightUnits, width, depth, heightScale) {
   const height = heightUnits * heightScale / 1000;
+  const sideHeight = 124;
   return [
-    `matrix(${width},${width * 0.22},${-depth * 0.36},${depth * 0.6},0,${-height})`,
-    `matrix(${width},${width * 0.22},0,${height},${-depth * 0.36},${depth * 0.6 - height})`,
-    `matrix(${depth * 0.36},${-depth * 0.6},0,${height},${width - depth * 0.36},${width * 0.22 + depth * 0.6 - height})`,
+    `matrix(1,0.22,-0.36,0.6,0,${-height})`,
+    `matrix(1,0.22,0,${height / sideHeight},${-depth * 0.36},${depth * 0.6 - height})`,
+    `matrix(0.36,-0.6,0,${height / sideHeight},${width - depth * 0.36},${width * 0.22 + depth * 0.6 - height})`,
   ];
 }
 

--- a/src/adapters/cityflow/test/csscityflow-mobile.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-mobile.test.mjs
@@ -44,17 +44,18 @@ test("mobile is deterministic, compact, 2D, and has a bounded complete loop", ()
       assert.ok(Math.abs(x) < 400 && Math.abs(y) < 400);
       const [top, left, right] = mobileFaceTransforms(heights[frame * count + box], width, depth, product.playback.heightScale)
         .map((value) => value.slice(7, -1).split(",").map(Number));
-      const point = (matrix, u, v) => [matrix[0] * u + matrix[2] * v + matrix[4],
-        matrix[1] * u + matrix[3] * v + matrix[5]];
+      const point = (matrix, u, v, faceWidth, faceHeight) => [
+        matrix[0] * u * faceWidth + matrix[2] * v * faceHeight + matrix[4],
+        matrix[1] * u * faceWidth + matrix[3] * v * faceHeight + matrix[5]];
       const near = (a, b) => a.forEach((value, index) => assert.ok(Math.abs(value - b[index]) < 1e-10));
-      near(point(top, 0, 1), point(left, 0, 0));
-      near(point(top, 0, 0), [0, -height]);
-      near(point(top, 1, 1), point(left, 1, 0));
-      near(point(top, 1, 1), point(right, 0, 0));
-      near(point(top, 1, 0), point(right, 1, 0));
-      near(point(left, 1, 1), point(right, 0, 1));
-      near(point(left, 0, 1), [-depth * 0.36, depth * 0.6]);
-      near(point(right, 1, 1), [width, width * 0.22]);
+      near(point(top, 0, 1, width, depth), point(left, 0, 0, width, 124));
+      near(point(top, 0, 0, width, depth), [0, -height]);
+      near(point(top, 1, 1, width, depth), point(left, 1, 0, width, 124));
+      near(point(top, 1, 1, width, depth), point(right, 0, 0, depth, 124));
+      near(point(top, 1, 0, width, depth), point(right, 1, 0, depth, 124));
+      near(point(left, 1, 1, width, 124), point(right, 0, 1, depth, 124));
+      near(point(left, 0, 1, width, 124), [-depth * 0.36, depth * 0.6]);
+      near(point(right, 1, 1, depth, 124), [width, width * 0.22]);
     }
     assert.ok(motion > 0, `frame ${frame} must not repeat the preceding image`);
   }


### PR DESCRIPTION
## What changed

- give each mobile roof and side its prepared local width and height once at mount
- keep the same 2D projected polygons with bounded matrix coefficients
- retain the existing 72 tower roots, 216 face leaves, scalar playback packet, and cached per-frame transforms
- leave desktop rendering and every prepared asset unchanged

## Why

Physical Android Chrome dropped or malformed faces when every 1 by 1 leaf was independently magnified by large matrix coefficients. Painting the same polygons on real-sized local surfaces removes that Android raster/compositor failure without changing scene geometry.

## Evidence

- physical Google Pixel 9 Pro XL, Android 16, Chrome 152.0.7977.75
- 448 by 827 CSS viewport at DPR 2.25
- all 360 prepared frames checked from the physical device
- 0 black opening pixels across the clipped stage
- 72 retained roots and 216 retained face leaves
- 30 of 30 Cityflow tests pass
- preparation determinism passes
- deploy build passes
- desktop prepared product is byte-for-byte unchanged