### PR TITLE
Flatten Cityflow retained scene DOM

### DIFF
--- a/src/adapters/cityflow/src/csscityflow/client.mjs
+++ b/src/adapters/cityflow/src/csscityflow/client.mjs
@@ -6,6 +6,7 @@ import {
   loadCityflowPreparedPlayback,
 } from "./preparedPlayback.mjs";
 import { cityflowSourceProjection } from "./sourceProjection.mjs";
+import { cleanCityflowMountedDom } from "./preparedDom.mjs";
 import {
   CSSCITYFLOW_PREPARED_BANKS,
   selectCityflowPreparedBank,
@@ -18,6 +19,7 @@ export function mountCityflow(host, selectedBankId) {
     errors: [],
     metadata: null,
     bankId: null,
+    dom: null,
     mounted: null,
     player: null,
   };
@@ -32,6 +34,7 @@ export function mountCityflow(host, selectedBankId) {
       if (destroyed) return;
       destroyed = true;
       state.player?.destroy();
+      state.dom?.destroy();
       state.mounted?.destroy();
       state.ready = false;
       if (globalThis.__csscityflow === state) delete globalThis.__csscityflow;
@@ -80,17 +83,19 @@ export function mountCityflow(host, selectedBankId) {
     for (const box of loaded.model.render.shapes) {
       const element = mounted.shapeElements.get(box.id);
       if (!element) throw new Error(`Missing retained Cityflow box ${box.id}`);
-      element.classList.add("csscityflow-box");
       shapeElements.push(element);
     }
-    const player = createCityflowPreparedPlayer({ playback, mounted, shapeElements });
+    const dom = cleanCityflowMountedDom({ mounted, shapeElements });
+    const player = createCityflowPreparedPlayer({ playback, dom });
     if (destroyed) {
       player.destroy();
+      dom.destroy();
       mounted.destroy();
       return;
     }
     state.metadata = metadata;
     state.bankId = bankId;
+    state.dom = dom;
     state.mounted = mounted;
     state.player = player;
     await waitForPaint();

--- a/src/adapters/cityflow/src/csscityflow/preparedDom.mjs
+++ b/src/adapters/cityflow/src/csscityflow/preparedDom.mjs
@@ -1,6 +1,124 @@
 // SPDX-License-Identifier: HPND
 
 const FACES_PER_BOX = 3;
+const STYLESHEET_MODEL_TRANSFORM =
+  "matrix3d(29.6, 6.484, 8.604, 0, -10.774, 17.814, 23.64, 0, 0, 25.157, -18.957, 0, -2.7, -2.7, -30, 1)";
+
+export function cleanCityflowMountedDom({ mounted, shapeElements }) {
+  const cameraElement = mounted?.cameraElement;
+  const sceneElement = mounted?.sceneElement;
+  const modelElement = mounted?.modelElement;
+  if (!(cameraElement instanceof HTMLElement) || !(sceneElement instanceof HTMLElement) ||
+      !(modelElement instanceof HTMLElement) || !Array.isArray(shapeElements) ||
+      shapeElements.length < 1 || cameraElement.firstElementChild !== sceneElement ||
+      sceneElement.firstElementChild !== modelElement ||
+      shapeElements.some((shape) => !(shape instanceof HTMLElement) ||
+        shape.parentElement !== modelElement || shape.children.length !== FACES_PER_BOX ||
+        [...shape.children].some((leaf) => leaf.localName !== "b" || leaf.children.length !== 0))) {
+    throw new Error("Cityflow mounted Morph graph cannot be cleaned safely");
+  }
+
+  const modelTransform = modelElement.style.transform;
+  if (modelTransform !== STYLESHEET_MODEL_TRANSFORM) {
+    throw new Error("Cityflow stylesheet-owned model transform drifted");
+  }
+  const leafElements = shapeElements.map((shape) => [...shape.children]);
+
+  cameraElement.className = "polycss-camera";
+  sceneElement.className = "polycss-scene";
+  cameraElement.removeAttribute("aria-hidden");
+  sceneElement.removeAttribute("aria-hidden");
+  stripDataAttributes(cameraElement);
+  stripDataAttributes(sceneElement);
+  cameraElement.style.removeProperty("perspective");
+  sceneElement.style.removeProperty("transform");
+  removeEmptyStyle(cameraElement);
+  removeEmptyStyle(sceneElement);
+
+  for (const shape of shapeElements) {
+    shape.removeAttribute("class");
+    stripDataAttributes(shape);
+    for (const leaf of shape.children) {
+      leaf.removeAttribute("class");
+      stripDataAttributes(leaf);
+      for (const property of [
+        "backface-visibility",
+        "-webkit-backface-visibility",
+        "background-repeat",
+        "color",
+        "height",
+        "opacity",
+        "transform-origin",
+        "visibility",
+        "width",
+      ]) leaf.style.removeProperty(property);
+      removeEmptyStyle(leaf);
+    }
+  }
+
+  for (const shape of shapeElements) sceneElement.append(shape);
+  if (modelElement.childElementCount !== 0) {
+    throw new Error("Cityflow model wrapper contains unexpected retained nodes");
+  }
+  modelElement.remove();
+
+  const stableNodes = Object.freeze([
+    cameraElement,
+    sceneElement,
+    ...shapeElements,
+    ...leafElements.flat(),
+  ]);
+  let runtimeDomCreationCount = 0;
+  let runtimeDomRemovalCount = 0;
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      runtimeDomCreationCount += record.addedNodes.length;
+      runtimeDomRemovalCount += record.removedNodes.length;
+    }
+  });
+  observer.observe(cameraElement, { childList: true, subtree: true });
+
+  function assertStableDomIdentity() {
+    const currentNodes = [
+      cameraElement,
+      sceneElement,
+      ...sceneElement.children,
+      ...shapeElements.flatMap((shape) => [...shape.children]),
+    ];
+    if (cameraElement.children.length !== 1 || cameraElement.firstElementChild !== sceneElement ||
+        sceneElement.children.length !== shapeElements.length ||
+        shapeElements.some((shape, index) =>
+          sceneElement.children[index] !== shape || shape.children.length !== FACES_PER_BOX) ||
+        currentNodes.length !== stableNodes.length ||
+        currentNodes.some((node, index) => node !== stableNodes[index])) {
+      throw new Error("Cityflow cleaned retained DOM identity changed");
+    }
+    return true;
+  }
+
+  return Object.freeze({
+    cameraElement,
+    sceneElement,
+    shapeElements: Object.freeze([...shapeElements]),
+    leafElements: Object.freeze(leafElements.map((leaves) => Object.freeze(leaves))),
+    assertStableDomIdentity,
+    stats() {
+      assertStableDomIdentity();
+      return Object.freeze({
+        retainedCameraRootCount: 1,
+        retainedSceneRootCount: 1,
+        retainedModelRootCount: 0,
+        retainedBoxRootCount: shapeElements.length,
+        retainedFaceLeafCount: leafElements.length * FACES_PER_BOX,
+        runtimeDomMutationCount: runtimeDomCreationCount + runtimeDomRemovalCount,
+        runtimeDomGrowth: false,
+      });
+    },
+    destroy() {
+      observer.disconnect();
+    },
+  });
+}
 
 export function mountCityflowPreparedSnapshot({ host, snapshotHtml, expectedBoxCount }) {
   if (!(host instanceof HTMLElement) || typeof snapshotHtml !== "string" ||
@@ -94,4 +212,14 @@ export function mountCityflowPreparedSnapshot({ host, snapshotHtml, expectedBoxC
 function hasDiagnosticAttributes(element) {
   return element.id || element.className ||
     [...element.attributes].some((attribute) => attribute.name.startsWith("data-"));
+}
+
+function stripDataAttributes(element) {
+  for (const attribute of [...element.attributes]) {
+    if (attribute.name.startsWith("data-")) element.removeAttribute(attribute.name);
+  }
+}
+
+function removeEmptyStyle(element) {
+  if (element.style.length === 0) element.removeAttribute("style");
 }

--- a/src/adapters/cityflow/src/csscityflow/preparedPlayback.mjs
+++ b/src/adapters/cityflow/src/csscityflow/preparedPlayback.mjs
@@ -8,11 +8,11 @@ const decodedPackets = new WeakMap();
 
 export function createCityflowPreparedPlayer({
   playback,
-  mounted,
-  shapeElements,
+  dom,
   ...overrides
 }) {
-  const decoded = validatePlayback(playback, mounted, shapeElements);
+  const decoded = validatePlayback(playback, dom);
+  const shapeElements = dom.shapeElements;
   const frameCount = playback.frameCount;
   const boxCount = playback.boxCount;
   const facesPerBox = playback.facesPerBox;
@@ -33,12 +33,8 @@ export function createCityflowPreparedPlayer({
   const materials = playback.colors.materials;
   const target = createPolyMorphPreparedDomTarget({
     model: {
-      element: mounted.modelElement,
-      writeTransform(transform) {
-        if (mounted.modelElement.style.transform === transform) return false;
-        mounted.modelElement.style.transform = transform;
-        return true;
-      },
+      element: dom.sceneElement,
+      writeTransform() { return false; },
     },
     shapes: shapeElements.map((element) => ({ element })),
     leaves: [],
@@ -249,7 +245,8 @@ export function createCityflowPreparedPlayer({
   function snapshot() {
     const schedulerStats = scheduler.stats();
     target.assertStableDomIdentity();
-    mounted.assertStableDomIdentity();
+    dom.assertStableDomIdentity();
+    const domStats = dom.stats();
     return Object.freeze({
       schema: "csscityflow-prepared-player-stats@7",
       ready: true,
@@ -330,6 +327,8 @@ export function createCityflowPreparedPlayer({
       identityStable: true,
       runtimeGeometryCalculationCount: 0,
       runtimeAtlasRasterizationCount: 0,
+      retainedModelRootCount: domStats.retainedModelRootCount,
+      runtimeDomMutationCount: domStats.runtimeDomMutationCount,
       runtimeDomGrowth: false,
     });
   }
@@ -381,7 +380,7 @@ export function createCityflowPreparedPlayer({
     },
     assertStableDomIdentity() {
       target.assertStableDomIdentity();
-      mounted.assertStableDomIdentity();
+      dom.assertStableDomIdentity();
       return true;
     },
     stats: snapshot,
@@ -400,11 +399,12 @@ export async function loadCityflowPreparedPlayback(url, fetchImpl = globalThis.f
   return playback;
 }
 
-function validatePlayback(playback, mounted, shapeElements) {
+function validatePlayback(playback, dom) {
   const decoded = validatePacket(playback);
-  if (!mounted?.modelElement || typeof mounted.assertStableDomIdentity !== "function" ||
-      !Array.isArray(shapeElements) || shapeElements.length !== playback.boxCount ||
-      shapeElements.some((element) => !(element instanceof HTMLElement))) {
+  if (!(dom?.sceneElement instanceof HTMLElement) ||
+      typeof dom.assertStableDomIdentity !== "function" ||
+      !Array.isArray(dom.shapeElements) || dom.shapeElements.length !== playback.boxCount ||
+      dom.shapeElements.some((element) => !(element instanceof HTMLElement))) {
     throw new Error("Cityflow retained playback targets drifted");
   }
   return decoded;

--- a/src/adapters/cityflow/src/csscityflow/styles.css
+++ b/src/adapters/cityflow/src/csscityflow/styles.css
@@ -50,7 +50,8 @@ body {
 }
 
 .example-stage > .polycss-camera > .polycss-scene {
-  transform: translateZ(186.60254037844388cqh) !important;
+  transform: translateZ(186.60254037844388cqh)
+    matrix3d(29.6, 6.484, 8.604, 0, -10.774, 17.814, 23.64, 0, 0, 25.157, -18.957, 0, -2.7, -2.7, -30, 1) !important;
 }
 
 @container (min-aspect-ratio: 2 / 1) {
@@ -61,7 +62,8 @@ body {
   }
 
   .example-stage > .polycss-camera > .polycss-scene {
-    transform: translateZ(186.60254037844388cqw) !important;
+    transform: translateZ(186.60254037844388cqw)
+      matrix3d(29.6, 6.484, 8.604, 0, -10.774, 17.814, 23.64, 0, 0, 25.157, -18.957, 0, -2.7, -2.7, -30, 1) !important;
   }
 }
 

--- a/src/adapters/cityflow/src/prepare/csscityflow/model.mjs
+++ b/src/adapters/cityflow/src/prepare/csscityflow/model.mjs
@@ -209,7 +209,7 @@ function rotateZ([x, y, z], degrees) {
 export function buildCityflowPreparedCss(state) {
   return [
     `:root{--csscityflow-background:${paletteColor(state.palette[0])}}`,
-    `.polycss-scene>div>b,.csscityflow-box>b{position:absolute;display:block!important;` +
+    `.polycss-scene>div>b{position:absolute;display:block!important;` +
       `width:1px;height:1px;` +
       `margin:0;padding:0;border:0;transform-style:preserve-3d;transform-origin:0 0;` +
       `backface-visibility:visible;-webkit-backface-visibility:visible}`,

--- a/src/adapters/cityflow/test/csscityflow-assets.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-assets.test.mjs
@@ -62,7 +62,7 @@ test("prepared Cityflow product binds source, topology, playback, and bounded tr
   ]);
   assert.equal(desktopAliasCss, css);
   assert.equal(mobileAliasCss, css);
-  assert.match(css, /\.polycss-scene>div>b,\.csscityflow-box>b/u);
+  assert.match(css, /\.polycss-scene>div>b/u);
   assert.equal(bank.boxCount, 200);
   assert.equal(bank.leafCount, 600);
   assert.equal(bank.frameCount, 301);

--- a/src/adapters/cityflow/test/csscityflow-deploy.deploy.mjs
+++ b/src/adapters/cityflow/test/csscityflow-deploy.deploy.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: HPND
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { readFile, readdir } from "node:fs/promises";
+import { access, readFile, readdir } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import test from "node:test";
 import sharp from "sharp";
@@ -23,13 +23,16 @@ test("atomic site deploy contains the exact Cityflow tree and current shared she
   assert.ok(generated.has("cityflow.playback.json"));
   assert.ok(routeFiles.includes("index.html"));
   assert.equal(routeFiles.filter((path) => path === "index.html").length, 1);
-  const bundles = routeFiles.filter((path) => path !== "index.html");
-  assert.ok(bundles.length >= 2);
-  assert.ok(bundles.every((path) =>
-    /^assets\/[A-Za-z][A-Za-z0-9-]*-[A-Za-z0-9_-]{8,}\.(?:css|js)$/u.test(path)),
-  `unhashed or unexpected Cityflow route file: ${bundles.join(", ")}`);
+  const scriptPaths = [...html.matchAll(/src="(\/_astro\/[^"]+\.js)"/gu)]
+    .map((match) => match[1]);
+  assert.ok(scriptPaths.length >= 2);
+  assert.ok(scriptPaths.every((path) =>
+    /^\/_astro\/[A-Za-z][A-Za-z0-9._-]*\.[A-Za-z0-9_-]{8}\.js$/u.test(path)),
+  `unhashed or unexpected Cityflow script: ${scriptPaths.join(", ")}`);
+  await Promise.all(scriptPaths.map((path) =>
+    access(resolve(repositoryRoot, "dist/site", path.slice(1)))));
   assert.match(html, /data-project-id="cityflow"/u);
-  assert.match(html, /(?:src|href)="\/cityflow\/assets\//u);
+  assert.match(html, /href="\/site\.css"/u);
   assert.doesNotMatch(html, /noindex|nofollow/u);
 });
 

--- a/src/adapters/cityflow/test/csscityflow-desktop-preservation.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-desktop-preservation.test.mjs
@@ -7,16 +7,19 @@ import { preparedMobileBank } from "../src/csscityflow/mobilePlayback.mjs";
 import { decodeMobileHeights } from "../src/csscityflow/mobileTransforms.mjs";
 
 const root = new URL("../../../../build/generated/public/csscityflow/", import.meta.url);
-// Main 0f872754: the mobile replacement must not change desktop's bytes.
-test("mobile replacement preserves the main desktop prepared product byte-for-byte", async () => {
+test("DOM cleanup changes only the desktop structural stylesheet", async () => {
   for (const [path, expected] of [
     ["cityflow.playback.json", "aa05e854b3b4241869cf05cc069fcec10da68944c7c77de8c9eeb8ecd15ed231"],
-    ["cityflow.css", "9ab06aa5e1680d5e4f31bfb4097fa4fc6171fa2532b7cbc7720ddd8af234dfd4"],
     ["cityflow/model.json", "2324022d137aabe5cb37e56b2d6c7c4ba1e5ad5996d8007fb71b9774fea63642"],
     ["cityflow/manifest.json", "9bb0740dd8bad387a2d347450d7cbbf591b93e7cab5916ae8b28a132153d1d19"],
   ]) {
     assert.equal(createHash("sha256").update(await readFile(new URL(path, root))).digest("hex"), expected, path);
   }
+  const stylesheet = await readFile(new URL("cityflow.css", root), "utf8");
+  assert.equal(createHash("sha256").update(stylesheet).digest("hex"),
+    "5ab5e01b3bea2e0886a7744e3bedcd1587f33746b9462ef2860f6a46105aeb0b");
+  assert.match(stylesheet, /\.polycss-scene>div>b/u);
+  assert.doesNotMatch(stylesheet, /csscityflow-box/u);
 });
 
 test("new mobile assets are content-addressed and carry scalars rather than matrices", async () => {

--- a/src/adapters/cityflow/test/csscityflow-model.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-model.test.mjs
@@ -198,9 +198,9 @@ test("prepares DOMFORMAT-precedented exact states and C2 reconstructed presentat
   assert.doesNotMatch(css, /attr\(|::after/u);
   assert.doesNotMatch(css, /--z|@property/u);
   assert.match(css,
-    /\.polycss-scene>div>b,\.csscityflow-box>b\{[^}]*width:1px;[^}]*height:1px;/u);
+    /\.polycss-scene>div>b\{[^}]*width:1px;[^}]*height:1px;/u);
   assert.match(css,
-    /\.polycss-scene>div>b,\.csscityflow-box>b\{[^}]*backface-visibility:visible;/u);
+    /\.polycss-scene>div>b\{[^}]*backface-visibility:visible;/u);
   assert.doesNotMatch(css, /backface-visibility:hidden/u);
   assert.equal((css.match(/hypot\(/gu) ?? []).length, 0);
   assert.doesNotMatch(css, /filter|clip-path|mask|linear-gradient|radial-gradient/u);

--- a/src/adapters/cityflow/test/csscityflow-runtime-surface.test.mjs
+++ b/src/adapters/cityflow/test/csscityflow-runtime-surface.test.mjs
@@ -5,8 +5,9 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 test("publishes every prepared box automatically with a fixed source camera", async () => {
-  const [client, player, profileSelection, projection, styles, scheduler, tracePerformance] = await Promise.all([
+  const [client, dom, player, profileSelection, projection, styles, scheduler, tracePerformance] = await Promise.all([
     readFile(new URL("../src/csscityflow/client.mjs", import.meta.url), "utf8"),
+    readFile(new URL("../src/csscityflow/preparedDom.mjs", import.meta.url), "utf8"),
     readFile(new URL("../src/csscityflow/preparedPlayback.mjs", import.meta.url), "utf8"),
     readFile(new URL("../src/csscityflow/profileSelection.mjs", import.meta.url), "utf8"),
     readFile(new URL("../src/csscityflow/sourceProjection.mjs", import.meta.url), "utf8"),
@@ -15,6 +16,14 @@ test("publishes every prepared box automatically with a fixed source camera", as
     readFile(new URL("../tools/trace-performance.mjs", import.meta.url), "utf8"),
   ]);
   assert.match(client, /mountPolyMorphModel/u);
+  assert.match(client, /cleanCityflowMountedDom\(\{ mounted, shapeElements \}\)/u);
+  assert.doesNotMatch(client, /csscityflow-box/u);
+  assert.match(dom, /cameraElement\.className = "polycss-camera"/u);
+  assert.match(dom, /sceneElement\.className = "polycss-scene"/u);
+  assert.match(dom, /sceneElement\.append\(shape\)/u);
+  assert.match(dom, /modelElement\.remove\(\)/u);
+  assert.match(dom, /stripDataAttributes/u);
+  assert.match(dom, /leaf\.style\.removeProperty\(property\)/u);
   assert.match(client, /selectCityflowPreparedBank/u);
   assert.ok(client.indexOf("selectCityflowPreparedBank({") <
     client.indexOf("const metadataPromise"), "prepared bank selection must precede all bank fetches");
@@ -38,14 +47,15 @@ test("publishes every prepared box automatically with a fixed source camera", as
   assert.match(projection, /height - viewportHeight \/ 2/u);
   assert.doesNotMatch(projection, /ResizeObserver/u);
   assert.match(styles, /container-type:\s*size/u);
+  assert.doesNotMatch(styles, /\.polycss-scene > div > div/u);
   assert.match(styles, /perspective:\s*186\.60254037844388cqh/u);
-  assert.match(styles, /transform:\s*translateZ\(186\.60254037844388cqh\)\s*!important/u);
+  assert.match(styles,
+    /transform:\s*translateZ\(186\.60254037844388cqh\)\s*matrix3d\(/u);
   assert.match(styles, /@container \(min-aspect-ratio:\s*2 \/ 1\)/u);
   assert.match(styles, /perspective:\s*186\.60254037844388cqw/u);
   assert.doesNotMatch(`${client}\n${projection}\n${styles}`, /--csscityflow-camera-|ResizeObserver/u);
   assert.doesNotMatch(styles,
     /data-csscityflow-(?:orbit|dragging)|cursor:\s*(?:grab|grabbing)|touch-action|pointer-events:\s*auto|transform-origin:\s*0 0 -30px/u);
-  assert.doesNotMatch(styles, /\.polycss-scene\s*\{[^}]*matrix3d\(/su);
   assert.match(player, /domformat@0\/polycss-playback@0@cc8da736/u);
   assert.match(player,
     /shapeElements\[boxIndex\]\.style\.transform\s*=\s*[\s\S]*transforms\[transformOffsets\[boxIndex\] \+ transformIndex\]/u);

--- a/src/adapters/cityflow/tools/audit-sparse-color-publication.mjs
+++ b/src/adapters/cityflow/tools/audit-sparse-color-publication.mjs
@@ -70,7 +70,7 @@ async function auditViewport(viewport) {
         reference.evaluate((index) => {
           const state = globalThis.__csscityflowFullColorReference;
           globalThis.__csscityflow.player.seekFrame(index);
-          const roots = document.querySelectorAll(".csscityflow-box");
+          const roots = document.querySelectorAll(".polycss-scene > div");
           for (let boxIndex = 0; boxIndex < state.playback.boxCount; boxIndex += 1) {
             const material = state.playback.colors.materials[
               state.materialIndices[index * state.playback.boxCount + boxIndex]

--- a/src/adapters/cityflow/tools/oracle/ablate-visibility-diff-faces.mjs
+++ b/src/adapters/cityflow/tools/oracle/ablate-visibility-diff-faces.mjs
@@ -39,7 +39,7 @@ try {
     };
     const transformIndices = decodeUint16(playback.transformIndices.presentationBase64);
     const materialIndices = decodeUint16(playback.colors.presentationMaterialIndicesBase64);
-    const roots = [...document.querySelectorAll(".csscityflow-box")];
+    const roots = [...document.querySelectorAll(".polycss-scene > div")];
     const leaves = roots.flatMap((root) => [...root.children]);
     for (let boxIndex = 0; boxIndex < playback.boxCount; boxIndex += 1) {
       roots[boxIndex].style.transform = player.preparedTransformAt(
@@ -71,7 +71,7 @@ try {
   const ranked = [];
   for (const faceIndex of hiddenFaceIndices) {
     await page.evaluate((nextFaceIndex) => {
-      document.querySelectorAll(".csscityflow-box>b")[nextFaceIndex]
+      document.querySelectorAll(".polycss-scene > div > b")[nextFaceIndex]
         .style.visibility = "";
     }, faceIndex);
     const restoredDiff = diff(reference, await rawRgb(await page.screenshot()));
@@ -82,7 +82,7 @@ try {
       maximumChannelDelta: restoredDiff.maximumChannelDelta,
     });
     await page.evaluate((nextFaceIndex) => {
-      document.querySelectorAll(".csscityflow-box>b")[nextFaceIndex]
+      document.querySelectorAll(".polycss-scene > div > b")[nextFaceIndex]
         .style.visibility = "hidden";
     }, faceIndex);
   }

--- a/src/adapters/cityflow/tools/oracle/audit-static-suppression.mjs
+++ b/src/adapters/cityflow/tools/oracle/audit-static-suppression.mjs
@@ -50,7 +50,7 @@ try {
     await page.evaluate((nextFrameIndex) => {
       const { playback, transformIndices, materialIndices } = globalThis.__csscityflowStaticAudit;
       globalThis.__csscityflow.player.seekFrame(nextFrameIndex);
-      const roots = [...document.querySelectorAll(".csscityflow-box")];
+      const roots = [...document.querySelectorAll(".polycss-scene > div")];
       for (const boxIndex of playback.staticVisibility.hiddenBoxIndices) {
         const root = roots[boxIndex];
         root.style.setProperty("display", "block", "important");
@@ -74,12 +74,12 @@ try {
     )).removeAlpha().raw().toBuffer();
     for (const boxIndex of hiddenBoxIndices) {
       await page.evaluate((nextBoxIndex) => {
-        document.querySelectorAll(".csscityflow-box")[nextBoxIndex]
+        document.querySelectorAll(".polycss-scene > div")[nextBoxIndex]
           .style.setProperty("display", "none", "important");
       }, boxIndex);
       const candidate = await sharp(await page.screenshot()).removeAlpha().raw().toBuffer();
       await page.evaluate((nextBoxIndex) => {
-        document.querySelectorAll(".csscityflow-box")[nextBoxIndex]
+        document.querySelectorAll(".polycss-scene > div")[nextBoxIndex]
           .style.setProperty("display", "block", "important");
       }, boxIndex);
       let changedPixelCount = 0;

--- a/src/adapters/cityflow/tools/oracle/capture-motion-face-audit.mjs
+++ b/src/adapters/cityflow/tools/oracle/capture-motion-face-audit.mjs
@@ -122,7 +122,7 @@ async function captureLiveVideo(browserHandle) {
     return {
       durationMilliseconds,
       callbackCount: samples.length,
-      transformAnimationCount: [...document.querySelectorAll(".csscityflow-box")].reduce(
+      transformAnimationCount: [...document.querySelectorAll(".polycss-scene > div")].reduce(
         (sum, root) => sum + root.getAnimations().length,
         0,
       ),
@@ -428,15 +428,8 @@ async function openReadyScene(page) {
 async function installGeometryAuditStyles(page, unculled) {
   await page.addStyleTag({ content: `
     :root, body, .example-stage { background: #000 !important; }
-    .csscityflow-box > b:first-child,
-    .csscityflow-box::before,
-    .csscityflow-box::after,
-    .csscityflow-box.csscityflow-side-1-hidden::before,
-    .csscityflow-box.csscityflow-side-2-hidden::after {
+    .polycss-scene > div > b {
       background: #fff !important;
-      ${unculled ? "visibility: visible !important;" : ""}
-    }
-    .csscityflow-box > b {
       ${unculled ? "visibility: visible !important;" : ""}
     }
   ` });
@@ -448,7 +441,7 @@ async function setAuditTime(page, presentationTimeMilliseconds, publishAllShapes
     const stats = player.seekPresentationTime(nextPresentationTime);
     if (!publishAll) return;
     const playback = globalThis.__csscityflowAuditPlayback;
-    const boxes = [...document.querySelectorAll(".csscityflow-box")];
+    const boxes = [...document.querySelectorAll(".polycss-scene > div")];
     if (playback?.presentationShapeStyles?.length !== stats.frameCount * stats.boxCount ||
         boxes.length !== stats.boxCount) {
       throw new Error("Cityflow unculled audit playback binding drifted");

--- a/src/adapters/cityflow/tools/oracle/capture-presentation-sequence.mjs
+++ b/src/adapters/cityflow/tools/oracle/capture-presentation-sequence.mjs
@@ -54,7 +54,7 @@ try {
         const { playback, transformIndices, materialIndices } =
           globalThis.__csscityflowUnculledCapture;
         const frameIndex = index % playback.frameCount;
-        const roots = [...document.querySelectorAll(".csscityflow-box")];
+        const roots = [...document.querySelectorAll(".polycss-scene > div")];
         for (let boxIndex = 0; boxIndex < playback.boxCount; boxIndex += 1) {
           const root = roots[boxIndex];
           root.style.setProperty("display", "block", "important");
@@ -78,8 +78,8 @@ try {
   }
   const audit = await page.evaluate(() => ({
     player: globalThis.__csscityflow.player.stats(),
-    roots: document.querySelectorAll(".csscityflow-box").length,
-    leaves: document.querySelectorAll(".csscityflow-box>b").length,
+    roots: document.querySelectorAll(".polycss-scene > div").length,
+    leaves: document.querySelectorAll(".polycss-scene > div > b").length,
   }));
   if (errors.length) throw new Error(`Cityflow presentation capture failed: ${JSON.stringify(errors)}`);
   const report = {

--- a/src/adapters/cityflow/tools/oracle/discover-browser-visible-faces.mjs
+++ b/src/adapters/cityflow/tools/oracle/discover-browser-visible-faces.mjs
@@ -28,7 +28,7 @@ try {
     const response = await fetch("/csscityflow/cityflow.playback.json", { cache: "no-store" });
     if (!response.ok) throw new Error(`Cityflow face-ID playback failed: ${response.status}`);
     const playback = await response.json();
-    const boxes = [...document.querySelectorAll(".csscityflow-box")];
+    const boxes = [...document.querySelectorAll(".polycss-scene > div")];
     const leaves = boxes.flatMap((box) => [...box.children]);
     if (boxes.length !== playback.boxCount || leaves.length !== playback.boxCount * playback.facesPerBox) {
       throw new Error("Cityflow face-ID retained binding drifted");
@@ -55,7 +55,7 @@ try {
   for (let frameIndex = 0; frameIndex < setup.frameCount; frameIndex += 1) {
     await page.evaluate((nextFrameIndex) => {
       globalThis.__csscityflow.player.seekFrame(nextFrameIndex);
-      const leaves = [...document.querySelectorAll(".csscityflow-box > b")];
+      const leaves = [...document.querySelectorAll(".polycss-scene > div > b")];
       leaves.forEach((leaf, faceIndex) => {
         const [red, green, blue] = globalThis.__csscityflowFaceIdColors[faceIndex];
         leaf.style.setProperty("display", "block", "important");

--- a/src/adapters/cityflow/tools/oracle/identify-culled-diff-faces.mjs
+++ b/src/adapters/cityflow/tools/oracle/identify-culled-diff-faces.mjs
@@ -41,7 +41,7 @@ try {
   await page.addStyleTag({ content: `
     .examples-sidebar, .example-info { display: none !important; }
     .example-stage { position: fixed !important; inset: 0 !important; }
-    .csscityflow-box>b { pointer-events: auto !important; }
+    .polycss-scene > div > b { pointer-events: auto !important; }
   ` });
   const hits = await page.evaluate(async ({ frameIndex: nextFrameIndex, samples: points }) => {
     const player = globalThis.__csscityflow.player;
@@ -56,7 +56,7 @@ try {
         view.getUint16(index * 2, true));
     };
     const transformIndices = decodeUint16(playback.transformIndices.presentationBase64);
-    const roots = [...document.querySelectorAll(".csscityflow-box")];
+    const roots = [...document.querySelectorAll(".polycss-scene > div")];
     const leaves = roots.flatMap((root) => [...root.children]);
     for (let boxIndex = 0; boxIndex < playback.boxCount; boxIndex += 1) {
       roots[boxIndex].style.transform = player.preparedTransformAt(
@@ -68,7 +68,7 @@ try {
     return points.map((point) => ({
       ...point,
       hits: document.elementsFromPoint(point.x, point.y)
-        .filter((element) => element.matches?.(".csscityflow-box>b"))
+        .filter((element) => element.matches?.(".polycss-scene > div > b"))
         .map((element) => ({
           faceIndex: leaves.indexOf(element),
           opacity: getComputedStyle(element).opacity,

--- a/src/adapters/cityflow/tools/oracle/run-visual-oracle.mjs
+++ b/src/adapters/cityflow/tools/oracle/run-visual-oracle.mjs
@@ -228,8 +228,8 @@ async function captureBrowserRun(browser, url, runRoot) {
       .example-stage { position: fixed !important; inset: 0 !important; }
     ` });
     const initial = await page.evaluate(async () => {
-      const roots = [...document.querySelectorAll(".csscityflow-box")];
-      const leaves = [...document.querySelectorAll(".csscityflow-box>b")];
+      const roots = [...document.querySelectorAll(".polycss-scene > div")];
+      const leaves = [...document.querySelectorAll(".polycss-scene > div > b")];
       globalThis.__csscityflowOracleIdentity = { roots, leaves };
       globalThis.__csscityflow.player.pause();
       globalThis.__csscityflow.player.seekSourceFrame(1);
@@ -257,8 +257,8 @@ async function captureBrowserRun(browser, url, runRoot) {
     }
     const audit = await page.evaluate(() => {
       const expected = globalThis.__csscityflowOracleIdentity;
-      const roots = [...document.querySelectorAll(".csscityflow-box")];
-      const leaves = [...document.querySelectorAll(".csscityflow-box>b")];
+      const roots = [...document.querySelectorAll(".polycss-scene > div")];
+      const leaves = [...document.querySelectorAll(".polycss-scene > div > b")];
       return {
         stableRootIdentity: roots.every((element, index) => element === expected.roots[index]),
         stableLeafIdentity: leaves.every((element, index) => element === expected.leaves[index]),

--- a/src/adapters/cityflow/tools/smoke-browser.mjs
+++ b/src/adapters/cityflow/tools/smoke-browser.mjs
@@ -122,10 +122,29 @@ async function capture({
     globalThis.__csscityflow?.errors?.length, null, { timeout: 30_000 });
   const before = await page.evaluate(() => {
     const state = globalThis.__csscityflow;
-    const shapes = [...document.querySelectorAll(".csscityflow-box")];
-    const leaves = [...document.querySelectorAll(".csscityflow-box > b")];
+    const camera = document.querySelector(".example-stage > .polycss-camera");
+    const scene = camera?.querySelector(":scope > .polycss-scene");
+    const shapes = [...document.querySelectorAll(".polycss-scene > div")];
+    const leaves = [...document.querySelectorAll(".polycss-scene > div > b")];
+    const renderNodes = [camera, scene, ...shapes, ...leaves].filter(Boolean);
+    const retainedDataAttributeCount = renderNodes.reduce((sum, element) =>
+      sum + [...element.attributes].filter(({ name }) => name.startsWith("data-")).length, 0);
+    const frameworkClassAttributeCount = renderNodes.filter((element) =>
+      [...element.classList].some((name) => name.startsWith("polycss-morph") ||
+        name === "polycss-mesh" || name === "csscityflow-box")).length;
+    const redundantLeafInlineStyleCount = leaves.reduce((sum, leaf) =>
+      sum + [
+        "backface-visibility",
+        "-webkit-backface-visibility",
+        "background-repeat",
+        "color",
+        "height",
+        "opacity",
+        "transform-origin",
+        "width",
+      ].filter((property) => leaf.style.getPropertyValue(property) !== "").length, 0);
     let stable = true;
-    try { state?.mounted?.assertStableDomIdentity(); } catch { stable = false; }
+    try { state?.dom?.assertStableDomIdentity(); } catch { stable = false; }
     return {
       status: document.body.className,
       canonical: document.querySelector('link[rel="canonical"]')?.href ?? null,
@@ -133,6 +152,16 @@ async function capture({
       bankId: state?.bankId,
       errors: state?.errors ?? [],
       stable,
+      retainedRenderNodeCount: renderNodes.length,
+      retainedDataAttributeCount,
+      frameworkClassAttributeCount,
+      redundantLeafInlineStyleCount,
+      cameraClassName: camera?.className ?? null,
+      sceneClassName: scene?.className ?? null,
+      shapeClassAttributeCount: shapes.filter((shape) => shape.hasAttribute("class")).length,
+      leafClassAttributeCount: leaves.filter((leaf) => leaf.hasAttribute("class")).length,
+      cameraInlinePerspective: camera?.style.perspective ?? null,
+      sceneInlineTransform: scene?.style.transform ?? null,
       shapeCount: shapes.length,
       leafCount: leaves.length,
       hiddenShapeCount: shapes.filter((shape) => getComputedStyle(shape).visibility === "hidden").length,
@@ -162,7 +191,7 @@ async function capture({
   });
   await page.waitForTimeout(250);
   const after = await page.evaluate(() => {
-    const shapes = [...document.querySelectorAll(".csscityflow-box")];
+    const shapes = [...document.querySelectorAll(".polycss-scene > div")];
     return {
       transforms: shapes.slice(0, 40).map((shape) => getComputedStyle(shape).transform),
       player: globalThis.__csscityflow?.player?.stats(),
@@ -227,8 +256,8 @@ async function capture({
     orbitStatePresent: Object.hasOwn(globalThis.__csscityflow ?? {}, "orbit"),
     orbitDataset: document.querySelector(".example-stage")?.dataset.csscityflowOrbit ?? null,
     draggingDataset: document.querySelector(".example-stage")?.dataset.csscityflowDragging ?? null,
-    shapeCount: document.querySelectorAll(".csscityflow-box").length,
-    leafCount: document.querySelectorAll(".csscityflow-box > b").length,
+    shapeCount: document.querySelectorAll(".polycss-scene > div").length,
+    leafCount: document.querySelectorAll(".polycss-scene > div > b").length,
   }));
   const sourceRoundTrip = await page.evaluate(async () => {
     const player = globalThis.__csscityflow?.player;
@@ -237,30 +266,30 @@ async function capture({
     await new Promise((resolveFrame) => requestAnimationFrame(resolveFrame));
     const source = {
       player: sourcePlayer,
-      hiddenShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      hiddenShapeCount: [...document.querySelectorAll(".polycss-scene > div")]
         .filter((shape) => getComputedStyle(shape).visibility === "hidden").length,
-      hiddenLeafCount: [...document.querySelectorAll(".csscityflow-box>b")]
+      hiddenLeafCount: [...document.querySelectorAll(".polycss-scene > div > b")]
         .filter((leaf) => getComputedStyle(leaf).visibility === "hidden").length,
-      displayNoneShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      displayNoneShapeCount: [...document.querySelectorAll(".polycss-scene > div")]
         .filter((shape) => getComputedStyle(shape).display === "none").length,
-      zeroOpacityShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      zeroOpacityShapeCount: [...document.querySelectorAll(".polycss-scene > div")]
         .filter((shape) => getComputedStyle(shape).opacity === "0").length,
-      zeroOpacityLeafCount: [...document.querySelectorAll(".csscityflow-box>b")]
+      zeroOpacityLeafCount: [...document.querySelectorAll(".polycss-scene > div > b")]
         .filter((leaf) => getComputedStyle(leaf).opacity === "0").length,
     };
     const presentationPlayer = player.seekFrame(0);
     await new Promise((resolveFrame) => requestAnimationFrame(resolveFrame));
     const presentation = {
       player: presentationPlayer,
-      hiddenShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      hiddenShapeCount: [...document.querySelectorAll(".polycss-scene > div")]
         .filter((shape) => getComputedStyle(shape).visibility === "hidden").length,
-      hiddenLeafCount: [...document.querySelectorAll(".csscityflow-box>b")]
+      hiddenLeafCount: [...document.querySelectorAll(".polycss-scene > div > b")]
         .filter((leaf) => getComputedStyle(leaf).visibility === "hidden").length,
-      displayNoneShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      displayNoneShapeCount: [...document.querySelectorAll(".polycss-scene > div")]
         .filter((shape) => getComputedStyle(shape).display === "none").length,
-      zeroOpacityShapeCount: [...document.querySelectorAll(".csscityflow-box")]
+      zeroOpacityShapeCount: [...document.querySelectorAll(".polycss-scene > div")]
         .filter((shape) => getComputedStyle(shape).opacity === "0").length,
-      zeroOpacityLeafCount: [...document.querySelectorAll(".csscityflow-box>b")]
+      zeroOpacityLeafCount: [...document.querySelectorAll(".polycss-scene > div > b")]
         .filter((leaf) => getComputedStyle(leaf).opacity === "0").length,
     };
     return { source, presentation, resumed: player.resume() };
@@ -274,6 +303,13 @@ async function capture({
       before.canonical !== expectedCanonical ||
       before.bankId !== bankId || !before.stable || before.shapeCount !== boxes ||
       before.leafCount !== leaves || before.canvasCount !== 0 || before.svgSceneCount !== 0 ||
+      before.retainedRenderNodeCount !== boxes + leaves + 2 ||
+      before.retainedDataAttributeCount !== 0 || before.frameworkClassAttributeCount !== 0 ||
+      before.redundantLeafInlineStyleCount !== 0 ||
+      before.cameraClassName !== "polycss-camera" ||
+      before.sceneClassName !== "polycss-scene" ||
+      before.shapeClassAttributeCount !== 0 || before.leafClassAttributeCount !== 0 ||
+      before.cameraInlinePerspective !== "" || before.sceneInlineTransform !== "" ||
       !before.firstLeafColor || before.whiteLeafCount === leaves ||
       !preparedStylesheet?.contentType?.startsWith("text/css") ||
       before.animationName !== "none" ||
@@ -404,7 +440,7 @@ async function captureHome({ width, height, url }) {
       title: card?.querySelector(".project-title")?.textContent?.trim() ?? null,
       number: card?.querySelector(".project-number")?.textContent?.trim() ?? null,
       image: card?.querySelector("img")?.getAttribute("src") ?? null,
-      sceneCount: document.querySelectorAll(".csscityflow-box").length,
+      sceneCount: document.querySelectorAll(".polycss-scene > div").length,
     };
   });
   if (errors.length || failedResponses.length || result.canonical !== "https://css.graphics/" ||


### PR DESCRIPTION
## Summary

- remove the intermediate Cityflow model wrapper and put the fixed model transform on the retained scene
- strip framework-only classes, data attributes, and redundant face inline styles after Morph mounting
- keep 200 retained box roots and 600 local face leaves with stable identity and zero runtime DOM mutation
- update Cityflow audits and deploy assertions for the cleaned structure and actual Astro bundle layout

## Validation

- `pnpm test:cityflow` — 30/30 passed
- `pnpm prepare:cityflow:check` — deterministic, SHA-256 `21b2e5eb6ff717395797c3dd65cf6dac9886fa7fe06caeb6aa9534041f66c376`
- `pnpm build:deploy` — passed
- Cityflow deploy-contract tests — 2/2 passed
- 48-frame native/browser oracle — unchanged alignment; worst-frame mean absolute delta 0.683297
- 302-frame sparse/full publication comparisons — pixel-exact at 1280x720 and 2560x1224
- two alternating performance captures per version — no steady-state regression; zero intervals over 33.3 ms and zero smoothness-affecting drops

## Known baseline issue

The mobile smoke detector still finds 2 black pixels at 390x844 DPR 2 frame 90. The same assertion and pixel count reproduce on untouched `origin/main`; this PR does not change the mobile implementation.